### PR TITLE
feat(link): auto-verify a code arriving in the URL

### DIFF
--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -236,7 +236,53 @@ describe("DeviceLinkPage", () => {
 				expect.objectContaining({ user_code: "ENGR-7X4K", vault_id: 7 }),
 			),
 		);
-		expect(await screen.findByText(/vault linked/iu)).toBeInTheDocument();
+		expect(await screen.findByText(/your vault is linked/iu)).toBeInTheDocument();
+	});
+
+	// The heading used to stay "Link Obsidian Vault" on the success step — a
+	// title for a job already finished. It should name the step you're on.
+	it("retitles the page for each step", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			user_code_valid: true,
+		});
+		post.mockResolvedValue({ ok: true, vault_id: 7 });
+		renderPage();
+		expect(screen.getByRole("heading", { name: /link obsidian vault/iu })).toBeInTheDocument();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		expect(
+			await screen.findByRole("heading", { name: /choose a vault to sync/iu }),
+		).toBeInTheDocument();
+
+		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		expect(
+			await screen.findByRole("heading", { name: /finish in obsidian/iu }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: /link obsidian vault/iu }),
+		).not.toBeInTheDocument();
+	});
+
+	it("lets you go to the vault without waiting for the first sync", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			user_code_valid: true,
+		});
+		post.mockResolvedValue({ ok: true, vault_id: 7 });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		expect(
+			await screen.findByRole("button", { name: /go to my vault without waiting/iu }),
+		).toBeInTheDocument();
 	});
 
 	// Obsidian registers the `obsidian://` URI scheme, so getting the user back
@@ -276,7 +322,7 @@ describe("DeviceLinkPage", () => {
 		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
 		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
 
-		expect(await screen.findByText(/vault linked/iu)).toBeInTheDocument();
+		expect(await screen.findByText(/your vault is linked/iu)).toBeInTheDocument();
 		expect(screen.queryByRole("link", { name: /open obsidian/iu })).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -267,7 +267,7 @@ describe("DeviceLinkPage", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("lets you go to the vault without waiting for the first sync", async () => {
+	it("lets you continue to the web app without waiting for the first sync", async () => {
 		get.mockResolvedValue({
 			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
 			user_code_valid: true,
@@ -281,7 +281,7 @@ describe("DeviceLinkPage", () => {
 		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
 
 		expect(
-			await screen.findByRole("button", { name: /go to my vault without waiting/iu }),
+			await screen.findByRole("button", { name: /continue to web app/iu }),
 		).toBeInTheDocument();
 	});
 

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -92,6 +92,7 @@ function renderPage() {
 
 afterEach(() => {
 	vi.clearAllMocks();
+	window.history.replaceState({}, "", "/link");
 	authState.current = { isSignedIn: true };
 	billingState.current = {
 		caps: { obsidian_connections: null, mcp_connections: null, api_write_enabled: true },
@@ -112,6 +113,43 @@ describe("DeviceLinkPage", () => {
 	it("focuses the code field on arrival", () => {
 		renderPage();
 		expect(screen.getByPlaceholderText(/XXXX-XXXX/iu)).toHaveFocus();
+	});
+
+	// RFC 8628 verification_uri_complete. The plugin opens /link?code=ENGR-7X4K,
+	// so the user never retypes what their own machine already knows.
+	it("auto-verifies a code supplied in the query string", async () => {
+		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		renderPage();
+
+		await waitFor(() => expect(get).toHaveBeenCalledWith("/vaults?user_code=ENGR-7X4K"));
+		expect(await screen.findByRole("radio", { name: /personal/iu })).toBeInTheDocument();
+	});
+
+	// Authorizing is still an explicit act: auto-verify only lists the vaults.
+	// Nothing is linked until the user picks one and clicks Sync.
+	it("does not authorize on its own after auto-verifying", async () => {
+		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		renderPage();
+
+		await screen.findByRole("radio", { name: /personal/iu });
+		expect(post).not.toHaveBeenCalled();
+	});
+
+	// A single-use code shouldn't linger in history, bookmarks, or a shared URL.
+	it("scrubs the code out of the URL once it has been read", async () => {
+		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		renderPage();
+
+		await waitFor(() => expect(window.location.search).toBe(""));
+		expect(window.location.pathname).toBe("/link");
+	});
+
+	it("does not auto-verify when no code was supplied", () => {
+		renderPage();
+		expect(get).not.toHaveBeenCalled();
 	});
 
 	it("rejects a code that is not 8 characters", () => {

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -152,6 +152,65 @@ describe("DeviceLinkPage", () => {
 		expect(get).not.toHaveBeenCalled();
 	});
 
+	// The backend answers 200 with the user's vault list regardless of whether
+	// the code is real — `user_code_valid` is the only signal. Before this,
+	// every 8-character string sailed through to the picker and only failed at
+	// authorize, three clicks later.
+	it("rejects a typed code the backend reports as invalid", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			user_code_valid: false,
+		});
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ZZZZZZZZ" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(/invalid or has expired/iu);
+		expect(screen.queryByRole("radio", { name: /personal/iu })).not.toBeInTheDocument();
+		expect(screen.getByPlaceholderText(/XXXX-XXXX/iu)).toBeInTheDocument();
+	});
+
+	it("rejects an invalid code that arrived in the query string", async () => {
+		window.history.replaceState({}, "", "/link?code=ZZZZ-ZZZZ");
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			user_code_valid: false,
+		});
+		renderPage();
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(/invalid or has expired/iu);
+		expect(screen.queryByRole("radio", { name: /personal/iu })).not.toBeInTheDocument();
+	});
+
+	// A valid code whose plugin sent no vault-name hint reports
+	// suggested_vault_name: null. That must NOT read as invalid.
+	it("accepts a valid code that has no suggested vault name", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			suggested_vault_name: null,
+			user_code_valid: true,
+		});
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+
+		expect(await screen.findByRole("radio", { name: /personal/iu })).toBeInTheDocument();
+	});
+
+	// Forward compatibility: a frontend deployed ahead of the backend sees no
+	// `user_code_valid` at all. Rejecting on undefined would break every link.
+	it("proceeds when the backend omits user_code_valid entirely", async () => {
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+
+		expect(await screen.findByRole("radio", { name: /personal/iu })).toBeInTheDocument();
+	});
+
 	it("rejects a code that is not 8 characters", () => {
 		renderPage();
 		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ABC" } });

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -301,8 +301,14 @@ describe("DeviceLinkPage", () => {
 		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
 		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
 
-		await waitFor(() => expect(setActiveVaultId).toHaveBeenCalledWith(7));
+		// The user still has to go back to Obsidian and finish the sync, so the
+		// step MUST render. What can't happen is the waiting — `vault_populated`
+		// is a 0->1 event and this vault is already past that.
+		expect(
+			await screen.findByRole("heading", { name: /finish in obsidian/iu }),
+		).toBeInTheDocument();
 		expect(screen.queryByText(/waiting for your first sync/iu)).not.toBeInTheDocument();
+		expect(screen.queryByText(/the moment it lands/iu)).not.toBeInTheDocument();
 	});
 
 	// An empty vault genuinely can produce the event, so the wait is real there.

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -119,7 +119,7 @@ describe("DeviceLinkPage", () => {
 	// so the user never retypes what their own machine already knows.
 	it("auto-verifies a code supplied in the query string", async () => {
 		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
-		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
 		renderPage();
 
 		await waitFor(() => expect(get).toHaveBeenCalledWith("/vaults?user_code=ENGR-7X4K"));
@@ -130,7 +130,7 @@ describe("DeviceLinkPage", () => {
 	// Nothing is linked until the user picks one and clicks Sync.
 	it("does not authorize on its own after auto-verifying", async () => {
 		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
-		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
 		renderPage();
 
 		await screen.findByRole("radio", { name: /personal/iu });
@@ -140,7 +140,7 @@ describe("DeviceLinkPage", () => {
 	// A single-use code shouldn't linger in history, bookmarks, or a shared URL.
 	it("scrubs the code out of the URL once it has been read", async () => {
 		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
-		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
 		renderPage();
 
 		await waitFor(() => expect(window.location.search).toBe(""));
@@ -158,7 +158,7 @@ describe("DeviceLinkPage", () => {
 	// authorize, three clicks later.
 	it("rejects a typed code the backend reports as invalid", async () => {
 		get.mockResolvedValue({
-			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			user_code_valid: false,
 		});
 		renderPage();
@@ -174,7 +174,7 @@ describe("DeviceLinkPage", () => {
 	it("rejects an invalid code that arrived in the query string", async () => {
 		window.history.replaceState({}, "", "/link?code=ZZZZ-ZZZZ");
 		get.mockResolvedValue({
-			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			user_code_valid: false,
 		});
 		renderPage();
@@ -187,7 +187,7 @@ describe("DeviceLinkPage", () => {
 	// suggested_vault_name: null. That must NOT read as invalid.
 	it("accepts a valid code that has no suggested vault name", async () => {
 		get.mockResolvedValue({
-			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			suggested_vault_name: null,
 			user_code_valid: true,
 		});
@@ -202,7 +202,7 @@ describe("DeviceLinkPage", () => {
 	// Forward compatibility: a frontend deployed ahead of the backend sees no
 	// `user_code_valid` at all. Rejecting on undefined would break every link.
 	it("proceeds when the backend omits user_code_valid entirely", async () => {
-		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
 		renderPage();
 
 		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
@@ -220,7 +220,7 @@ describe("DeviceLinkPage", () => {
 	});
 
 	it("verifies a valid code and authorizes the chosen vault", async () => {
-		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
 		post.mockResolvedValue({ ok: true, vault_id: 7 });
 		renderPage();
 
@@ -243,7 +243,7 @@ describe("DeviceLinkPage", () => {
 	// title for a job already finished. It should name the step you're on.
 	it("retitles the page for each step", async () => {
 		get.mockResolvedValue({
-			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			user_code_valid: true,
 		});
 		post.mockResolvedValue({ ok: true, vault_id: 7 });
@@ -269,7 +269,7 @@ describe("DeviceLinkPage", () => {
 
 	it("lets you continue to the web app without waiting for the first sync", async () => {
 		get.mockResolvedValue({
-			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			user_code_valid: true,
 		});
 		post.mockResolvedValue({ ok: true, vault_id: 7 });
@@ -285,13 +285,50 @@ describe("DeviceLinkPage", () => {
 		).toBeInTheDocument();
 	});
 
+	// `vault_populated` fires when a vault goes from 0 to 1 notes. Link into a
+	// vault that already has notes and it can never fire — so waiting on it is
+	// waiting on nothing. The picker already knows note_count; use it.
+	it("does not wait for a first sync when the linked vault already has notes", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			user_code_valid: true,
+		});
+		post.mockResolvedValue({ ok: true, vault_id: 7 });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		await waitFor(() => expect(setActiveVaultId).toHaveBeenCalledWith(7));
+		expect(screen.queryByText(/waiting for your first sync/iu)).not.toBeInTheDocument();
+	});
+
+	// An empty vault genuinely can produce the event, so the wait is real there.
+	it("waits for the first sync when the linked vault is empty", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
+			user_code_valid: true,
+		});
+		post.mockResolvedValue({ ok: true, vault_id: 7 });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		expect(await screen.findByText(/waiting for your first sync/iu)).toBeInTheDocument();
+	});
+
 	// Obsidian registers the `obsidian://` URI scheme, so getting the user back
 	// to their editor is a link, not an integration. The vault name is the one
 	// the plugin sent at device-flow start — i.e. the LOCAL Obsidian vault name,
 	// which is exactly what `obsidian://open?vault=` addresses.
 	it("offers a deep link back to Obsidian once the vault is linked", async () => {
 		get.mockResolvedValue({
-			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			suggested_vault_name: "My Local Notes",
 			user_code_valid: true,
 		});
@@ -311,7 +348,7 @@ describe("DeviceLinkPage", () => {
 	// is not a thing. Hide the button rather than render a broken link.
 	it("hides the Obsidian deep link when the plugin sent no vault name", async () => {
 		get.mockResolvedValue({
-			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			user_code_valid: true,
 		});
 		post.mockResolvedValue({ ok: true, vault_id: 7 });
@@ -329,7 +366,7 @@ describe("DeviceLinkPage", () => {
 	it("forwards to the linked vault (sets it active) after authorizing", async () => {
 		get.mockResolvedValue({
 			vaults: [
-				{ id: 7, name: "Personal", note_count: 12 },
+				{ id: 7, name: "Personal", note_count: 0 },
 				{ id: 9, name: "Work", note_count: 3 },
 			],
 		});
@@ -370,7 +407,7 @@ describe("DeviceLinkPage", () => {
 			current_connections: { obsidian: 1, mcp: 0 },
 			device_swap_cooldown_remaining_hours: 17,
 		};
-		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 12 }] });
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
 		renderPage();
 
 		const alert = screen.getByRole("alert");

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -239,6 +239,47 @@ describe("DeviceLinkPage", () => {
 		expect(await screen.findByText(/vault linked/iu)).toBeInTheDocument();
 	});
 
+	// Obsidian registers the `obsidian://` URI scheme, so getting the user back
+	// to their editor is a link, not an integration. The vault name is the one
+	// the plugin sent at device-flow start — i.e. the LOCAL Obsidian vault name,
+	// which is exactly what `obsidian://open?vault=` addresses.
+	it("offers a deep link back to Obsidian once the vault is linked", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			suggested_vault_name: "My Local Notes",
+			user_code_valid: true,
+		});
+		post.mockResolvedValue({ ok: true, vault_id: 7 });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		const link = await screen.findByRole("link", { name: /open obsidian/iu });
+		expect(link).toHaveAttribute("href", "obsidian://open?vault=My%20Local%20Notes");
+	});
+
+	// No hint means we cannot address a vault, and `obsidian://open` without one
+	// is not a thing. Hide the button rather than render a broken link.
+	it("hides the Obsidian deep link when the plugin sent no vault name", async () => {
+		get.mockResolvedValue({
+			vaults: [{ id: 7, name: "Personal", note_count: 12 }],
+			user_code_valid: true,
+		});
+		post.mockResolvedValue({ ok: true, vault_id: 7 });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		expect(await screen.findByText(/vault linked/iu)).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /open obsidian/iu })).not.toBeInTheDocument();
+	});
+
 	it("forwards to the linked vault (sets it active) after authorizing", async () => {
 		get.mockResolvedValue({
 			vaults: [

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -21,6 +21,17 @@ vi.mock("../auth/use-auth-adapter", () => ({
 	useAuthAdapter: () => ({ getToken: () => Promise.resolve(null), ...authState.current }),
 }));
 
+// The success step listens for `vault_populated` over a socket. Capture how it
+// is mounted so a test can prove it does NOT open one when there is no 0->1
+// transition left to hear about.
+const vaultReadyArgs = vi.hoisted(() => ({ last: null as any }));
+vi.mock("../onboarding/use-vault-ready-events", () => ({
+	useVaultReadyEvents: (args: any) => {
+		vaultReadyArgs.last = args;
+		return { vaultPopulated: false, vaultId: null };
+	},
+}));
+
 vi.mock("../theme/theme-toggle", () => ({
 	default: () => <button type="button">theme</button>,
 }));
@@ -110,6 +121,7 @@ function renderPage(entry = "/link") {
 afterEach(() => {
 	vi.clearAllMocks();
 	billingPending.current = false;
+	vaultReadyArgs.last = null;
 	window.history.replaceState({}, "", "/link");
 	authState.current = { isSignedIn: true };
 	billingState.current = {
@@ -243,7 +255,9 @@ describe("DeviceLinkPage", () => {
 
 		expect(await screen.findByRole("alert")).toHaveTextContent(/invalid or has expired/iu);
 		expect(screen.queryByRole("radio", { name: /personal/iu })).not.toBeInTheDocument();
-		expect(screen.getByPlaceholderText(/XXXX-XXXX/iu)).toBeInTheDocument();
+		// Formatted, not left as the raw 8 characters the user typed: every other
+		// value in this field renders as XXXX-XXXX.
+		expect(screen.getByPlaceholderText(/XXXX-XXXX/iu)).toHaveValue("ZZZZ-ZZZZ");
 	});
 
 	it("rejects an invalid code that arrived in the query string", async () => {
@@ -460,6 +474,40 @@ describe("DeviceLinkPage", () => {
 		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
 
 		await waitFor(() => expect(setActiveVaultId).toHaveBeenCalledWith(9));
+	});
+
+	// An empty vault has a 0->1 transition left, so the step promises an
+	// automatic hand-off and must be listening for it.
+	it("listens for the first sync when the linked vault is empty", async () => {
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
+		post.mockResolvedValue({ ok: true, vault_id: 7 });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		fireEvent.click(await screen.findByRole("radio", { name: /personal/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		await screen.findByText(/your vault is linked/iu);
+		expect(vaultReadyArgs.last?.enabled).toBe(true);
+	});
+
+	// A vault that already holds notes will never emit `vault_populated`, and
+	// the step says so. Opening the socket anyway meant an unrelated broadcast
+	// could still forward the user — doing the thing we just told them we
+	// would not do.
+	it("does NOT open the socket when the linked vault already has notes", async () => {
+		get.mockResolvedValue({ vaults: [{ id: 9, name: "Work", note_count: 3 }] });
+		post.mockResolvedValue({ ok: true, vault_id: 9 });
+		renderPage();
+
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+		fireEvent.click(await screen.findByRole("radio", { name: /work/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /^sync$/iu }));
+
+		await screen.findByText(/your vault is linked/iu);
+		expect(vaultReadyArgs.last?.enabled).toBe(false);
 	});
 
 	it("shows the heads-up banner (but keeps the code input) when at the Obsidian cap", () => {

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import DeviceLinkPage from "./device-link-page";
 
@@ -36,6 +36,7 @@ interface FakeBilling {
 	current_connections: { obsidian: number; mcp: number };
 	device_swap_cooldown_remaining_hours: number | null;
 }
+const billingPending = vi.hoisted(() => ({ current: false }));
 const billingState = vi.hoisted(() => ({
 	current: {
 		caps: { obsidian_connections: null, mcp_connections: null, api_write_enabled: true },
@@ -47,7 +48,10 @@ vi.mock("../api/queries", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../api/queries")>();
 	return {
 		...actual,
-		useBillingStatus: () => ({ data: billingState.current }),
+		useBillingStatus: () => ({
+			data: billingPending.current ? undefined : billingState.current,
+			isPending: billingPending.current,
+		}),
 		useMe: () => ({ data: { id: 1, email: "me@example.com" } }),
 		// The cap panel reads this — keep it deterministic across tests so we
 		// don't trigger real network fetches via the partial-mock pass-through.
@@ -79,19 +83,33 @@ vi.mock("../api/queries", async (importOriginal) => {
 	};
 });
 
-function renderPage() {
-	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	return render(
+// Renders the router's own location so a test can assert what the URL bar
+// would show. The page scrubs through the router, and react-router's location
+// is the only thing that reflects that — `window.location` is decoupled here.
+function LocationProbe() {
+	const { pathname, search } = useLocation();
+	return <span data-testid="location">{`${pathname}${search}`}</span>;
+}
+
+function pageTree(entry: string, qc: QueryClient) {
+	return (
 		<QueryClientProvider client={qc}>
-			<MemoryRouter>
+			<MemoryRouter initialEntries={[entry]}>
 				<DeviceLinkPage />
+				<LocationProbe />
 			</MemoryRouter>
-		</QueryClientProvider>,
+		</QueryClientProvider>
 	);
+}
+
+function renderPage(entry = "/link") {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return { qc, ...render(pageTree(entry, qc)) };
 }
 
 afterEach(() => {
 	vi.clearAllMocks();
+	billingPending.current = false;
 	window.history.replaceState({}, "", "/link");
 	authState.current = { isSignedIn: true };
 	billingState.current = {
@@ -118,9 +136,8 @@ describe("DeviceLinkPage", () => {
 	// RFC 8628 verification_uri_complete. The plugin opens /link?code=ENGR-7X4K,
 	// so the user never retypes what their own machine already knows.
 	it("auto-verifies a code supplied in the query string", async () => {
-		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
 		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
-		renderPage();
+		renderPage("/link?code=ENGR-7X4K");
 
 		await waitFor(() => expect(get).toHaveBeenCalledWith("/vaults?user_code=ENGR-7X4K"));
 		expect(await screen.findByRole("radio", { name: /personal/iu })).toBeInTheDocument();
@@ -129,22 +146,80 @@ describe("DeviceLinkPage", () => {
 	// Authorizing is still an explicit act: auto-verify only lists the vaults.
 	// Nothing is linked until the user picks one and clicks Sync.
 	it("does not authorize on its own after auto-verifying", async () => {
-		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
 		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
-		renderPage();
+		renderPage("/link?code=ENGR-7X4K");
 
 		await screen.findByRole("radio", { name: /personal/iu });
 		expect(post).not.toHaveBeenCalled();
 	});
 
 	// A single-use code shouldn't linger in history, bookmarks, or a shared URL.
+	//
+	// Asserted on the ROUTER's location, which is what the address bar shows on
+	// createBrowserRouter. The old version checked `window.location` under a
+	// MemoryRouter — two decoupled things — so it passed no matter what the
+	// page did, including when the code was still live in `useLocation()` and
+	// being re-emitted into the billing links.
 	it("scrubs the code out of the URL once it has been read", async () => {
-		window.history.replaceState({}, "", "/link?code=ENGR-7X4K");
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
+		renderPage("/link?code=ENGR-7X4K");
+
+		await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("/link"));
+		expect(screen.getByTestId("location").textContent).not.toContain("ENGR");
+	});
+
+	// Scrub the credential, not the whole query string: other params on this
+	// URL belong to whoever put them there.
+	it("leaves unrelated query params alone", async () => {
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
+		renderPage("/link?code=ENGR-7X4K&ref=newsletter");
+
+		await waitFor(() => expect(get).toHaveBeenCalled());
+		const url = screen.getByTestId("location").textContent ?? "";
+		expect(url).toContain("ref=newsletter");
+		expect(url).not.toContain("code=");
+	});
+
+	// The default vault selection is cap-aware, and the cap arrives from
+	// /billing/status. Typing a code takes longer than that fetch, so only the
+	// auto path can outrun it — and when it did, an at-cap user was defaulted
+	// onto a create-new row that renders disabled, with Sync still armed for a
+	// guaranteed 402.
+	it("waits for the vault cap before auto-verifying", async () => {
+		billingPending.current = true;
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
+		const { qc, rerender } = renderPage("/link?code=ENGR-7X4K");
+
+		expect(get).not.toHaveBeenCalled();
+
+		// Same mount, cap now known — the verify must resume on its own rather
+		// than needing another visit.
+		billingPending.current = false;
+		rerender(pageTree("/link?code=ENGR-7X4K", qc));
+		await waitFor(() => expect(get).toHaveBeenCalledWith("/vaults?user_code=ENGR-7X4K"));
+	});
+
+	// RFC 8628 §5.4: typing the code IS the anti-phishing beat, and arriving
+	// with ?code= skips it. The suggested vault name comes from an
+	// unauthenticated endpoint, so it is not evidence of who is asking.
+	it("warns about the requesting device only when the code arrived in the URL", async () => {
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
+		renderPage("/link?code=ENGR-7X4K");
+
+		expect(
+			await screen.findByText(/only continue if you started this from obsidian/iu),
+		).toBeInTheDocument();
+	});
+
+	it("does not warn when the user typed the code themselves", async () => {
 		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
 		renderPage();
 
-		await waitFor(() => expect(window.location.search).toBe(""));
-		expect(window.location.pathname).toBe("/link");
+		fireEvent.change(screen.getByPlaceholderText(/XXXX-XXXX/iu), { target: { value: "ENGR7X4K" } });
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+
+		await screen.findByRole("radio", { name: /personal/iu });
+		expect(screen.queryByText(/only continue if you started this/iu)).not.toBeInTheDocument();
 	});
 
 	it("does not auto-verify when no code was supplied", () => {
@@ -172,12 +247,11 @@ describe("DeviceLinkPage", () => {
 	});
 
 	it("rejects an invalid code that arrived in the query string", async () => {
-		window.history.replaceState({}, "", "/link?code=ZZZZ-ZZZZ");
 		get.mockResolvedValue({
 			vaults: [{ id: 7, name: "Personal", note_count: 0 }],
 			user_code_valid: false,
 		});
-		renderPage();
+		renderPage("/link?code=ZZZZ-ZZZZ");
 
 		expect(await screen.findByRole("alert")).toHaveTextContent(/invalid or has expired/iu);
 		expect(screen.queryByRole("radio", { name: /personal/iu })).not.toBeInTheDocument();

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -25,6 +25,16 @@ interface Vault {
 
 type Step = "enter-code" | "pick-vault" | "success" | "error";
 
+// The heading names the step you're on. It used to be a single ternary that
+// only special-cased pick-vault, so the success screen kept announcing "Link
+// Obsidian Vault" for a job that was already done.
+const STEP_TITLES: Record<Step, string> = {
+	"enter-code": "Link Obsidian Vault",
+	"pick-vault": "Choose a vault to sync",
+	success: "Finish in Obsidian",
+	error: "Link Obsidian Vault",
+};
+
 // RFC 8628 verification_uri_complete: the plugin sends the user to
 // /link?code=ENGR-7X4K, so read and normalize the code it already knows.
 // Returns "" when absent, and only returns the dashed 9-char form when the
@@ -265,7 +275,7 @@ function DeviceLinkPage() {
 				)}
 			>
 				<h1 className="font-bold text-2xl text-foreground tracking-tight sm:text-3xl">
-					{step === "pick-vault" ? "Choose a vault to sync" : "Link Obsidian Vault"}
+					{STEP_TITLES[step]}
 				</h1>
 
 				{capCheck.swapCooldownHours !== null && step !== "success" ? (
@@ -422,37 +432,40 @@ function SuccessStep({ linkedVaultId, obsidianVaultName, onForward }: SuccessSte
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="flex flex-col gap-1">
-				<h2 className="font-semibold text-foreground text-lg">Vault linked!</h2>
-				<p className="text-foreground text-sm">
-					Now jump back to Obsidian and run your first sync.
-				</p>
-			</div>
-
-			{/* Obsidian registers the `obsidian://` URI scheme, so this is a plain
-			    link — no integration, no detection. Deliberately a button and not
-			    an automatic redirect: browsers suppress protocol launches without
-			    a user gesture, and there is no success callback, so nothing below
-			    may depend on the jump having worked. It also opens Obsidian on
-			    whatever machine the BROWSER is on, which is why it's an offer
-			    sitting next to "Skip ahead" rather than the only way forward. */}
-			{obsidianVaultName ? (
-				<Button asChild className="self-start">
-					<a href={`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}`}>
-						Open Obsidian
-					</a>
-				</Button>
-			) : null}
+			{/* No second heading here — the panel's h1 already says "Finish in
+			    Obsidian", and "Vault linked!" underneath it was the same news twice. */}
+			<p className="text-foreground text-sm">
+				Your vault is linked. Obsidian is waiting for you to start the first sync.
+			</p>
 
 			<SyncStatusPill message="Waiting for your first sync…" />
 
 			<p className="text-muted-foreground text-sm">
-				Once it lands we'll take you to your vault automatically.
+				We'll open your vault here the moment it lands.
 			</p>
 
-			<Button type="button" variant="ghost" onClick={onForward} className="self-start text-sm">
-				Skip ahead
-			</Button>
+			{/* Actions bottom-right, matching the footer pattern used elsewhere
+			    (e.g. settings/connections-page.tsx). Secondary first, primary last.
+
+			    Obsidian registers the `obsidian://` URI scheme, so the primary is a
+			    plain link — no integration, no detection. Deliberately a button and
+			    not an automatic redirect: browsers suppress protocol launches
+			    without a user gesture, and there is no success callback, so nothing
+			    here may depend on the jump having worked. It also opens Obsidian on
+			    whatever machine the BROWSER is on, which is why the escape hatch
+			    beside it is always present. */}
+			<footer className="flex justify-end gap-2 pt-2">
+				<Button type="button" variant="ghost" onClick={onForward} className="text-sm">
+					Go to my vault without waiting
+				</Button>
+				{obsidianVaultName ? (
+					<Button asChild>
+						<a href={`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}`}>
+							Open Obsidian
+						</a>
+					</Button>
+				) : null}
+			</footer>
 		</div>
 	);
 }

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -97,9 +97,23 @@ function DeviceLinkPage() {
 		setError("");
 		try {
 			const formattedCode = `${formatted.slice(0, 4)}-${formatted.slice(4)}`;
-			const data = await api.get<{ vaults: Vault[]; suggested_vault_name?: string | null }>(
-				`/vaults?user_code=${encodeURIComponent(formattedCode)}`,
-			);
+			const data = await api.get<{
+				vaults: Vault[];
+				suggested_vault_name?: string | null;
+				user_code_valid?: boolean;
+			}>(`/vaults?user_code=${encodeURIComponent(formattedCode)}`);
+			// This endpoint answers 200 with the caller's vault list whether or not
+			// the code is real — `user_code_valid` is the only validity signal, and
+			// a null `suggested_vault_name` is NOT one (a valid code from a plugin
+			// that sent no hint has both). Without this check every 8-character
+			// string reached the vault picker and only failed at authorize.
+			//
+			// Compared against `false`, never falsy: a frontend deployed ahead of
+			// the backend sees `undefined` here and must still let the link through.
+			if (data.user_code_valid === false) {
+				setError("This code is invalid or has expired. Please try again from Obsidian.");
+				return;
+			}
 			setUserCode(formattedCode);
 			setVaults(data.vaults ?? []);
 			const suggested = data.suggested_vault_name?.trim() || "";

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -23,7 +23,7 @@ interface Vault {
 	note_count: number;
 }
 
-type Step = "enter-code" | "pick-vault" | "success" | "error";
+type Step = "enter-code" | "pick-vault" | "success";
 
 // The heading names the step you're on. It used to be a single ternary that
 // only special-cased pick-vault, so the success screen kept announcing "Link
@@ -32,7 +32,6 @@ const STEP_TITLES: Record<Step, string> = {
 	"enter-code": "Link Obsidian Vault",
 	"pick-vault": "Choose a vault to sync",
 	success: "Finish in Obsidian",
-	error: "Link Obsidian Vault",
 };
 
 // RFC 8628 verification_uri_complete: the plugin sends the user to
@@ -40,11 +39,8 @@ const STEP_TITLES: Record<Step, string> = {
 // Returns "" when absent, and only returns the dashed 9-char form when the
 // query held a full 8-character code — a partial value stays unformatted so
 // the auto-verify below won't fire on it.
-function readCodeFromQuery(): string {
-	if (typeof window === "undefined") {
-		return "";
-	}
-	const raw = new URLSearchParams(window.location.search).get("code") ?? "";
+function readCodeFromQuery(search: string): string {
+	const raw = new URLSearchParams(search).get("code") ?? "";
 	const clean = raw
 		.toUpperCase()
 		.replace(/[^A-Z2-9]/gu, "")
@@ -65,7 +61,13 @@ function DeviceLinkPage() {
 	// Captured once at mount. `userCode` drifts as the user types, but whether
 	// the code ARRIVED from the plugin is fixed — and only that earns an
 	// automatic verify (see the effect below).
-	const [urlCode] = useState(readCodeFromQuery);
+	// Read from the ROUTER's location, not window.location: the scrub below
+	// goes through the router, so reading the raw window would leave the two
+	// disagreeing about whether the code is still in the URL.
+	const [urlCode] = useState(() => readCodeFromQuery(location.search));
+	// Did the plugin hand us the code, or did the user type it? Only the first
+	// skips RFC 8628's manual-entry speed bump, so only it needs the caution.
+	const arrivedWithCode = urlCode.length === 9;
 	const [userCode, setUserCode] = useState(urlCode);
 	const [vaults, setVaults] = useState<Vault[]>([]);
 	// `selection` is the radio-row value: 'matched' (create new with the
@@ -93,7 +95,7 @@ function DeviceLinkPage() {
 	// Vault cap awareness for the picker — Free has vaults_cap=1, so once the
 	// user has any vault, the "create new" options would 402 on submit. Disable
 	// them proactively and force a link-into-existing choice.
-	const { data: billing } = useBillingStatus();
+	const { data: billing, isPending: billingPending } = useBillingStatus();
 	const vaultsCap = billing?.caps.vaults ?? null;
 	const atVaultCap = typeof vaultsCap === "number" && vaultsCap > 0 && vaults.length >= vaultsCap;
 
@@ -123,11 +125,14 @@ function DeviceLinkPage() {
 			//
 			// Compared against `false`, never falsy: a frontend deployed ahead of
 			// the backend sees `undefined` here and must still let the link through.
+			// Normalize the field before the validity branch: rejecting the code
+			// used to leave "ZZZZZZZZ" sitting in an input that formats every
+			// other value as "ZZZZ-ZZZZ".
+			setUserCode(formattedCode);
 			if (data.user_code_valid === false) {
 				setError("This code is invalid or has expired. Please try again from Obsidian.");
 				return;
 			}
-			setUserCode(formattedCode);
 			setVaults(data.vaults ?? []);
 			const suggested = data.suggested_vault_name?.trim() || "";
 			setSuggestedName(suggested);
@@ -173,13 +178,32 @@ function DeviceLinkPage() {
 	// and shouldn't sit in history or survive a copy-pasted URL.
 	const autoVerified = useRef(false);
 	useEffect(() => {
-		if (autoVerified.current || !isSignedIn || urlCode.length !== 9) {
+		// Wait for billing: `handleVerifyCode` picks the default selection using
+		// `vaultsCap`, which is null until the query lands. The manual path is
+		// never affected (typing takes longer than the fetch), but the auto path
+		// fires at mount — and with a null cap an at-cap user defaulted to a
+		// create-new row that is then rendered disabled, leaving Sync armed for
+		// a guaranteed 402. `isPending` and not `data === undefined` so a FAILED
+		// billing fetch still lets the link through.
+		if (autoVerified.current || !isSignedIn || urlCode.length !== 9 || billingPending) {
 			return;
 		}
 		autoVerified.current = true;
-		window.history.replaceState({}, "", window.location.pathname + window.location.hash);
+		// Scrub via the ROUTER, not window.history: the app runs on
+		// createBrowserRouter, and a raw replaceState leaves react-router's own
+		// location untouched — so `useLocation().search` kept the code, and the
+		// billing links below (which preserve `search` on purpose) put the
+		// credential straight back into the address bar and into history.
+		// Delete only `code`; a blanket wipe would silently eat a future
+		// redirect or auth-callback param.
+		const scrubbed = new URLSearchParams(location.search);
+		scrubbed.delete("code");
+		navigate(
+			{ pathname: location.pathname, search: scrubbed.toString(), hash: location.hash },
+			{ replace: true },
+		);
 		handleVerifyCode();
-	}, [isSignedIn, urlCode, handleVerifyCode]);
+	}, [isSignedIn, urlCode, handleVerifyCode, billingPending, location, navigate]);
 
 	if (!isSignedIn) {
 		return (
@@ -390,6 +414,18 @@ function DeviceLinkPage() {
 							</p>
 						)}
 
+						{/* The typed-code step IS the phishing defence RFC 8628 §5.4 names,
+						    and arriving with ?code= skips it. `vault_name` is
+						    attacker-supplied (POST /api/auth/device is unauthenticated),
+						    so the name shown above is NOT evidence of who is asking —
+						    say so on the path that lost the speed bump. */}
+						{arrivedWithCode && (
+							<p className="text-muted-foreground text-xs">
+								A device asked to sync with your account. Only continue if you started this from
+								Obsidian &mdash; the vault name above was supplied by that device.
+							</p>
+						)}
+
 						<Button
 							type="button"
 							onClick={handleAuthorize}
@@ -442,7 +478,11 @@ function SuccessStep({
 	const { data: me } = useMe();
 	const { vaultPopulated, vaultId } = useVaultReadyEvents({
 		userId: me?.id ?? null,
-		enabled: true,
+		// A non-empty vault has no 0->1 transition left, so the step below tells
+		// the user there is no automatic hand-off. Opening the socket anyway
+		// would have forwarded them regardless — doing the thing we just said
+		// we wouldn't.
+		enabled: awaitFirstSync,
 	});
 
 	// Auto-forward to the dashboard once the plugin's first sync lands. Match

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -434,7 +434,10 @@ function SuccessStep({ linkedVaultId, obsidianVaultName, onForward }: SuccessSte
 		<div className="flex flex-col gap-4">
 			{/* No second heading here — the panel's h1 already says "Finish in
 			    Obsidian", and "Vault linked!" underneath it was the same news twice. */}
-			<p className="text-foreground text-sm">
+			{/* text-base, not the text-sm used for hints on the earlier steps: this
+			    is the one instruction on the screen, and at text-sm it read like
+			    fine print the user could skip. */}
+			<p className="text-base text-foreground">
 				Your vault is linked. Obsidian is waiting for you to start the first sync.
 			</p>
 
@@ -456,7 +459,7 @@ function SuccessStep({ linkedVaultId, obsidianVaultName, onForward }: SuccessSte
 			    beside it is always present. */}
 			<footer className="flex justify-end gap-2 pt-2">
 				<Button type="button" variant="ghost" onClick={onForward} className="text-sm">
-					Go to my vault without waiting
+					Continue to web app
 				</Button>
 				{obsidianVaultName ? (
 					<Button asChild>

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -378,7 +378,11 @@ function DeviceLinkPage() {
 				)}
 
 				{step === "success" && (
-					<SuccessStep linkedVaultId={linkedVaultId} onForward={() => navigate("/")} />
+					<SuccessStep
+						linkedVaultId={linkedVaultId}
+						obsidianVaultName={suggestedName}
+						onForward={() => navigate("/")}
+					/>
 				)}
 
 				{Boolean(error) && (
@@ -393,10 +397,14 @@ function DeviceLinkPage() {
 
 interface SuccessStepProps {
 	linkedVaultId: string | null;
+	// The LOCAL Obsidian vault name the plugin sent at device-flow start, which
+	// is what `obsidian://open?vault=` addresses — not the server-side vault the
+	// user just picked, whose name may differ. Empty when the plugin sent no hint.
+	obsidianVaultName: string;
 	onForward: () => void;
 }
 
-function SuccessStep({ linkedVaultId, onForward }: SuccessStepProps) {
+function SuccessStep({ linkedVaultId, obsidianVaultName, onForward }: SuccessStepProps) {
 	const { data: me } = useMe();
 	const { vaultPopulated, vaultId } = useVaultReadyEvents({
 		userId: me?.id ?? null,
@@ -420,6 +428,21 @@ function SuccessStep({ linkedVaultId, onForward }: SuccessStepProps) {
 					Now jump back to Obsidian and run your first sync.
 				</p>
 			</div>
+
+			{/* Obsidian registers the `obsidian://` URI scheme, so this is a plain
+			    link — no integration, no detection. Deliberately a button and not
+			    an automatic redirect: browsers suppress protocol launches without
+			    a user gesture, and there is no success callback, so nothing below
+			    may depend on the jump having worked. It also opens Obsidian on
+			    whatever machine the BROWSER is on, which is why it's an offer
+			    sitting next to "Skip ahead" rather than the only way forward. */}
+			{obsidianVaultName ? (
+				<Button asChild className="self-start">
+					<a href={`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}`}>
+						Open Obsidian
+					</a>
+				</Button>
+			) : null}
 
 			<SyncStatusPill message="Waiting for your first sync…" />
 

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { useAutofocus } from "@/hooks/use-autofocus";
@@ -25,6 +25,23 @@ interface Vault {
 
 type Step = "enter-code" | "pick-vault" | "success" | "error";
 
+// RFC 8628 verification_uri_complete: the plugin sends the user to
+// /link?code=ENGR-7X4K, so read and normalize the code it already knows.
+// Returns "" when absent, and only returns the dashed 9-char form when the
+// query held a full 8-character code — a partial value stays unformatted so
+// the auto-verify below won't fire on it.
+function readCodeFromQuery(): string {
+	if (typeof window === "undefined") {
+		return "";
+	}
+	const raw = new URLSearchParams(window.location.search).get("code") ?? "";
+	const clean = raw
+		.toUpperCase()
+		.replace(/[^A-Z2-9]/gu, "")
+		.slice(0, 8);
+	return clean.length === 8 ? `${clean.slice(0, 4)}-${clean.slice(4)}` : clean;
+}
+
 function DeviceLinkPage() {
 	const { isSignedIn } = useAuthAdapter();
 	const navigate = useNavigate();
@@ -35,19 +52,11 @@ function DeviceLinkPage() {
 	// arrives from the plugin specifically to type into it — land with focus
 	// already there. Keyed on the step so returning to it re-focuses.
 	const codeRef = useAutofocus<HTMLInputElement>(step === "enter-code");
-	// RFC 8628 verification_uri_complete: if the plugin sends the user to
-	// /link?code=ENGR-7X4K, prefill the field instead of forcing a re-type.
-	const [userCode, setUserCode] = useState(() => {
-		if (typeof window === "undefined") {
-			return "";
-		}
-		const raw = new URLSearchParams(window.location.search).get("code") ?? "";
-		const clean = raw
-			.toUpperCase()
-			.replace(/[^A-Z2-9]/gu, "")
-			.slice(0, 8);
-		return clean.length === 8 ? `${clean.slice(0, 4)}-${clean.slice(4)}` : clean;
-	});
+	// Captured once at mount. `userCode` drifts as the user types, but whether
+	// the code ARRIVED from the plugin is fixed — and only that earns an
+	// automatic verify (see the effect below).
+	const [urlCode] = useState(readCodeFromQuery);
+	const [userCode, setUserCode] = useState(urlCode);
 	const [vaults, setVaults] = useState<Vault[]>([]);
 	// `selection` is the radio-row value: 'matched' (create new with the
 	// plugin-suggested name), 'custom' (create new with the input below), or
@@ -75,20 +84,9 @@ function DeviceLinkPage() {
 	const vaultsCap = billing?.caps.vaults ?? null;
 	const atVaultCap = typeof vaultsCap === "number" && vaultsCap > 0 && vaults.length >= vaultsCap;
 
-	if (!isSignedIn) {
-		return (
-			<AuthShell>
-				<AuthPanel className="flex flex-col gap-3">
-					<h1 className={heading}>Link Obsidian Vault</h1>
-					<p className="text-muted-foreground text-sm">
-						Please sign in to link your Obsidian vault.
-					</p>
-				</AuthPanel>
-			</AuthShell>
-		);
-	}
-
-	async function handleVerifyCode() {
+	// useCallback (not a plain function) so the auto-verify effect below can
+	// depend on it without re-firing every render.
+	const handleVerifyCode = useCallback(async () => {
 		const formatted = userCode.toUpperCase().replace(/[^A-Z2-9]/gu, "");
 		if (formatted.length !== 8) {
 			setError("Code must be 8 characters (e.g., ENGR-7X4K)");
@@ -134,6 +132,39 @@ function DeviceLinkPage() {
 		} finally {
 			setLoading(false);
 		}
+	}, [userCode, vaultsCap]);
+
+	// The plugin already knows the code, so a complete link URL means the only
+	// step left is choosing a vault — run the verify for them and land there.
+	//
+	// Deliberately does NOT authorize. Linking stays an explicit Sync click on a
+	// screen that names the vault, which is the consent beat that makes carrying
+	// the code in a URL safe (RFC 8628's device-code phishing concern is about
+	// approving someone ELSE's code, and only a real consent screen defends it).
+	//
+	// Scrubs the code out of the address bar too: it's a single-use credential
+	// and shouldn't sit in history or survive a copy-pasted URL.
+	const autoVerified = useRef(false);
+	useEffect(() => {
+		if (autoVerified.current || !isSignedIn || urlCode.length !== 9) {
+			return;
+		}
+		autoVerified.current = true;
+		window.history.replaceState({}, "", window.location.pathname + window.location.hash);
+		handleVerifyCode();
+	}, [isSignedIn, urlCode, handleVerifyCode]);
+
+	if (!isSignedIn) {
+		return (
+			<AuthShell>
+				<AuthPanel className="flex flex-col gap-3">
+					<h1 className={heading}>Link Obsidian Vault</h1>
+					<p className="text-muted-foreground text-sm">
+						Please sign in to link your Obsidian vault.
+					</p>
+				</AuthPanel>
+			</AuthShell>
+		);
 	}
 
 	const isMatched = selection === "matched";

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -229,8 +229,22 @@ function DeviceLinkPage() {
 				// owes the first sync from inside Obsidian. The success step listens
 				// for the `vault_populated` broadcast and forwards then.
 				setActiveVaultId(vault_id);
-				setLinkedVaultId(vault_id);
 				qc.invalidateQueries({ queryKey: ["vaults"] });
+
+				// `vault_populated` fires on a vault's 0 -> 1 note transition, so a
+				// vault that ALREADY has notes can never emit it. Parking the user on
+				// "waiting for your first sync" there means waiting on an event that
+				// is not coming, until they give up and click through. Only an empty
+				// vault has a first-sync milestone to wait for.
+				const target = createNew
+					? null
+					: vaults.find((v) => String(v.id) === String(selection));
+				if (target && target.note_count > 0) {
+					navigate("/");
+					return;
+				}
+
+				setLinkedVaultId(vault_id);
 				setStep("success");
 			} catch (authErr) {
 				if (swappedFromName) {

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -75,6 +75,9 @@ function DeviceLinkPage() {
 	const [suggestedName, setSuggestedName] = useState("");
 	const [customName, setCustomName] = useState("");
 	const [linkedVaultId, setLinkedVaultId] = useState<string | null>(null);
+	// Whether the success step has a first-sync milestone to wait for. False when
+	// linking into a vault that already has notes — see handleAuthorize.
+	const [awaitFirstSync, setAwaitFirstSync] = useState(true);
 	const [error, setError] = useState("");
 	const [loading, setLoading] = useState(false);
 	// Device-flow is "I'm moving in" not "I want a 4th tab" — when at cap, we
@@ -232,17 +235,14 @@ function DeviceLinkPage() {
 				qc.invalidateQueries({ queryKey: ["vaults"] });
 
 				// `vault_populated` fires on a vault's 0 -> 1 note transition, so a
-				// vault that ALREADY has notes can never emit it. Parking the user on
-				// "waiting for your first sync" there means waiting on an event that
-				// is not coming, until they give up and click through. Only an empty
-				// vault has a first-sync milestone to wait for.
-				const target = createNew
-					? null
-					: vaults.find((v) => String(v.id) === String(selection));
-				if (target && target.note_count > 0) {
-					navigate("/");
-					return;
-				}
+				// vault that ALREADY has notes can never emit it.
+				//
+				// That kills the WAITING, not the step. The user still has to go back
+				// to Obsidian and finish the sync, so the instructions and the Open
+				// Obsidian button must render either way — skipping straight to the
+				// vault drops the one thing this screen exists to tell them.
+				const target = createNew ? null : vaults.find((v) => String(v.id) === String(selection));
+				setAwaitFirstSync(!target || target.note_count === 0);
 
 				setLinkedVaultId(vault_id);
 				setStep("success");
@@ -405,6 +405,7 @@ function DeviceLinkPage() {
 					<SuccessStep
 						linkedVaultId={linkedVaultId}
 						obsidianVaultName={suggestedName}
+						awaitFirstSync={awaitFirstSync}
 						onForward={() => navigate("/")}
 					/>
 				)}
@@ -425,10 +426,19 @@ interface SuccessStepProps {
 	// is what `obsidian://open?vault=` addresses — not the server-side vault the
 	// user just picked, whose name may differ. Empty when the plugin sent no hint.
 	obsidianVaultName: string;
+	// False when the linked vault already has notes: there is no 0 -> 1
+	// transition left, so there is no `vault_populated` coming and promising an
+	// automatic hand-off would be a lie.
+	awaitFirstSync: boolean;
 	onForward: () => void;
 }
 
-function SuccessStep({ linkedVaultId, obsidianVaultName, onForward }: SuccessStepProps) {
+function SuccessStep({
+	linkedVaultId,
+	obsidianVaultName,
+	awaitFirstSync,
+	onForward,
+}: SuccessStepProps) {
 	const { data: me } = useMe();
 	const { vaultPopulated, vaultId } = useVaultReadyEvents({
 		userId: me?.id ?? null,
@@ -455,11 +465,22 @@ function SuccessStep({ linkedVaultId, obsidianVaultName, onForward }: SuccessSte
 				Your vault is linked. Obsidian is waiting for you to start the first sync.
 			</p>
 
-			<SyncStatusPill message="Waiting for your first sync…" />
-
-			<p className="text-muted-foreground text-sm">
-				We'll open your vault here the moment it lands.
-			</p>
+			{/* Only an empty vault has a 0 -> 1 transition left, so only an empty
+			    vault can produce `vault_populated`. Showing a spinner and promising
+			    an automatic hand-off anywhere else advertises something that is
+			    never going to happen. */}
+			{awaitFirstSync ? (
+				<>
+					<SyncStatusPill message="Waiting for your first sync…" />
+					<p className="text-muted-foreground text-sm">
+						We'll open your vault here the moment it lands.
+					</p>
+				</>
+			) : (
+				<p className="text-muted-foreground text-sm">
+					Your notes will appear here as they sync. You can come back any time.
+				</p>
+			)}
 
 			{/* Actions bottom-right, matching the footer pattern used elsewhere
 			    (e.g. settings/connections-page.tsx). Secondary first, primary last.

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -45,9 +45,20 @@ defmodule Engram.Auth.DeviceFlow do
     |> Repo.insert(skip_tenant_check: true)
   end
 
-  # Read the suggested name a plugin sent at start_device_flow time. Returns
-  # nil if the code is unknown, expired, no longer pending, never carried a
-  # hint, OR has already been viewed by a different authenticated user.
+  # Look up a pending device-link row on behalf of the authenticated user
+  # reading it, and report BOTH whether the code is usable and the suggested
+  # vault name the plugin sent at start_device_flow time.
+  #
+  #   {:ok, name} — real, pending, unexpired, claimable by this user
+  #   {:ok, nil}  — same, but the plugin never sent a vault-name hint
+  #   :error      — unknown, expired, already authorized, or claimed by
+  #                 a different authenticated user
+  #
+  # `{:ok, nil}` and `:error` are DELIBERATELY distinct. This used to return a
+  # bare name, so a valid-but-unnamed code and a bogus code were both `nil`;
+  # /link had no way to tell them apart and waved through any 8-character
+  # typo, deferring the real check to authorize three clicks later. Callers
+  # must not collapse them again.
   #
   # The lookup is bound to the first authenticated user who reads the code
   # — set atomically on the same row in this UPDATE. Without this binding
@@ -56,7 +67,7 @@ defmodule Engram.Auth.DeviceFlow do
   # and read the original user's local Obsidian vault name. The row's main
   # `user_id` is set later, at authorize time, and so is unsuitable as a
   # pre-authorize ownership check.
-  def suggested_vault_name(user_code, user_id) when is_binary(user_id) do
+  def view_pending_code(user_code, user_id) when is_binary(user_id) do
     now = DateTime.utc_now()
 
     query =
@@ -70,16 +81,17 @@ defmodule Engram.Auth.DeviceFlow do
 
     case Repo.update_all(query, [set: [viewer_user_id: user_id]], skip_tenant_check: true) do
       {1, _} ->
-        Repo.one(
-          from(da in DeviceAuthorization,
-            where: da.user_code == ^user_code,
-            select: da.vault_name
-          ),
-          skip_tenant_check: true
-        )
+        {:ok,
+         Repo.one(
+           from(da in DeviceAuthorization,
+             where: da.user_code == ^user_code,
+             select: da.vault_name
+           ),
+           skip_tenant_check: true
+         )}
 
       _ ->
-        nil
+        :error
     end
   end
 

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -95,6 +95,53 @@ defmodule Engram.Auth.DeviceFlow do
     end
   end
 
+  @doc """
+  True when `device_code` names a real authorization that is still pending
+  and unexpired. Gate for `EngramWeb.DeviceChannel` joins — without it the
+  `device:*` topic space would be an unauthenticated fan-out surface anyone
+  could hold subscriptions against.
+
+  Deliberately NOT a token check: it answers "is this worth waiting on", and
+  the actual credential exchange stays in the single-use REST endpoint.
+  """
+  @spec pending_device_code?(String.t()) :: boolean()
+  def pending_device_code?(device_code) when is_binary(device_code) do
+    now = DateTime.utc_now()
+
+    Repo.exists?(
+      from(da in DeviceAuthorization,
+        where: da.device_code == ^device_code and da.status == "pending" and da.expires_at > ^now
+      ),
+      skip_tenant_check: true
+    )
+  end
+
+  @doc """
+  Tell anyone waiting on `device:{device_code}` that the code was approved,
+  so they can exchange it immediately instead of discovering it on the next
+  poll tick.
+
+  The payload is deliberately empty. A broadcast reaches every subscriber at
+  once while the token exchange is single-use, so shipping credentials here
+  would be weaker than the endpoint it front-runs. See
+  `EngramWeb.DeviceChannel`.
+
+  Always returns `:ok`. This is an optimisation, not a step of the flow — the
+  plugin keeps a slow fallback poll running — so a PubSub failure must not
+  fail the user's authorize call. Logged rather than raised.
+  """
+  @spec notify_authorized(String.t()) :: :ok
+  def notify_authorized(device_code) when is_binary(device_code) do
+    case EngramWeb.Endpoint.broadcast("device:#{device_code}", "authorized", %{}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("device-flow authorized notify failed", reason: inspect(reason))
+        :ok
+    end
+  end
+
   def authorize_device(user_code, user, vault_id) do
     now = DateTime.utc_now()
 

--- a/lib/engram/logger/redact_filter.ex
+++ b/lib/engram/logger/redact_filter.ex
@@ -53,6 +53,10 @@ defmodule Engram.Logger.RedactFilter do
                     # OAuth tokens — never log raw bearer values
                     :access_token,
                     :refresh_token,
+                    # RFC 8628 device flow — `device_code` redeems into both
+                    # tokens above, so it is a bearer credential in its own
+                    # right for its 300s life.
+                    :device_code,
                     :authorization_header,
                     :client_secret,
                     :client_secret_hash

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -5692,10 +5692,25 @@ defmodule Engram.Notes do
     # regardless of vault size. Scope stays per-vault (NOT the per-user
     # usage_meters counter — multi-vault users must still get the event
     # for a new vault's first note).
-    {:ok, ids} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(from(n in scoped(user, vault), select: n.id, limit: 2))
-      end)
+    #
+    # Predicates must MATCH `Vaults.do_content_counts/2` (`is_nil(deleted_at)`
+    # and `kind == "note"`), because the page this event unblocks gates on
+    # THAT counter. `scoped/2` alone counts folder markers and tombstones,
+    # which live in this same table — and the plugin's catch-up seeds folder
+    # rows BEFORE the first note, so any vault with one empty folder saw 2
+    # rows here, skipped the broadcast, and left the web page spinning on a
+    # `note_count` of 0 forever. Two "count the notes" predicates that
+    # disagree is the bug; keep them identical.
+    #
+    # `skip_tenant_check:` rather than `Repo.with_tenant/2`: outside a
+    # transaction that helper opens BEGIN + set_config + COMMIT, and this
+    # runs on every genesis insert of a bulk first sync. The query already
+    # filters user_id AND vault_id, so the tenant round-trip buys nothing.
+    ids =
+      Repo.all(
+        from(n in scoped_live(user, vault), where: n.kind == "note", select: n.id, limit: 2),
+        skip_tenant_check: true
+      )
 
     _ =
       if length(ids) == 1 do

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -906,6 +906,14 @@ defmodule Engram.Notes do
         # CrdtDeliver call sites in this module.
         {:ok, {:ok, note, :announce}} ->
           :ok = CrdtDeliver.announce_ready(user.id, vault.id, note.path, note.id)
+
+          # The web /link success page waits on this before forwarding the user
+          # to their vault. It used to fire only from the REST upsert/batch
+          # paths — which the Obsidian plugin stopped using when it moved to
+          # CRDT — so an Obsidian first sync, the exact case that page exists
+          # for, never advanced. Same post-commit position as the announce
+          # above; the helper's own 0->1 probe keeps it to the first note.
+          :ok = maybe_broadcast_vault_populated(user, vault)
           {:ok, note}
 
         {:ok, {:ok, note, {:announce_moved, old_path}}} ->

--- a/lib/engram_web/channels/device_channel.ex
+++ b/lib/engram_web/channels/device_channel.ex
@@ -28,7 +28,12 @@ defmodule EngramWeb.DeviceChannel do
   that, the topic space would be an unauthenticated, unbounded fan-out
   surface that anyone could hold subscriptions against indefinitely.
   """
-  use EngramWeb, :channel
+  # `log_join: false` is load-bearing, not noise control: Phoenix logs
+  # "JOIN {topic}" at :info, and this topic embeds the device_code — the
+  # bearer credential for the token exchange. RedactFilter only scrubs
+  # metadata, never message bodies, so the default would put a live
+  # 300s credential into Loki on every link. `log_handle_in` likewise.
+  use Phoenix.Channel, log_join: false, log_handle_in: false
 
   alias Engram.Auth.DeviceFlow
 
@@ -43,4 +48,12 @@ defmodule EngramWeb.DeviceChannel do
 
   @impl true
   def join(_topic, _payload, _socket), do: {:error, %{reason: "unknown_topic"}}
+
+  # This channel is push-only — nothing legitimate is ever sent up it. Phoenix
+  # injects no fallback clause, so without this any inbound event raises
+  # UndefinedFunctionError and crashes the channel process, which on an
+  # UNAUTHENTICATED socket hands an attacker a Logger.error + a Sentry event
+  # per frame. Drop them silently instead.
+  @impl true
+  def handle_in(_event, _payload, socket), do: {:noreply, socket}
 end

--- a/lib/engram_web/channels/device_channel.ex
+++ b/lib/engram_web/channels/device_channel.ex
@@ -1,0 +1,46 @@
+defmodule EngramWeb.DeviceChannel do
+  @moduledoc """
+  Pre-auth notification channel for the device flow. Topic:
+  `"device:{device_code}"`.
+
+  Replaces the plugin's polling loop: when the user authorizes in the
+  browser, subscribers are pushed an `"authorized"` event and exchange the
+  code for tokens once, instead of asking every 5 seconds whether anything
+  happened yet.
+
+  ## Why a notification and not the tokens
+
+  A broadcast reaches every subscriber to a topic at once; the token exchange
+  is single-use, so the first caller consumes the code and the rest get 410.
+  Putting credentials on the channel would therefore be strictly WEAKER than
+  the REST endpoint it replaces. The channel says "go exchange now"; the
+  exchange stays exactly where it was.
+
+  ## Why the topic can be named by the device_code
+
+  Under RFC 8628 the `device_code` is already the bearer credential for the
+  token exchange, so knowing it is equivalent to being able to redeem it —
+  subscribing leaks nothing that POSTing it wouldn't. It carries 256 bits of
+  entropy, is single-use, and expires in 300s. Phoenix routes topics by exact
+  name, so there is nothing to enumerate.
+
+  Join is still gated on the code being real, pending and unexpired: without
+  that, the topic space would be an unauthenticated, unbounded fan-out
+  surface that anyone could hold subscriptions against indefinitely.
+  """
+  use EngramWeb, :channel
+
+  alias Engram.Auth.DeviceFlow
+
+  @impl true
+  def join("device:" <> device_code, _payload, socket) when byte_size(device_code) > 0 do
+    if DeviceFlow.pending_device_code?(device_code) do
+      {:ok, socket}
+    else
+      {:error, %{reason: "unknown_or_expired"}}
+    end
+  end
+
+  @impl true
+  def join(_topic, _payload, _socket), do: {:error, %{reason: "unknown_topic"}}
+end

--- a/lib/engram_web/channels/device_socket.ex
+++ b/lib/engram_web/channels/device_socket.ex
@@ -1,0 +1,24 @@
+defmodule EngramWeb.DeviceSocket do
+  @moduledoc """
+  Unauthenticated socket for the RFC 8628 device flow.
+
+  The plugin holds no token until the flow completes — obtaining one IS the
+  flow — so it cannot join `EngramWeb.UserSocket`, whose `connect/3` rejects
+  any params without a `"token"`. That chicken-and-egg is why device-flow
+  completion used to be a 5s polling loop.
+
+  Authorization is scoped at the CHANNEL, not here: `connect/3` always
+  succeeds (like `EngramWeb.OriginProbeSocket`) and `EngramWeb.DeviceChannel`
+  refuses to join a topic whose `device_code` isn't real, pending and
+  unexpired. A socket with no joined channel can do nothing.
+  """
+  use Phoenix.Socket
+
+  channel("device:*", EngramWeb.DeviceChannel)
+
+  @impl true
+  def connect(_params, socket, _connect_info), do: {:ok, socket}
+
+  @impl true
+  def id(_socket), do: nil
+end

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -68,6 +68,10 @@ defmodule EngramWeb.DeviceAuthController do
   defp do_authorize(conn, user_code, user, vault_id) do
     case DeviceFlow.authorize_device(user_code, user, vault_id) do
       {:ok, auth} ->
+        # Wake the waiting plugin now instead of letting it find out on a poll
+        # tick. This is a notification only — the plugin still exchanges the
+        # code through the single-use REST endpoint. See EngramWeb.DeviceChannel.
+        :ok = DeviceFlow.notify_authorized(auth.device_code)
         json(conn, %{ok: true, vault_id: auth.vault_id})
 
       {:error, :not_found_or_expired} ->

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -17,8 +17,8 @@ defmodule EngramWeb.VaultsController do
     summary: "List vaults",
     description:
       "Lists the user's active vaults with their note and attachment counts. Pass `deleted=true` " <>
-        "to list soft-deleted vaults instead, or `user_code` to also echo a `suggested_vault_name` " <>
-        "for an in-progress device link.",
+        "to list soft-deleted vaults instead, or `user_code` to also report `user_code_valid` " <>
+        "and a `suggested_vault_name` for an in-progress device link.",
     tags: ["Vaults"],
     parameters: [
       deleted: [
@@ -54,11 +54,18 @@ defmodule EngramWeb.VaultsController do
     payload =
       case Map.get(params, "user_code") do
         code when is_binary(code) and code != "" ->
-          Map.put(
-            payload,
-            :suggested_vault_name,
-            DeviceFlow.suggested_vault_name(code, user.id)
-          )
+          # `user_code_valid` is the ONLY reliable validity signal here — a
+          # real code may legitimately have no `suggested_vault_name`, so a
+          # nil name says nothing about the code. /link rejects on this field.
+          {valid, suggested} =
+            case DeviceFlow.view_pending_code(code, user.id) do
+              {:ok, vault_name} -> {true, vault_name}
+              :error -> {false, nil}
+            end
+
+          payload
+          |> Map.put(:suggested_vault_name, suggested)
+          |> Map.put(:user_code_valid, valid)
 
         _ ->
           payload

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -24,6 +24,15 @@ defmodule EngramWeb.Endpoint do
     longpoll: false,
     drainer: [batch_size: 1_000, batch_interval: 2_000, shutdown: 25_000]
 
+  # Device flow — no auth by necessity: the plugin has no token until the
+  # flow it is waiting on completes, so it cannot use UserSocket. Join is
+  # gated per-topic on a real, pending device_code. See EngramWeb.DeviceSocket.
+  socket "/socket/device", EngramWeb.DeviceSocket,
+    websocket: [
+      check_origin: {__MODULE__, :check_origin, []}
+    ],
+    longpoll: false
+
   # Origin-allowlist probe — no auth, no channels. Reuses the same
   # check_origin MFA as the main socket so the smoke validates the
   # exact allowlist used by UserSocket. See EngramWeb.OriginProbeSocket

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -29,7 +29,12 @@ defmodule EngramWeb.Endpoint do
   # gated per-topic on a real, pending device_code. See EngramWeb.DeviceSocket.
   socket "/socket/device", EngramWeb.DeviceSocket,
     websocket: [
-      check_origin: {__MODULE__, :check_origin, []}
+      check_origin: {__MODULE__, :check_origin, []},
+      # Phoenix defaults to :infinity. This is the only socket reachable
+      # WITHOUT a token, and the frame is buffered before join/3 ever runs,
+      # so the default would let anyone stream unbounded bytes into memory
+      # pre-auth. Join payloads are `%{}` and nothing is ever sent up.
+      max_frame_size: 64_000
     ],
     longpoll: false
 

--- a/lib/engram_web/schemas/vaults.ex
+++ b/lib/engram_web/schemas/vaults.ex
@@ -56,7 +56,16 @@ defmodule EngramWeb.Schemas.VaultsResponse do
       suggested_vault_name: %Schema{
         type: :string,
         nullable: true,
-        description: "Present only when a `user_code` query param is supplied (device-link flow)."
+        description:
+          "Present only when a `user_code` query param is supplied (device-link flow). " <>
+            "May be null for a perfectly valid code — check `user_code_valid`, not this."
+      },
+      user_code_valid: %Schema{
+        type: :boolean,
+        description:
+          "Present only when a `user_code` query param is supplied. True when the code is " <>
+            "real, still pending, unexpired, and claimable by the calling user. This is the " <>
+            "validity signal; a null `suggested_vault_name` is not."
       }
     },
     required: [:vaults]

--- a/openapi.json
+++ b/openapi.json
@@ -1317,9 +1317,15 @@
       "VaultsResponse": {
         "properties": {
           "suggested_vault_name": {
-            "description": "Present only when a `user_code` query param is supplied (device-link flow).",
+            "description": "Present only when a `user_code` query param is supplied (device-link flow). May be null for a perfectly valid code — check `user_code_valid`, not this.",
             "nullable": true,
             "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "user_code_valid": {
+            "description": "Present only when a `user_code` query param is supplied. True when the code is real, still pending, unexpired, and claimable by the calling user. This is the validity signal; a null `suggested_vault_name` is not.",
+            "type": "boolean",
             "x-struct": null,
             "x-validate": null
           },
@@ -4038,7 +4044,7 @@
     "/api/vaults": {
       "get": {
         "callbacks": {},
-        "description": "Lists the user's active vaults with their note and attachment counts. Pass `deleted=true` to list soft-deleted vaults instead, or `user_code` to also echo a `suggested_vault_name` for an in-progress device link.",
+        "description": "Lists the user's active vaults with their note and attachment counts. Pass `deleted=true` to list soft-deleted vaults instead, or `user_code` to also report `user_code_valid` and a `suggested_vault_name` for an in-progress device link.",
         "operationId": "vaults-index",
         "parameters": [
           {

--- a/test/engram/auth/device_flow_test.exs
+++ b/test/engram/auth/device_flow_test.exs
@@ -39,27 +39,37 @@ defmodule Engram.Auth.DeviceFlowTest do
     end
   end
 
-  describe "suggested_vault_name/2" do
+  describe "view_pending_code/2" do
     test "returns the hint stored at start time for a pending code" do
       reader = insert(:user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Brainvault")
-      assert DeviceFlow.suggested_vault_name(auth.user_code, reader.id) == "Brainvault"
+      assert DeviceFlow.view_pending_code(auth.user_code, reader.id) == {:ok, "Brainvault"}
     end
 
-    test "returns nil for unknown code" do
+    # The distinction this whole function exists to preserve: a real code that
+    # simply carried no vault-name hint is still a VALID code. Collapsing this
+    # into the same nil as an unknown code is what let /link wave through any
+    # 8-character typo.
+    test "returns {:ok, nil} for a pending code with no hint — valid, just unnamed" do
       reader = insert(:user)
-      assert DeviceFlow.suggested_vault_name("ZZZZ-ZZZZ", reader.id) == nil
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      assert DeviceFlow.view_pending_code(auth.user_code, reader.id) == {:ok, nil}
     end
 
-    test "returns nil once the code has been authorized (no longer pending)" do
+    test "returns :error for unknown code" do
+      reader = insert(:user)
+      assert DeviceFlow.view_pending_code("ZZZZ-ZZZZ", reader.id) == :error
+    end
+
+    test "returns :error once the code has been authorized (no longer pending)" do
       user = insert(:user)
       vault = insert(:vault, user: user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Local")
       {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
-      assert DeviceFlow.suggested_vault_name(auth.user_code, user.id) == nil
+      assert DeviceFlow.view_pending_code(auth.user_code, user.id) == :error
     end
 
-    test "returns nil for expired code" do
+    test "returns :error for expired code" do
       reader = insert(:user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Local")
       past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
@@ -70,22 +80,22 @@ defmodule Engram.Auth.DeviceFlowTest do
         skip_tenant_check: true
       )
 
-      assert DeviceFlow.suggested_vault_name(auth.user_code, reader.id) == nil
+      assert DeviceFlow.view_pending_code(auth.user_code, reader.id) == :error
     end
 
-    test "the first reader claims the code; subsequent reads by other users return nil" do
+    test "the first reader claims the code; subsequent reads by other users error" do
       first = insert(:user)
       second = insert(:user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Sensitive Vault")
 
       # First user gets the name and atomically claims the row.
-      assert DeviceFlow.suggested_vault_name(auth.user_code, first.id) == "Sensitive Vault"
+      assert DeviceFlow.view_pending_code(auth.user_code, first.id) == {:ok, "Sensitive Vault"}
 
       # Second user (e.g. someone who shoulder-surfed the code) is blocked.
-      assert DeviceFlow.suggested_vault_name(auth.user_code, second.id) == nil
+      assert DeviceFlow.view_pending_code(auth.user_code, second.id) == :error
 
       # First user can re-read their own claim.
-      assert DeviceFlow.suggested_vault_name(auth.user_code, first.id) == "Sensitive Vault"
+      assert DeviceFlow.view_pending_code(auth.user_code, first.id) == {:ok, "Sensitive Vault"}
     end
   end
 

--- a/test/engram/logger/redact_filter_test.exs
+++ b/test/engram/logger/redact_filter_test.exs
@@ -41,6 +41,7 @@ defmodule Engram.Logger.RedactFilterTest do
         :code_verifier,
         :access_token,
         :refresh_token,
+        :device_code,
         :authorization_header,
         :client_secret,
         :client_secret_hash

--- a/test/engram/notes_crdt_vault_populated_test.exs
+++ b/test/engram/notes_crdt_vault_populated_test.exs
@@ -35,6 +35,36 @@ defmodule Engram.NotesCrdtVaultPopulatedTest do
     assert broadcast_vault_id == vault.id
   end
 
+  # The probe counts NOTES, and folder markers live in the same table. The
+  # plugin's catch-up seeds a folder row for every empty local folder BEFORE
+  # it pushes any note, so this is the ordinary first sync, not a corner: a
+  # bare `scoped/2` probe saw 2 rows, stayed silent, and stranded the web
+  # page on a `note_count` that was still 0.
+  test "a folder marker does not count as a note", %{user: user, vault: vault} do
+    {:ok, _marker} = Notes.create_folder_marker(user, vault, "Empty Folder")
+
+    {:ok, _note} = Notes.genesis_crdt_note(user, vault, Ecto.UUID.generate(), "First Note.md")
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "vault_populated"}
+  end
+
+  # Same class, other predicate: a deleted note is invisible to the counter
+  # the page gates on, so it must be invisible to the probe too.
+  test "a tombstoned note does not count", %{user: user, vault: vault} do
+    {:ok, gone} = Notes.genesis_crdt_note(user, vault, Ecto.UUID.generate(), "Gone.md")
+    assert_receive %Phoenix.Socket.Broadcast{event: "vault_populated"}
+    # Tombstone the row directly: what the probe must ignore is the row STATE,
+    # and going through the delete API would drag its own path-lookup and
+    # tenant plumbing into a test about a WHERE clause.
+    {1, _} =
+      Ecto.Query.from(n in Notes.Note, where: n.id == ^gone.id)
+      |> Engram.Repo.update_all([set: [deleted_at: DateTime.utc_now()]], skip_tenant_check: true)
+
+    {:ok, _note} = Notes.genesis_crdt_note(user, vault, Ecto.UUID.generate(), "Fresh.md")
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "vault_populated"}
+  end
+
   # The listener is one-shot and the event means "this vault stopped being
   # empty", so later creates must stay quiet — otherwise every note in a
   # first sync fans out a redundant broadcast to every connected client.

--- a/test/engram/notes_crdt_vault_populated_test.exs
+++ b/test/engram/notes_crdt_vault_populated_test.exs
@@ -1,0 +1,48 @@
+defmodule Engram.NotesCrdtVaultPopulatedTest do
+  @moduledoc """
+  `vault_populated` is what the web /link success page waits on before
+  forwarding the user to their vault.
+
+  It used to be broadcast only from the REST upsert and batch paths. The
+  Obsidian plugin does not use either — it creates notes over the CRDT
+  channel (`crdt_create` -> `genesis_crdt_note`) — so for the exact scenario
+  the page was built for, an Obsidian first sync, the event never fired and
+  the page waited forever.
+  """
+  use Engram.DataCase, async: false
+
+  alias Engram.Notes
+
+  setup do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+    EngramWeb.Endpoint.subscribe("user:#{user.id}")
+    {:ok, user: user, vault: vault}
+  end
+
+  test "a crdt genesis create in an empty vault announces vault_populated", %{
+    user: user,
+    vault: vault
+  } do
+    id = Ecto.UUID.generate()
+    {:ok, _note} = Notes.genesis_crdt_note(user, vault, id, "First Note.md")
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      event: "vault_populated",
+      payload: %{vault_id: broadcast_vault_id}
+    }
+
+    assert broadcast_vault_id == vault.id
+  end
+
+  # The listener is one-shot and the event means "this vault stopped being
+  # empty", so later creates must stay quiet — otherwise every note in a
+  # first sync fans out a redundant broadcast to every connected client.
+  test "a second create does not announce again", %{user: user, vault: vault} do
+    {:ok, _} = Notes.genesis_crdt_note(user, vault, Ecto.UUID.generate(), "First Note.md")
+    assert_receive %Phoenix.Socket.Broadcast{event: "vault_populated"}
+
+    {:ok, _} = Notes.genesis_crdt_note(user, vault, Ecto.UUID.generate(), "Second Note.md")
+    refute_receive %Phoenix.Socket.Broadcast{event: "vault_populated"}, 200
+  end
+end

--- a/test/engram_web/channels/device_channel_test.exs
+++ b/test/engram_web/channels/device_channel_test.exs
@@ -84,9 +84,23 @@ defmodule EngramWeb.DeviceChannelTest do
 
       assert_push("authorized", payload)
       # The plugin reacts by doing exactly ONE token exchange. Credentials must
-      # never ride the channel — see moduledoc.
-      refute Map.has_key?(payload, :access_token)
-      refute Map.has_key?(payload, :refresh_token)
+      # never ride the channel — see moduledoc. Assert the whole payload, not
+      # two key names: the invariant is "carries nothing", and a named-key
+      # check silently passes for any THIRD field someone adds later.
+      assert payload == %{}
+    end
+
+    # Nothing legitimate is ever sent UP this channel, and it is
+    # unauthenticated. Without a fallback clause Phoenix raises
+    # UndefinedFunctionError, and each crash costs a Logger.error + a Sentry
+    # event that any client can trigger on repeat.
+    test "an unexpected inbound event is dropped, not crashed on" do
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _reply, socket} = subscribe_and_join(socket_conn(), "device:#{auth.device_code}")
+
+      ref = push(socket, "whatever", %{"junk" => true})
+      refute_reply(ref, :error, %{}, 100)
+      assert Process.alive?(socket.channel_pid)
     end
   end
 end

--- a/test/engram_web/channels/device_channel_test.exs
+++ b/test/engram_web/channels/device_channel_test.exs
@@ -1,0 +1,92 @@
+defmodule EngramWeb.DeviceChannelTest do
+  @moduledoc """
+  The pre-auth notification channel that replaces device-flow polling.
+
+  The plugin has no token until the flow completes — that is the whole point
+  of the flow — so this rides an unauthenticated socket and is keyed by the
+  `device_code`, which under RFC 8628 is already the bearer credential.
+
+  The channel carries a NOTIFICATION, never tokens: every subscriber to a
+  topic receives a broadcast simultaneously, whereas the token exchange is
+  single-use. Pushing credentials here would be strictly weaker than the
+  REST endpoint it replaces.
+  """
+  use EngramWeb.ChannelCase, async: false
+
+  import Ecto.Query
+
+  alias Engram.Auth.DeviceFlow
+  alias Engram.Repo
+
+  defp socket_conn do
+    {:ok, socket} = connect(EngramWeb.DeviceSocket, %{})
+    socket
+  end
+
+  describe "join" do
+    test "accepts a real pending device code" do
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "My Vault")
+
+      assert {:ok, _reply, _socket} =
+               subscribe_and_join(socket_conn(), "device:#{auth.device_code}")
+    end
+
+    test "rejects an unknown device code" do
+      assert {:error, %{reason: "unknown_or_expired"}} =
+               subscribe_and_join(socket_conn(), "device:not-a-real-code")
+    end
+
+    # Without this the topic is an unauthenticated, unbounded fan-out surface:
+    # anyone could hold subscriptions to arbitrary topic names forever.
+    test "rejects an expired device code" do
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "My Vault")
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(da in Engram.Auth.DeviceAuthorization, where: da.id == ^auth.id),
+        [set: [expires_at: past]],
+        skip_tenant_check: true
+      )
+
+      assert {:error, %{reason: "unknown_or_expired"}} =
+               subscribe_and_join(socket_conn(), "device:#{auth.device_code}")
+    end
+
+    test "rejects a code that has already been authorized" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "My Vault")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+
+      assert {:error, %{reason: "unknown_or_expired"}} =
+               subscribe_and_join(socket_conn(), "device:#{auth.device_code}")
+    end
+
+    # Topics that don't match `device:*` never reach join/3 — Phoenix rejects
+    # them at the socket router. The reachable degenerate case is a `device:`
+    # topic with an EMPTY code, which the byte_size guard drops so it can't
+    # fall through to a lookup for "".
+    test "rejects a device topic with an empty code" do
+      assert {:error, %{reason: "unknown_topic"}} = subscribe_and_join(socket_conn(), "device:")
+    end
+  end
+
+  describe "authorization notification" do
+    test "subscribers are told the code was authorized, and are NOT sent tokens" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "My Vault")
+
+      {:ok, _reply, _socket} = subscribe_and_join(socket_conn(), "device:#{auth.device_code}")
+
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+      DeviceFlow.notify_authorized(auth.device_code)
+
+      assert_push("authorized", payload)
+      # The plugin reacts by doing exactly ONE token exchange. Credentials must
+      # never ride the channel — see moduledoc.
+      refute Map.has_key?(payload, :access_token)
+      refute Map.has_key?(payload, :refresh_token)
+    end
+  end
+end

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -36,14 +36,14 @@ defmodule EngramWeb.DeviceAuthControllerTest do
         post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: "My Notes"})
 
       resp = json_response(conn, 200)
-      assert DeviceFlow.suggested_vault_name(resp["user_code"], reader.id) == "My Notes"
+      assert DeviceFlow.view_pending_code(resp["user_code"], reader.id) == {:ok, "My Notes"}
     end
 
     test "ignores blank vault_name", %{conn: conn} do
       reader = insert(:user)
       conn = post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: "   "})
       resp = json_response(conn, 200)
-      assert DeviceFlow.suggested_vault_name(resp["user_code"], reader.id) == nil
+      assert DeviceFlow.view_pending_code(resp["user_code"], reader.id) == {:ok, nil}
     end
 
     test "truncates long vault_name to 100 chars", %{conn: conn} do
@@ -51,7 +51,7 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       long = String.duplicate("a", 250)
       conn = post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: long})
       resp = json_response(conn, 200)
-      stored = DeviceFlow.suggested_vault_name(resp["user_code"], reader.id)
+      {:ok, stored} = DeviceFlow.view_pending_code(resp["user_code"], reader.id)
       assert String.length(stored) == 100
     end
   end

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -69,6 +69,23 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       assert %{"ok" => true} = json_response(conn, 200)
     end
 
+    # The plugin's live path hangs off this broadcast. Asserting it HERE and
+    # not just in the channel test is the point: the channel test calls
+    # notify_authorized/1 by hand, so deleting the call from the controller
+    # left the whole suite green while every plugin fell back to the 30s poll.
+    test "notifies the waiting device over its channel", %{authed_conn: conn, user: user} do
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      EngramWeb.Endpoint.subscribe("device:#{auth.device_code}")
+
+      post(conn, "/api/auth/device/authorize", %{user_code: auth.user_code, vault_id: vault.id})
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "authorized", payload: payload}
+      # The notification carries NOTHING: a broadcast fans out to every
+      # subscriber, while the token exchange is single-use.
+      assert payload == %{}
+    end
+
     test "creates new vault when vault_id is 'new'", %{authed_conn: conn} do
       {:ok, auth} = DeviceFlow.start_device_flow("client_1")
 

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -66,25 +66,50 @@ defmodule EngramWeb.VaultsControllerTest do
       conn = get(conn, "/api/vaults?user_code=#{auth.user_code}")
       body = json_response(conn, 200)
       assert body["suggested_vault_name"] == "My Obsidian Vault"
+      assert body["user_code_valid"] == true
     end
 
-    test "suggested_vault_name is nil when user_code has no hint stored", %{conn: conn} do
+    # A pending code with no hint is still a code the user can link with, so
+    # it must report valid. /link keys its reject on `user_code_valid`, not on
+    # a missing name — conflating the two is the bug this field exists to stop.
+    test "suggested_vault_name is nil but the code is still valid when no hint was stored",
+         %{conn: conn} do
       {:ok, auth} = DeviceFlow.start_device_flow("client_test")
       conn = get(conn, "/api/vaults?user_code=#{auth.user_code}")
       body = json_response(conn, 200)
       assert Map.has_key?(body, "suggested_vault_name")
       assert body["suggested_vault_name"] == nil
+      assert body["user_code_valid"] == true
     end
 
-    test "omits suggested_vault_name when no user_code passed", %{conn: conn} do
+    test "omits suggested_vault_name and user_code_valid when no user_code passed",
+         %{conn: conn} do
       conn = get(conn, "/api/vaults")
       body = json_response(conn, 200)
       refute Map.has_key?(body, "suggested_vault_name")
+      refute Map.has_key?(body, "user_code_valid")
     end
 
-    test "returns nil suggested_vault_name for unknown user_code", %{conn: conn} do
+    test "reports user_code_valid false for unknown user_code", %{conn: conn} do
       conn = get(conn, "/api/vaults?user_code=ZZZZ-ZZZZ")
       body = json_response(conn, 200)
+      assert body["suggested_vault_name"] == nil
+      assert body["user_code_valid"] == false
+    end
+
+    test "reports user_code_valid false for an expired code", %{conn: conn} do
+      {:ok, auth} = DeviceFlow.start_device_flow("client_test", "Stale Vault")
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Engram.Repo.update_all(
+        from(da in Engram.Auth.DeviceAuthorization, where: da.id == ^auth.id),
+        [set: [expires_at: past]],
+        skip_tenant_check: true
+      )
+
+      conn = get(conn, "/api/vaults?user_code=#{auth.user_code}")
+      body = json_response(conn, 200)
+      assert body["user_code_valid"] == false
       assert body["suggested_vault_name"] == nil
     end
 


### PR DESCRIPTION
## What

When the device code arrives via `?code=ENGR-7X4K` (RFC 8628 `verification_uri_complete`), `/link` now runs the verify step automatically and lands the user on the vault picker. The code is then scrubbed out of the address bar.

## Why

This page has always *read* `?code=`, but nothing ever set it — the backend returns a bare page URL and the plugin opened exactly that. The paired plugin PR starts sending it, so this finishes the job.

New flow: plugin shows code → browser opens → vault list already loaded → pick a vault → click Sync. Zero typing, one click.

## Only the verify is automatic

Authorizing still requires an explicit Sync click on a screen that names the vault. That consent beat is what makes carrying a code in a URL safe — device-code phishing is about getting someone to approve a stranger's code, and the defense is the consent screen, not URL secrecy.

The code is scrubbed from history because it's a single-use credential that shouldn't survive a bookmark or a copy-pasted URL.

## Note on the diff size

`handleVerifyCode` became a `useCallback` so the effect can depend on it without re-firing every render (biome's `useExhaustiveDependencies` rejects a dep recreated each render). Hooks can't sit after a conditional return, so the signed-out early return moved below it. No behavior change from that move.

## Testing

4 new tests: auto-verifies a query-string code, does **not** authorize on its own, scrubs the code from the URL, and stays put when no code was supplied.

- `vitest run` — 1562 pass across 182 files
- `bun run build` (tsc + vite) clean, biome clean

## Paired with

engram-app/Engram-obsidian#428 (the plugin side). Either can merge first — each is inert without the other.