### PR TITLE
feat(crdt): bound room lifetime by draining idle rooms, not killing them

### DIFF
--- a/ci/compose.yml
+++ b/ci/compose.yml
@@ -163,6 +163,19 @@ services:
       # Same CI=true gating (runtime.exs) keeps prod limits un-weakenable.
       CRDT_MSG_RATE_LIMIT_OVERRIDE: "100000"
       CRDT_HS_RATE_LIMIT_OVERRIDE: "100000"
+      # Room drain (#1152) turned ON for e2e only, under the same CI=true gate.
+      # In production NOTHING sets idle_exit_ms, so the drain never fires and is
+      # therefore never exercised against a real client — every unit and channel
+      # test stands a test process in for the plugin. Enabling it here means the
+      # whole Obsidian suite runs with rooms being released out from under the
+      # client mid-session, which is the only way to prove the property the
+      # design rests on: the client re-spins on its next frame and loses nothing.
+      #
+      # 5s is short enough that rooms genuinely drain between test steps and long
+      # enough that it is not pathological. If this destabilises the suite, that
+      # is a REAL finding about the drain, not CI noise — raise it deliberately
+      # rather than deleting the line.
+      CRDT_IDLE_EXIT_MS: ${CRDT_IDLE_EXIT_MS:-5000}
       # Free-tier launch test_72_cancel_to_free_overlimit signs a synthetic
       # subscription.canceled webhook with this fixed secret so the e2e
       # exercises the real verify_signature → upsert_from_paddle_event path

--- a/ci/compose.yml
+++ b/ci/compose.yml
@@ -176,6 +176,17 @@ services:
       # is a REAL finding about the drain, not CI noise — raise it deliberately
       # rather than deleting the line.
       CRDT_IDLE_EXIT_MS: ${CRDT_IDLE_EXIT_MS:-5000}
+      # LRU backstop, also e2e-only. Idle-exit alone never evicts a room that
+      # stays busy, so without these the LRU only ever ran against spawn stubs
+      # in unit tests — it had never touched a real SharedDoc.
+      #
+      # A tiny cap plus a fast sweep is the point: e2e vaults hold few notes, so
+      # a production-shaped cap would never be reached and this would cover
+      # nothing. The sweep interval matters as much as the cap — it defaults to
+      # 30s, and most e2e tests finish inside that, so a low cap alone would arm
+      # the LRU and never fire it.
+      CRDT_MAX_RESIDENT_ROOMS: ${CRDT_MAX_RESIDENT_ROOMS:-3}
+      CRDT_LRU_SWEEP_MS: ${CRDT_LRU_SWEEP_MS:-3000}
       # Free-tier launch test_72_cancel_to_free_overlimit signs a synthetic
       # subscription.canceled webhook with this fixed secret so the e2e
       # exercises the real verify_signature → upsert_from_paddle_event path

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -322,6 +322,19 @@ case Engram.RuntimeConfig.ci_gated_int_override(&System.get_env/1, "CRDT_MAX_RES
     :ok
 end
 
+case Engram.RuntimeConfig.ci_gated_int_override(&System.get_env/1, "CRDT_LRU_SWEEP_MS") do
+  {:ok, ms} ->
+    config :engram, Engram.Notes.CrdtRoomLru, sweep_interval_ms: ms
+
+  {:ignored, raw} ->
+    Logger.warning(
+      "CRDT_LRU_SWEEP_MS=#{raw} ignored: drain levers are only honored when CI=true."
+    )
+
+  :none ->
+    :ok
+end
+
 # Clerk auth (only required when AUTH_PROVIDER=clerk)
 # Note: use local variable, not Application.get_env — runtime.exs config
 # is accumulated and not yet applied, so get_env reads stale config.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -293,6 +293,35 @@ if rate_limit_overrides != [] do
   config :engram, rate_limit_overrides
 end
 
+# CRDT room-drain levers (#1152) — CI/E2E only, same CI=true gate. Written out
+# per-override rather than folded into a loop because each targets a NESTED
+# config key (module + key), not a flat app-env key like the block above.
+case Engram.RuntimeConfig.ci_gated_int_override(&System.get_env/1, "CRDT_IDLE_EXIT_MS") do
+  {:ok, ms} ->
+    config :engram, Engram.Notes.CrdtCheckpointTimer, idle_exit_ms: ms
+
+  {:ignored, raw} ->
+    Logger.warning(
+      "CRDT_IDLE_EXIT_MS=#{raw} ignored: drain levers are only honored when CI=true."
+    )
+
+  :none ->
+    :ok
+end
+
+case Engram.RuntimeConfig.ci_gated_int_override(&System.get_env/1, "CRDT_MAX_RESIDENT_ROOMS") do
+  {:ok, n} ->
+    config :engram, Engram.Notes.CrdtRoomLru, max_resident: n
+
+  {:ignored, raw} ->
+    Logger.warning(
+      "CRDT_MAX_RESIDENT_ROOMS=#{raw} ignored: drain levers are only honored when CI=true."
+    )
+
+  :none ->
+    :ok
+end
+
 # Clerk auth (only required when AUTH_PROVIDER=clerk)
 # Note: use local variable, not Application.get_env — runtime.exs config
 # is accumulated and not yet applied, so get_env reads stale config.

--- a/docs/context/crdt-room-lifetime-and-drain.md
+++ b/docs/context/crdt-room-lifetime-and-drain.md
@@ -164,6 +164,15 @@ drains repeatedly.
 - **PubSub, not a node-local registry.** Rooms are `:global`, so a room on this node may be
   observed by channels on any other node. `SharedDoc` also keeps `observer_process` private, so a
   room cannot message its own observers directly.
+- **The drain topic is PER VAULT, not per note — this is a memory decision, not a style one.**
+  Per-note meant one subscription per room OPEN, and the enroll-everything client opens a room per
+  note. Measured 2026-08-14: **309 bytes per subscription**, so ~725 KB per socket on a 2400-note
+  vault and **~707 MB per 1000 such clients** — against the same 1024 MB task whose memory this
+  feature exists to protect. Self-defeating at the scale #1146 targets, and invisible to every
+  correctness check: CI was fully green with the per-note version.
+  Per-vault needs no extra routing, because the drain carries the room pid and
+  `handle_info({:crdt_room_drain, room}, …)` already no-ops on a pid the channel does not hold.
+  `crdt_channel_drain_test.exs` pins it by COUNTING subscriptions while opening many rooms.
 - **`unobserve` is a `GenServer.call` with no timeout knob.** A room that already exited would
   **exit the channel**; one that is alive but wedged would **stall it for y_ex's 5 s default**.
   `release_room/1` guards cheapest-first: dead → skip; doesn't answer a

--- a/docs/context/crdt-room-lifetime-and-drain.md
+++ b/docs/context/crdt-room-lifetime-and-drain.md
@@ -121,6 +121,31 @@ CONCURRENT rooms, not cumulative ones, while drain-churn is the intended steady 
 `remember_drained/3`, which CLEARS on overflow: the only degradation is lost suppression (a re-spin
 announces, i.e. pre-drain behaviour), never incorrectness, so it needs no ordering bookkeeping.
 
+## The LRU backstop
+
+Idle-exit bounds rooms that go **quiet**. It does nothing for a continuously-active room, so a
+pathological mix of busy vaults still pins memory. `Engram.Notes.CrdtRoomLru` is the pressure valve:
+a named public ETS table (`note_id -> {pid, last_activity}`, mirroring `FanoutPacer`) plus a
+periodic sweep that prunes dead entries and then drains down to `max_resident`.
+
+Three properties worth keeping:
+
+- **It drains, it never kills.** Eviction broadcasts on the room's drain topic exactly as the idle
+  timer does. Killing would silently eat the next `sync_update`, which is the whole reason the drain
+  exists.
+- **It deliberately bypasses `idle?/2`.** Evicting rooms that are *not* idle is its entire job —
+  which is precisely why it must go through the safe release path instead of inventing a second one.
+- **Prune before selecting.** A room that exited between sweeps still holds an entry; counting
+  corpses toward residency evicts healthy rooms to free memory nothing is using.
+
+Only drain-ENABLED rooms are tracked (`touch/2` is called from the timer only when `idle_exit_ms`
+is set), so a note room can never be evicted and the feature stays inert until #1150 opts in. Every
+tracked pid is local — a room's timer runs on the room's node — so `Process.alive?/1` is safe here,
+unlike in the channel.
+
+`max_resident` defaults to 64 and wants tuning against real index-doc sizes once #1150 exists;
+#1146's arithmetic says ~128 resident rooms would consume an entire task.
+
 ## Observability
 
 `[:engram, :crdt, :room_drain]`, `%{count: 1}`, `%{phase: :requested | :reasked | :released |

--- a/docs/context/crdt-room-lifetime-and-drain.md
+++ b/docs/context/crdt-room-lifetime-and-drain.md
@@ -1,0 +1,224 @@
+# CRDT room lifetime — why `auto_exit` is not enough, and why an idle room is DRAINED, not stopped
+
+_Last verified: 2026-08-14_
+
+**TL;DR:** A `SharedDoc` room only exits when its **last observer leaves** (`auto_exit`). That
+bounds a *note* room, which is observed only while the note is open. It does **not** bound a
+per-vault **index** room (#1150), which is observed for as long as any client is connected — so
+its lifetime is session-length and residency scales with concurrent connections instead of
+mutation rate.
+
+The obvious fix — a timer that stops the idle room — **silently loses edits**, because a client
+edit is a `GenServer.cast`. So an idle room instead **broadcasts a drain**, its observers let go,
+and the `auto_exit` that already exists does the exiting.
+
+Shipped: PR TBD (`feat/crdt-room-idle-exit`), opt-in via `idle_exit_ms`, default `nil`.
+Refs: engram-app/Engram#1152, #1150, #1149, engram-app/engram-workspace#167.
+
+---
+
+## The trap: an edit is a cast, so a dead room eats it silently
+
+`y_ex` dispatches inbound frames by type (`deps/y_ex/lib/server/doc_server_worker.ex:16-31`):
+
+| frame | dispatch | what happens if the room is already dead |
+|---|---|---|
+| `MSG_QUERY_AWARENESS` `<<3>>` | `GenServer.call` | caller **exits** |
+| `sync_step1` `<<0,0,…>>` | `GenServer.call` | caller **exits** (kills the channel) |
+| **`sync_update` `<<0,2,…>>`** | **`GenServer.cast`** | **returns `:ok`, frame is dropped** |
+
+A client edit is a `sync_update`. `crdt_channel.ex` already carries the warning at its room
+monitor:
+
+> Watch the room: if it dies (crash, node loss), evict it from the cache so the next crdt_msg
+> re-creates it. Without this, send_yjs_message casts to a dead pid return `:ok` and every
+> subsequent edit is silently dropped.
+
+Today that only happens on a **crash**. A naive idle-exit would make it happen **on a timer, on
+purpose** — and the eviction is driven by an asynchronous `:DOWN`, so there is a real window where
+the channel's cached pid points at a corpse. That is silent user data loss, inside the very epic
+(#167) whose purpose is eliminating silent drift.
+
+**So #1152's literal wording — "a timer that exits with observers still attached" — is wrong, and
+should not be implemented as written.**
+
+## The inversion: make observers let go, and `auto_exit` does the rest
+
+`SharedDoc.handle_call({:unobserve, …})` returns `{:reply, :ok, state, 0}`, and that `:timeout`
+runs the same `observer_process === %{}` check as `:DOWN`
+(`deps/y_ex/lib/protocols/shared_doc.ex:190-201`). So the last unobserve stops the room by itself —
+no `GenServer.stop`, no fork of `y_ex`.
+
+```
+CrdtCheckpointTimer idle (no :activity for idle_exit_ms)
+  └─ PubSub.broadcast(CrdtRegistry.drain_topic(note_id), {:crdt_room_drain, room_pid})
+       └─ each CrdtChannel: evict assigns.rooms/room_doc  →  SharedDoc.unobserve(room)
+            └─ LAST unobserve → auto_exit → terminate/2
+                 └─ CrdtPersistence.unbind/3 → checkpoint (CheckpointGate, Oban overflow)
+```
+
+**Why this closes the race — message ordering, not luck.** The channel evicts its cached pid in
+the *same* `handle_info` that unobserves, so relative to the drain message:
+
+- a frame **ahead** of the drain in the channel's mailbox reached the room while it was still live
+- a frame **behind** it finds no cached pid and re-resolves through `ensure_room` → fresh room
+
+There is no interleaving where a frame casts at a dead pid. The one remaining race — a new
+`ensure_started` colliding with the dying room's `:global` deregistration — is pre-existing and
+already handled by `observe_with_retry` (`crdt_registry.ex:119-136`).
+
+## Things that already existed (do not rebuild them)
+
+Roughly half of #1152 turned out to be already-shipped machinery:
+
+- **checkpoint-then-exit** — `terminate/2` calls `unbind/3`, which checkpoints. Nothing extra.
+- **pool safety under a fleet-wide drain** — `CheckpointGate` caps inline checkpoints and overflows
+  to the `crdt_checkpoint` Oban queue (the 2026-07-09 pool-exhaustion fix).
+- **client re-spin** — `ensure_room` lazily recreates on the next frame. Built for crash/node-loss.
+- **residency enumeration** (for the LRU backstop) — `DynamicSupervisor.which_children(CrdtDocSupervisor)`,
+  already used by `DataCase.stop_crdt_rooms/0`.
+
+## The announce amplification (the non-obvious one)
+
+`start_and_observe_room` ends with `broadcast_from!(socket, "crdt_doc_ready", …)`, and its own
+comment says recipients answer with a syncStep1. That is cheap today because a **re-spin only
+happens on a crash or node loss**. The drain makes re-spin **routine**, so without care every
+drain→edit cycle fans a handshake out of every other device on the vault — against `@hs_limit`
+(`crdt_channel.ex:61`) and the plugin's 240/10s `crdt_msg` budget (Engram-obsidian#159). Handshake
+starvation is the documented trigger for the wrong-mint cross-file overwrite class, so this is not
+merely noisy.
+
+Fix: the channel records doc_ids it released to a drain (`assigns.drained`) and skips the announce
+on exactly that re-spin, consuming the mark so a *later* drain is suppressed independently. Scoped
+to the drain path on purpose — a crash re-spin still announces, because there the peer state really
+is unknown.
+
+**There is a second announce source that masks this in tests.** `CrdtCheckpoint` announces
+`crdt_doc_ready` on every content-*changing* checkpoint (`crdt_checkpoint.ex:213`, gated on
+`prev_hash != new_hash`). So:
+
+- draining a **clean** room (the ordinary index-room shape) announces nothing — compaction-only
+  checkpoints hash-match and stay quiet;
+- draining a **dirty** room announces once from the checkpoint, which is correct and pre-existing.
+
+Consequence for testing: **re-spin with a syncStep1, never with an edit.** An edit produces its own
+checkpoint announce, so the two sources become indistinguishable and a suppression test passes or
+fails for the wrong reason. This cost a debugging cycle.
+
+## Two things `auto_exit` gave us for free that a timer does not
+
+**Spread.** `auto_exit` fires on user behaviour, so exits are naturally desynchronised. Idle timers
+are armed when the room *starts*, so every room started in the same burst (a deploy, a reconnect
+storm) drains in the same instant — a synchronized checkpoint storm, i.e. the 2026-07-09
+pool-exhaustion shape. `CheckpointGate` + Oban would absorb it, but designing the spike in and
+leaning on the shock absorber is backwards. Hence `jittered_drain_delay/1`, additive only:
+`idle_exit_ms` is a floor (a minimum quiet period before a room may be taken away), so jitter must
+never shorten it.
+
+**A bound.** `auto_exit` needs no bookkeeping. The drain needs the channel to remember which
+doc_ids it released (`assigns.drained`) so the re-spin stays quiet — and `@default_max_rooms` bounds
+CONCURRENT rooms, not cumulative ones, while drain-churn is the intended steady state. Capped via
+`remember_drained/3`, which CLEARS on overflow: the only degradation is lost suppression (a re-spin
+announces, i.e. pre-drain behaviour), never incorrectness, so it needs no ordering bookkeeping.
+
+## Observability
+
+`[:engram, :crdt, :room_drain]`, `%{count: 1}`, `%{phase: :requested | :reasked | :released |
+:skipped}` → `engram_prom_ex_crdt_room_drain_total` (`Engram.PromEx.Crdt`).
+
+`released` should track `requested`. `requested` climbing while `released` stays flat means rooms
+are being asked to drain and not going away — the unbounded-residency failure the drain exists to
+prevent — and a rising `reasked` localises it to observers that cannot act. This is the only way to
+answer #1152's "resident room count bounded under a soak" in production rather than in a test.
+
+Cardinality contract: the four phase atoms and nothing else. Never note/vault/user ids — a room
+drains repeatedly.
+
+## Gotchas
+
+- **PubSub, not a node-local registry.** Rooms are `:global`, so a room on this node may be
+  observed by channels on any other node. `SharedDoc` also keeps `observer_process` private, so a
+  room cannot message its own observers directly.
+- **`unobserve` is a `GenServer.call` with no timeout knob.** A room that already exited would
+  **exit the channel**; one that is alive but wedged would **stall it for y_ex's 5 s default**.
+  `release_room/1` guards cheapest-first: dead → skip; doesn't answer a
+  `update_doc/3` no-op probe within 1 s → skip; else unobserve. `catch :exit` backstops each gap.
+
+  Skipping a wedged room loses nothing: `auto_exit` runs off the room's own observer bookkeeping,
+  so a room too wedged to answer was never going to exit on that unobserve anyway — the timer's
+  backed-off re-ask collects it when it recovers.
+
+  The probe is `update_doc/3` specifically because it is **public API that takes a timeout**, where
+  `unobserve/1` does not. Do NOT "fix" this by hand-rolling
+  `GenServer.call(room, {:unobserve, self()}, …)`: that hard-codes y_ex's private message shape and
+  would fail silently on a dep bump. Test it with plain non-replying processes for the same reason —
+  a stub that answers `{:update_doc, …}`/`{:unobserve, …}` would bake those shapes into the suite.
+- **Unsubscribe on the `:DOWN` path too.** `Phoenix.PubSub` does not dedupe subscriptions, so a
+  room that dies by crash (evicted via `:DOWN`, never drained) leaves the subscription behind and
+  the next `start_and_observe_room` stacks a second one — every later drain then arrives twice.
+- **`Phoenix.PubSub.subscribe/2` returns `:ok | {:error, …}`** and dialyzer flags the unmatched
+  return. Do not `_ =` it: a failed subscribe means that room can never be drained, i.e. exactly
+  the unbounded-residency failure the drain exists to prevent. Log it.
+- **The drain re-arms, with backoff.** An observer that ignores a drain (stale client, wedged
+  channel) is asked again rather than pinning the room forever — but each unanswered ask lengthens
+  the next (`drain_delay/1`, capped at 8x), so an observer that can *never* act cannot hold a fixed
+  broadcast rate for the life of the room. Any `:activity` resets the count.
+- **Gate the broadcast on observed idleness, not on the timer.** `Process.cancel_timer/1` cannot
+  un-send a message already in the mailbox, so an `:idle_drain` queued just before an `:activity`
+  is still handled after it. Re-arming alone does NOT give you "activity postpones the drain" —
+  `idle?/2` re-checks the real clock. Without it, a room being actively typed into gets drained
+  (lossless, since unbind checkpoints, but pure churn).
+- **`idle_exit_ms: 0` is not falsy in Elixir.** It survives an `||` config fallback and would
+  `send_after(…, 0)` in a tight broadcast loop. `arm_idle/1` is guarded on a positive integer so
+  `nil`, `0`, and garbage all no-op.
+- **Arm at `init`, not only on `:activity`.** The common index-room case is spin → handshake → go
+  quiet with no writes at all; a drain armed only by activity would never fire for it.
+
+## Testing notes
+
+Both mailbox orderings are pinned in `test/engram_web/channels/crdt_channel_drain_test.exs`. Send
+**both** the `push/3` and the drain **from the test process** — Erlang guarantees FIFO only per
+sender/receiver pair, so driving the drain through PubSub instead makes the interleaving a genuine
+race and the test a flake.
+
+Assert on **materialization**, not on internal state: if a frame is cast into a corpse, no room
+ever applies it and nothing reaches the row, whichever checkpoint path runs.
+
+In `test/engram/notes/crdt_room_idle_exit_test.exs`, park `settle_ms`/`ceiling_ms`/`eager_ms` at
+600_000 first. Otherwise the eager 250 ms flush materializes the content anyway and the
+"checkpoints on exit" assertion passes vacuously.
+
+## Constraints this puts on #1150 (read before enabling the drain)
+
+- **The drain only bounds rooms that HAVE observers.** A room with zero observers never
+  `auto_exit`s (no `:DOWN` fires, and `init` schedules no `:timeout`) and a drain does nothing for
+  it either — there is nobody to ask. `crdt_transport.ex:158` already names the class:
+  *"ensure_started has no observer and never reaps, leaking an immortal [room]."* So the index room
+  must always go through `ensure_observed`, never `ensure_started` alone, or the memory work is
+  defeated by construction.
+- **`idle_exit_ms` is a memory-vs-latency knob, not a free win.** A re-spin runs `bind` → tail-log
+  replay, and #1149 puts the index doc at ~2 MB encoded per 10k notes. Drain more eagerly than the
+  typical inter-mutation gap and you pay that rehydration on every burst.
+- **The client half is unverified here.** #1146 requires the client to reconcile against the CRDT,
+  not a projection. Everything above assumes the client re-handshakes on the next mutation rather
+  than falling back to the manifest; proving that is Engram-obsidian#362/#363.
+
+## Cross-node coverage is a hole (not specific to this work)
+
+`Process.alive?/1` is local-only and raises `ArgumentError` — `:error` class, so a `catch :exit`
+does NOT contain it — on a remote pid. Rooms are `:global`, so channels routinely hold remote room
+pids. An unguarded `alive?` here crashed the channel on every drain of a remote room.
+
+It was not caught by the suite because **cluster tests never run**: `CLUSTER_TESTS=1` appears
+nowhere in CI or the Makefile, and only `dek_cache_test.exs` carries `@tag :cluster`. The whole
+cross-node surface — the `:distributed_ets` rate limiter, PubSub cache eviction, and this drain —
+is CI-invisible. Assume any single-node-tested primitive is unproven across nodes until someone
+wires that env var into a job.
+
+## What this does NOT prove
+
+The mechanism is proven (exit with observers attached, checkpoint on exit, correct re-spin under
+both orderings, multi-observer release). The **load model is not**: #1149's 7.91 MB-per-10k-note
+figure belongs to an index doc that does not exist until #1150, so nothing here validates the
+absolute memory bound — only that residency is bounded at all. The resident-room LRU backstop
+(#1152's third bullet) is also still outstanding.

--- a/docs/context/crdt-room-lifetime-and-drain.md
+++ b/docs/context/crdt-room-lifetime-and-drain.md
@@ -212,8 +212,22 @@ pids. An unguarded `alive?` here crashed the channel on every drain of a remote 
 It was not caught by the suite because **cluster tests never run**: `CLUSTER_TESTS=1` appears
 nowhere in CI or the Makefile, and only `dek_cache_test.exs` carries `@tag :cluster`. The whole
 cross-node surface — the `:distributed_ets` rate limiter, PubSub cache eviction, and this drain —
-is CI-invisible. Assume any single-node-tested primitive is unproven across nodes until someone
-wires that env var into a job.
+is CI-invisible. Assume any single-node-tested primitive is unproven across nodes.
+
+**Do NOT "fix" this by adding `CLUSTER_TESTS=1` to the existing `unit-tests` job.** Measured
+2026-08-14 on this branch: without it, 4368 tests / 0 failures; with it, 4371 / **1 failure in an
+unrelated test** (`FanoutPacerTest` "two topics drain independently"). `ClusterCase.start_peer!`
+starts a second `Phoenix.PubSub` under the SAME `Engram.PubSub` name on the peer and connects the
+nodes, so the pg group spans both and every later broadcast fans out cross-node — which a 200 ms
+pacing assertion does not survive. Distribution also stays on for the remainder of the run once
+started, so the contamination is not confined to the cluster tests themselves.
+
+The workable shape is a SEPARATE job running `CLUSTER_TESTS=1 mix test --only cluster` in its own
+VM, which cannot contaminate the main suite by construction. Verified green 5/5 in isolation.
+
+Because of that hole, the remote-pid guard is ALSO covered by a single-node test that injects the
+"self" node (`locally_dead?/2`) rather than faking a remote pid — so the guard is gated by the
+default suite even though the `:cluster` test is not.
 
 ## What this does NOT prove
 

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -57,6 +57,9 @@ defmodule Engram.Application do
         # Bounds concurrent inline unbind checkpoints (self-healing via monitors);
         # must start before any CRDT room can terminate and call unbind/3.
         Engram.Notes.CheckpointGate,
+        # Owns the resident-room ETS table (#1152). Must start before any CRDT
+        # room, since a drain-enabled room's timer touches it on init.
+        Engram.Notes.CrdtRoomLru,
         Engram.Notes.FanoutPacer,
         # One DynamicSupervisor owns all live CRDT doc rooms. Rooms are
         # cluster-wide singletons via :global; this supervisor is the local

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -65,7 +65,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   """
   use GenServer
 
-  alias Engram.Notes.{CrdtCheckpoint, CrdtRegistry}
+  alias Engram.Notes.{CrdtCheckpoint, CrdtRegistry, CrdtRoomLru}
 
   require Logger
 
@@ -157,7 +157,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     # Armed at init, not only on activity: a room that spins for a handshake and
     # is never written to (the common index-room case — connect, sync, go quiet)
     # must still drain.
-    {:ok, arm_idle(state)}
+    {:ok, touch_lru(arm_idle(state))}
   end
 
   @impl true
@@ -170,13 +170,15 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     timer = Process.send_after(self(), :tick, delay)
 
     {:noreply,
-     arm_idle(%{
-       state
-       | first_dirty_at: first_dirty_at,
-         last_activity_at: now,
-         settle_timer: timer,
-         drain_attempts: 0
-     })}
+     touch_lru(
+       arm_idle(%{
+         state
+         | first_dirty_at: first_dirty_at,
+           last_activity_at: now,
+           settle_timer: timer,
+           drain_attempts: 0
+       })
+     )}
   end
 
   # The room has been quiet for `idle_exit_ms`. Ask its observers to let go; the
@@ -241,7 +243,17 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   # for both normal and abnormal room exits without leaving an orphaned timer.
   @impl true
   def handle_info({:EXIT, _room_pid, _reason}, state) do
+    if state.idle_exit_ms, do: CrdtRoomLru.forget(state.note_id)
     {:stop, :normal, state}
+  end
+
+  # Only drain-ENABLED rooms are tracked for eviction, so a note room can never
+  # be evicted and this whole feature stays inert until #1150 opts in.
+  defp touch_lru(%{idle_exit_ms: nil} = state), do: state
+
+  defp touch_lru(state) do
+    CrdtRoomLru.touch(state.note_id, state.room_pid)
+    state
   end
 
   @doc """

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -308,7 +308,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   # makes the contract hold for the public function too.
   @spec drain_delay(map()) :: pos_integer()
   def drain_delay(%{idle_exit_ms: ms, drain_attempts: attempts})
-      when is_integer(ms) and is_integer(attempts) do
+      when is_integer(ms) and ms > 0 and is_integer(attempts) do
     ms * min(attempts + 1, @max_drain_backoff)
   end
 

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -33,16 +33,53 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   stays settle-debounced and ceiling-capped, so there is still exactly ONE
   checkpoint per dirty streak (no per-keystroke churn, no double flush, no
   version/seq thrash). The cheap O(append) `update_v1` hot path is untouched.
+
+  ## Idle drain (`idle_exit_ms`, #1152)
+
+  OPT-IN and `nil` by default, so note rooms behave exactly as they always have.
+
+  `auto_exit` ends a room when its LAST OBSERVER leaves. That bounds a note
+  room, which is observed only while the note is open — but a per-vault index
+  room (#1150) is observed for as long as any client is connected, making its
+  lifetime session-length and its residency a function of concurrent
+  connections rather than mutation rate. #1149 measured 7.91 MB resident per
+  10k-note vault, which misses the target by two orders of magnitude.
+
+  When `idle_exit_ms` is set, a room that has seen no `:activity` for that long
+  broadcasts `{:crdt_room_drain, room_pid}` on `CrdtRegistry.drain_topic/1`.
+  Observers evict their cached pid and unobserve; the last unobserve trips the
+  EXISTING `auto_exit`, whose `terminate/2` runs `CrdtPersistence.unbind/3` and
+  checkpoints.
+
+  It does NOT stop the room itself, and that distinction is the whole design.
+  A client edit is a `sync_update` frame, which y_ex dispatches as a
+  `GenServer.cast` (`deps/y_ex/lib/server/doc_server_worker.ex:26`) — a cast to
+  a dead pid returns `:ok` and drops the edit. Stopping a room out from under an
+  attached observer would therefore turn a timer into silent data loss.
+  Draining makes observers let go FIRST, so a frame either lands on the live
+  room or re-resolves a fresh one, and the exit falls out of machinery that
+  already exists.
+
+  The broadcast re-arms, so an observer that ignores a drain (a stale client, a
+  wedged channel) is asked again rather than pinning the room forever.
   """
   use GenServer
 
-  alias Engram.Notes.CrdtCheckpoint
+  alias Engram.Notes.{CrdtCheckpoint, CrdtRegistry}
 
   require Logger
 
   @default_settle_ms 5_000
   @default_ceiling_ms 60_000
   @default_eager_ms 250
+
+  # Cap on the idle-drain re-ask multiplier (see drain_delay/1).
+  @max_drain_backoff 8
+
+  # Percent of the drain delay added as random jitter (see jittered_drain_delay/1).
+  @drain_jitter_pct 25
+
+  @drain_event [:engram, :crdt, :room_drain]
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -82,6 +119,8 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     settle_ms = Keyword.get(cfg, :settle_ms, @default_settle_ms)
     ceiling_ms = Keyword.get(cfg, :ceiling_ms, @default_ceiling_ms)
     eager_ms = Keyword.get(cfg, :eager_ms, @default_eager_ms)
+    # Per-room opt wins; config is the fleet-wide fallback. nil = drain disabled.
+    idle_exit_ms = Keyword.get(opts, :idle_exit_ms) || Keyword.get(cfg, :idle_exit_ms)
 
     # Trap exits so we receive {:EXIT, room_pid, reason} as a handle_info
     # message instead of dying silently. This lets us flush or log before
@@ -105,10 +144,20 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
       # eager-eligible. NOT reset on flush, so typing that resumes right after a
       # ceiling/settle flush is correctly seen as still-active (not eager).
       last_activity_at: nil,
-      settle_timer: nil
+      settle_timer: nil,
+      # nil = drain disabled (every note room today).
+      idle_exit_ms: idle_exit_ms,
+      idle_timer: nil,
+      # Consecutive drains broadcast with nobody acting on them. Backs the
+      # re-ask off so an unreachable observer (netsplit, wedged channel) cannot
+      # broadcast at a fixed rate forever. Reset by any activity.
+      drain_attempts: 0
     }
 
-    {:ok, state}
+    # Armed at init, not only on activity: a room that spins for a handshake and
+    # is never written to (the common index-room case — connect, sync, go quiet)
+    # must still drain.
+    {:ok, arm_idle(state)}
   end
 
   @impl true
@@ -121,7 +170,61 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     timer = Process.send_after(self(), :tick, delay)
 
     {:noreply,
-     %{state | first_dirty_at: first_dirty_at, last_activity_at: now, settle_timer: timer}}
+     arm_idle(%{
+       state
+       | first_dirty_at: first_dirty_at,
+         last_activity_at: now,
+         settle_timer: timer,
+         drain_attempts: 0
+     })}
+  end
+
+  # The room has been quiet for `idle_exit_ms`. Ask its observers to let go; the
+  # last unobserve trips auto_exit, which checkpoints via unbind on terminate.
+  # We deliberately do NOT stop the room here — see the moduledoc.
+  @impl true
+  def handle_info(:idle_drain, state) do
+    # Re-check idleness against OBSERVED activity rather than trusting the timer
+    # bookkeeping. `Process.cancel_timer/1` cannot un-send a message that already
+    # reached the mailbox, so an `:idle_drain` can be queued just before an
+    # `:activity` and still be processed after it — draining a room the user is
+    # actively editing. Lossless (unbind checkpoints) but it churns the room and
+    # contradicts the whole point of re-arming, so gate on the real clock.
+    state =
+      if idle?(state, monotonic_ms()) do
+        case Phoenix.PubSub.broadcast(
+               Engram.PubSub,
+               CrdtRegistry.drain_topic(state.note_id),
+               {:crdt_room_drain, state.room_pid}
+             ) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            # Transient by nature — the re-arm below asks again, and the attempt
+            # still counts so a persistently broken broadcast backs off rather
+            # than hammering. Logged because a room that can never ask its
+            # observers to let go is exactly the unbounded-residency case the
+            # drain exists to prevent.
+            Logger.warning(
+              "crdt drain broadcast failed: #{inspect(reason)}",
+              Engram.Logger.Metadata.with_category(:warning, :sync, note_id: state.note_id)
+            )
+        end
+
+        :telemetry.execute(@drain_event, %{count: 1}, %{
+          phase: if(state.drain_attempts == 0, do: :requested, else: :reasked)
+        })
+
+        %{state | drain_attempts: state.drain_attempts + 1}
+      else
+        state
+      end
+
+    # Re-arm either way: an observer that ignored the drain gets asked again
+    # instead of pinning the room forever — but at a backed-off interval, so an
+    # unreachable observer cannot hold a fixed broadcast rate indefinitely.
+    {:noreply, arm_idle(%{state | idle_timer: nil})}
   end
 
   @impl true
@@ -169,9 +272,83 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     {max(0, delay), first_dirty_at}
   end
 
+  @doc """
+  Whether the room has genuinely been quiet for its full `idle_exit_ms` as of
+  monotonic `now` — the gate on the drain broadcast.
+
+  Checked against OBSERVED activity rather than timer bookkeeping because
+  `Process.cancel_timer/1` cannot un-send a message already in the mailbox: an
+  `:idle_drain` can be queued just before an `:activity` and still be handled
+  after it. Without this gate that races into draining a room the user is
+  actively editing — lossless (unbind checkpoints) but pure churn, and the exact
+  thing re-arming exists to prevent.
+
+  A room that has never seen a write is idle by definition. That is the ordinary
+  index-room shape: spin, handshake, go quiet, never written to.
+  """
+  @spec idle?(map(), integer()) :: boolean()
+  def idle?(%{last_activity_at: nil}, _now), do: true
+
+  def idle?(state, now), do: now - state.last_activity_at >= state.idle_exit_ms
+
+  @doc """
+  How long to wait before the next `:idle_drain`, given how many consecutive
+  drains have already gone unanswered.
+
+  The first ask is at the plain `idle_exit_ms`. Each unanswered one lengthens the
+  next by a further multiple, capped at #{@max_drain_backoff}x, so an observer
+  that can never act (netsplit, wedged channel) degrades to an occasional re-ask
+  rather than broadcasting at a fixed rate for the life of the room. Any
+  `:activity` resets the count, so a room that goes quiet again drains promptly.
+  """
+  # Guarded on integers rather than widening the spec to number(): the result
+  # feeds Process.send_after/3, which REQUIRES a non-negative integer, so a
+  # float idle_exit_ms is a runtime crash rather than a typing inconvenience.
+  # arm_idle/1 already enforces this at the only production call site; the guard
+  # makes the contract hold for the public function too.
+  @spec drain_delay(map()) :: pos_integer()
+  def drain_delay(%{idle_exit_ms: ms, drain_attempts: attempts})
+      when is_integer(ms) and is_integer(attempts) do
+    ms * min(attempts + 1, @max_drain_backoff)
+  end
+
+  @doc """
+  `drain_delay/1` plus up to #{@drain_jitter_pct}% of random spread.
+
+  Without this, drains synchronize. `auto_exit` fires on user behaviour, so
+  exits spread themselves out naturally — but idle timers are armed when the
+  room STARTS, so every room started in the same burst (a deploy, a reconnect
+  storm) would drain in the same instant and fire a synchronized checkpoint
+  storm. That is the 2026-07-09 pool-exhaustion shape; `CheckpointGate` +
+  the Oban overflow would absorb it, but designing the spike in and leaning on
+  the shock absorber is backwards.
+
+  Jitter is ADDITIVE only. `idle_exit_ms` is a floor — a minimum quiet period
+  before a room may be taken away — and shortening it would drain rooms that
+  have not actually been idle long enough.
+  """
+  @spec jittered_drain_delay(map()) :: pos_integer()
+  def jittered_drain_delay(state) do
+    base = drain_delay(state)
+    base + :rand.uniform(max(div(base * @drain_jitter_pct, 100), 1)) - 1
+  end
+
   # ---------------------------------------------------------------------------
   # Private
   # ---------------------------------------------------------------------------
+
+  # No-op when the drain is disabled (`idle_exit_ms: nil`), which is every note
+  # room. Cancels first so activity genuinely postpones the drain rather than
+  # stacking timers.
+  # Guarded on a POSITIVE integer, so `nil` (every note room), `0`, and any
+  # nonsense value all land on the no-op clause. A zero window would otherwise
+  # re-arm at 0ms and spin the drain broadcast in a tight loop.
+  defp arm_idle(%{idle_exit_ms: ms} = state) when is_integer(ms) and ms > 0 do
+    _ = if state.idle_timer, do: Process.cancel_timer(state.idle_timer)
+    %{state | idle_timer: Process.send_after(self(), :idle_drain, jittered_drain_delay(state))}
+  end
+
+  defp arm_idle(state), do: state
 
   defp do_checkpoint(%{room_pid: room_pid} = state) do
     # Capture the row version BEFORE snapshotting the doc so it never exceeds the

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -196,7 +196,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
       if idle?(state, monotonic_ms()) do
         case Phoenix.PubSub.broadcast(
                Engram.PubSub,
-               CrdtRegistry.drain_topic(state.note_id),
+               CrdtRegistry.drain_topic(state.vault_id),
                {:crdt_room_drain, state.room_pid}
              ) do
           :ok ->
@@ -252,7 +252,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   defp touch_lru(%{idle_exit_ms: nil} = state), do: state
 
   defp touch_lru(state) do
-    CrdtRoomLru.touch(state.note_id, state.room_pid)
+    CrdtRoomLru.touch(state.note_id, state.room_pid, state.vault_id)
     state
   end
 

--- a/lib/engram/notes/crdt_doc.ex
+++ b/lib/engram/notes/crdt_doc.ex
@@ -55,7 +55,10 @@ defmodule Engram.Notes.CrdtDoc do
             room_pid: room_pid,
             user_id: user_id,
             vault_id: vault_id,
-            note_id: note_id
+            note_id: note_id,
+            # Opt-in idle drain (#1152). Absent for note rooms — they are bounded
+            # by auto_exit already, since a note is observed only while open.
+            idle_exit_ms: Keyword.get(opts, :idle_exit_ms)
           )
 
         # Store the timer pid in the room's process dictionary so that

--- a/lib/engram/notes/crdt_registry.ex
+++ b/lib/engram/notes/crdt_registry.ex
@@ -29,16 +29,26 @@ defmodule Engram.Notes.CrdtRegistry do
   def global_name(note_id) when is_binary(note_id), do: {:global, {:crdt_doc, note_id}}
 
   @doc """
-  PubSub topic a room's observers subscribe to, so the room can ask them to LET
-  GO when it has gone idle (#1152).
+  PubSub topic a vault's channels subscribe to, so a room can ask its observers
+  to LET GO when it has gone idle (#1152).
 
   PubSub rather than a node-local registry because rooms are `:global`: a room
   on this node can be observed by channels on any other node. `SharedDoc` also
   keeps its `observer_process` map private, so a room cannot enumerate its own
   observers to message them directly.
+
+  Scoped per VAULT, not per note. A per-note topic meant one subscription per
+  room OPEN, and the enroll-everything client opens a room per note — measured
+  at 309 bytes per subscription, that is ~725 KB per socket on a 2400-note vault
+  and ~707 MB per 1000 such clients, against the same 1024 MB task whose memory
+  this feature exists to protect. Self-defeating at the scale #1146 targets.
+
+  Per-vault costs ONE subscription per channel, and needs no extra filtering:
+  the drain carries the room pid, and a channel that does not hold that pid in
+  `room_doc` already no-ops.
   """
   @spec drain_topic(String.t()) :: String.t()
-  def drain_topic(note_id) when is_binary(note_id), do: "crdt_room_drain:" <> note_id
+  def drain_topic(vault_id) when is_binary(vault_id), do: "crdt_room_drain:" <> vault_id
 
   @doc """
   Find the live room for `note_id` WITHOUT starting one, returning `nil` when

--- a/lib/engram/notes/crdt_registry.ex
+++ b/lib/engram/notes/crdt_registry.ex
@@ -29,6 +29,18 @@ defmodule Engram.Notes.CrdtRegistry do
   def global_name(note_id) when is_binary(note_id), do: {:global, {:crdt_doc, note_id}}
 
   @doc """
+  PubSub topic a room's observers subscribe to, so the room can ask them to LET
+  GO when it has gone idle (#1152).
+
+  PubSub rather than a node-local registry because rooms are `:global`: a room
+  on this node can be observed by channels on any other node. `SharedDoc` also
+  keeps its `observer_process` map private, so a room cannot enumerate its own
+  observers to message them directly.
+  """
+  @spec drain_topic(String.t()) :: String.t()
+  def drain_topic(note_id) when is_binary(note_id), do: "crdt_room_drain:" <> note_id
+
+  @doc """
   Find the live room for `note_id` WITHOUT starting one, returning `nil` when
   no room is running anywhere in the cluster. Used by the deliver-out path,
   which must never spin a room for a note nobody is observing.

--- a/lib/engram/notes/crdt_room_lru.ex
+++ b/lib/engram/notes/crdt_room_lru.ex
@@ -63,9 +63,9 @@ defmodule Engram.Notes.CrdtRoomLru do
   checkpoint timer on start and on every write, and cheap by design: a single
   ETS insert on the hot path, no GenServer round-trip.
   """
-  @spec touch(String.t(), pid()) :: :ok
-  def touch(note_id, room_pid) do
-    :ets.insert(@table, {note_id, room_pid, System.monotonic_time(:millisecond)})
+  @spec touch(String.t(), pid(), String.t()) :: :ok
+  def touch(note_id, room_pid, vault_id) do
+    :ets.insert(@table, {note_id, room_pid, vault_id, System.monotonic_time(:millisecond)})
     :ok
   end
 
@@ -94,7 +94,8 @@ defmodule Engram.Notes.CrdtRoomLru do
   Which note_ids to evict: the oldest `length(entries) - cap`, least recently
   active first. Pure, so the policy is testable without rooms or ETS.
   """
-  @spec select_evictions([{String.t(), pid(), integer()}], non_neg_integer()) :: [String.t()]
+  @spec select_evictions([{String.t(), pid(), String.t(), integer()}], non_neg_integer()) ::
+          [String.t()]
   def select_evictions(entries, cap) do
     excess = length(entries) - cap
 
@@ -102,9 +103,9 @@ defmodule Engram.Notes.CrdtRoomLru do
       []
     else
       entries
-      |> Enum.sort_by(fn {_id, _pid, last} -> last end)
+      |> Enum.sort_by(fn {_id, _pid, _vault, last} -> last end)
       |> Enum.take(excess)
-      |> Enum.map(fn {id, _pid, _last} -> id end)
+      |> Enum.map(fn {id, _pid, _vault, _last} -> id end)
     end
   end
 
@@ -157,7 +158,7 @@ defmodule Engram.Notes.CrdtRoomLru do
   defp prune_dead do
     @table
     |> :ets.tab2list()
-    |> Enum.filter(fn {note_id, pid, _last} ->
+    |> Enum.filter(fn {note_id, pid, _vault, _last} ->
       if Process.alive?(pid) do
         true
       else
@@ -179,14 +180,14 @@ defmodule Engram.Notes.CrdtRoomLru do
 
     for note_id <- note_ids do
       case :ets.lookup(@table, note_id) do
-        [{^note_id, pid, _last}] ->
+        [{^note_id, pid, vault_id, _last}] ->
           # Same broadcast the idle timer sends: observers let go, auto_exit
           # checkpoints. Counted under its own phase so a dashboard can tell
           # memory-pressure eviction from an ordinary idle drain.
           _ =
             Phoenix.PubSub.broadcast(
               Engram.PubSub,
-              CrdtRegistry.drain_topic(note_id),
+              CrdtRegistry.drain_topic(vault_id),
               {:crdt_room_drain, pid}
             )
 

--- a/lib/engram/notes/crdt_room_lru.ex
+++ b/lib/engram/notes/crdt_room_lru.ex
@@ -1,0 +1,208 @@
+defmodule Engram.Notes.CrdtRoomLru do
+  @moduledoc """
+  Resident-room backstop for #1152: bounds how many drain-enabled CRDT rooms
+  stay resident on THIS node, evicting the least recently active.
+
+  ## Why idle-exit is not enough
+
+  The idle drain (`CrdtCheckpointTimer`) bounds rooms that go QUIET. It does
+  nothing for a room that is continuously active — and #1149 measured **7.91 MB
+  resident per 10k-note vault** against a 1024 MB task, so a pathological mix of
+  busy vaults still pins memory. This is the pressure valve for that case.
+
+  ## It drains, it never kills
+
+  Eviction broadcasts on the room's drain topic, exactly as the idle timer does:
+  observers evict their cached pid and unobserve, and the last unobserve trips
+  `auto_exit` → `terminate/2` → `unbind` → checkpoint. Killing a room instead
+  would silently eat the next `sync_update` (a `GenServer.cast` to a dead pid
+  returns `:ok`), which is the whole reason the drain exists.
+
+  Note the LRU deliberately **bypasses `CrdtCheckpointTimer.idle?/2`**: evicting
+  rooms that are *not* idle is its entire job. That is precisely why it must go
+  through the safe release path rather than inventing a second one.
+
+  ## Only drain-enabled rooms are tracked
+
+  `touch/2` is called from the checkpoint timer ONLY when `idle_exit_ms` is set,
+  so a note room never enters the table and can never be evicted. That keeps the
+  whole feature inert until #1150's index room opts in.
+
+  Every tracked pid is LOCAL: a room's timer is started on the same node as the
+  room (`CrdtDoc.start_link`), so `Process.alive?/1` — which raises on remote
+  pids — is safe here. Each node bounds its own residency, which is correct
+  because memory is per-node.
+
+  ## Config
+
+      config :engram, Engram.Notes.CrdtRoomLru,
+        max_resident: 64,
+        sweep_interval_ms: 30_000
+
+  `max_resident` wants tuning against real index-doc sizes once #1150 exists —
+  #1146's arithmetic says ~128 resident rooms would consume an entire task, so
+  the default deliberately sits well under that.
+  """
+  use GenServer
+
+  alias Engram.Notes.CrdtRegistry
+
+  require Logger
+
+  @table :crdt_room_lru
+  @default_max_resident 64
+  @default_sweep_interval_ms 30_000
+  @drain_event [:engram, :crdt, :room_drain]
+
+  # Client -------------------------------------------------------------------
+
+  def start_link(_opts \\ []), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @doc """
+  Record that `note_id`'s room is resident and active as of now. Called from the
+  checkpoint timer on start and on every write, and cheap by design: a single
+  ETS insert on the hot path, no GenServer round-trip.
+  """
+  @spec touch(String.t(), pid()) :: :ok
+  def touch(note_id, room_pid) do
+    :ets.insert(@table, {note_id, room_pid, System.monotonic_time(:millisecond)})
+    :ok
+  end
+
+  @doc "Drop a room's entry (its room exited)."
+  @spec forget(String.t()) :: :ok
+  def forget(note_id) do
+    :ets.delete(@table, note_id)
+    :ok
+  end
+
+  @doc "Live rooms currently tracked on this node."
+  @spec resident_count() :: non_neg_integer()
+  def resident_count, do: :ets.info(@table, :size)
+
+  @doc """
+  Prune dead entries, then drain down to `cap`. Synchronous so tests need not
+  wait out the sweep interval.
+  """
+  @spec sweep(pos_integer() | nil) :: :ok
+  def sweep(cap \\ nil), do: GenServer.call(__MODULE__, {:sweep, cap})
+
+  @doc false
+  def reset, do: GenServer.call(__MODULE__, :reset)
+
+  @doc """
+  Which note_ids to evict: the oldest `length(entries) - cap`, least recently
+  active first. Pure, so the policy is testable without rooms or ETS.
+  """
+  @spec select_evictions([{String.t(), pid(), integer()}], non_neg_integer()) :: [String.t()]
+  def select_evictions(entries, cap) do
+    excess = length(entries) - cap
+
+    if excess <= 0 do
+      []
+    else
+      entries
+      |> Enum.sort_by(fn {_id, _pid, last} -> last end)
+      |> Enum.take(excess)
+      |> Enum.map(fn {id, _pid, _last} -> id end)
+    end
+  end
+
+  # Server -------------------------------------------------------------------
+
+  @impl true
+  def init(:ok) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:sweep, cap}, _from, state) do
+    do_sweep(cap || max_resident())
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:reset, _from, state) do
+    :ets.delete_all_objects(@table)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    do_sweep(max_resident())
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  # Private ------------------------------------------------------------------
+
+  defp do_sweep(cap) do
+    live = prune_dead()
+    evict(select_evictions(live, cap), cap, length(live))
+  end
+
+  # A room that exited between sweeps still holds an entry. Prune BEFORE
+  # selecting, or corpses count toward residency and healthy rooms get evicted
+  # to free memory that nothing is using.
+  defp prune_dead do
+    @table
+    |> :ets.tab2list()
+    |> Enum.filter(fn {note_id, pid, _last} ->
+      if Process.alive?(pid) do
+        true
+      else
+        forget(note_id)
+        false
+      end
+    end)
+  end
+
+  defp evict([], _cap, _resident), do: :ok
+
+  defp evict(note_ids, cap, resident) do
+    # Never silent: an LRU eviction means the idle drain alone was not keeping
+    # up, which is a capacity signal and not routine.
+    Logger.warning(
+      "crdt room LRU evicting #{length(note_ids)} room(s) — resident=#{resident} cap=#{cap}",
+      Engram.Logger.Metadata.with_category(:warning, :sync)
+    )
+
+    for note_id <- note_ids do
+      case :ets.lookup(@table, note_id) do
+        [{^note_id, pid, _last}] ->
+          # Same broadcast the idle timer sends: observers let go, auto_exit
+          # checkpoints. Counted under its own phase so a dashboard can tell
+          # memory-pressure eviction from an ordinary idle drain.
+          _ =
+            Phoenix.PubSub.broadcast(
+              Engram.PubSub,
+              CrdtRegistry.drain_topic(note_id),
+              {:crdt_room_drain, pid}
+            )
+
+          :telemetry.execute(@drain_event, %{count: 1}, %{phase: :lru_evicted})
+
+        [] ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, sweep_interval_ms())
+
+  defp cfg, do: Application.get_env(:engram, __MODULE__, [])
+  defp max_resident, do: Keyword.get(cfg(), :max_resident) || @default_max_resident
+  defp sweep_interval_ms, do: Keyword.get(cfg(), :sweep_interval_ms) || @default_sweep_interval_ms
+end

--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -29,6 +29,7 @@ defmodule Engram.PromEx do
       Engram.PromEx.Crypto,
       Engram.PromEx.Indexing,
       Engram.PromEx.Notes,
+      Engram.PromEx.Crdt,
       Engram.PromEx.Reliability,
       Engram.PromEx.Usage,
       Engram.PromEx.RateLimiter,

--- a/lib/engram/prom_ex/crdt.ex
+++ b/lib/engram/prom_ex/crdt.ex
@@ -13,6 +13,9 @@ defmodule Engram.PromEx.Crdt do
         room's `auto_exit` fire and checkpoint.
       * `:skipped` — an observer declined to unobserve because the room was
         already dead or did not answer the liveness probe.
+      * `:lru_evicted` — `Engram.Notes.CrdtRoomLru` forced a drain because this
+        node was over `max_resident`, i.e. the room was NOT idle and got
+        evicted under memory pressure.
 
   Metrics:
 
@@ -20,12 +23,17 @@ defmodule Engram.PromEx.Crdt do
 
   ## Reading it
 
-  `released` should track `requested` closely. `requested` climbing while
-  `released` stays flat means rooms are being asked to drain and not going
+  `released` should track `requested + lru_evicted` closely. Requests climbing
+  while `released` stays flat means rooms are being asked to drain and not going
   away — the unbounded-residency failure the drain exists to prevent — and a
   rising `reasked` rate localises it to observers that cannot act (netsplit,
   wedged channels). A rising `skipped` rate means rooms are dying or wedging
   on their own, which is a different bug.
+
+  `lru_evicted` should normally be **zero**. Sustained non-zero means idle-exit
+  alone is not keeping up and the node is running at its resident cap — a
+  capacity signal, and the cue to re-tune `max_resident` (or `idle_exit_ms`)
+  against real index-doc sizes.
 
   This is also the only way to answer #1152's "resident room count bounded
   under a soak" in production rather than in a test.

--- a/lib/engram/prom_ex/crdt.ex
+++ b/lib/engram/prom_ex/crdt.ex
@@ -1,0 +1,60 @@
+defmodule Engram.PromEx.Crdt do
+  @moduledoc """
+  PromEx plugin for CRDT room-lifetime signals (#1152).
+
+  Subscribes to:
+
+    * `[:engram, :crdt, :room_drain]` — `%{count: 1}`, metadata `%{phase: atom}`:
+
+      * `:requested` — an idle room asked its observers to let go (first ask).
+      * `:reasked` — a follow-up ask, because the previous one changed nothing.
+        Emitted at a backed-off interval (`CrdtCheckpointTimer.drain_delay/1`).
+      * `:released` — an observer actually unobserved, which is what lets the
+        room's `auto_exit` fire and checkpoint.
+      * `:skipped` — an observer declined to unobserve because the room was
+        already dead or did not answer the liveness probe.
+
+  Metrics:
+
+    * `engram_prom_ex_crdt_room_drain_total` — tags `[:phase]`.
+
+  ## Reading it
+
+  `released` should track `requested` closely. `requested` climbing while
+  `released` stays flat means rooms are being asked to drain and not going
+  away — the unbounded-residency failure the drain exists to prevent — and a
+  rising `reasked` rate localises it to observers that cannot act (netsplit,
+  wedged channels). A rising `skipped` rate means rooms are dying or wedging
+  on their own, which is a different bug.
+
+  This is also the only way to answer #1152's "resident room count bounded
+  under a soak" in production rather than in a test.
+
+  Cardinality contract: the four phase atoms above and nothing else. NEVER add
+  note_id, vault_id, or user_id — there is one series per phase, and a room
+  drains repeatedly.
+  """
+
+  use PromEx.Plugin
+
+  @drain_event [:engram, :crdt, :room_drain]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :crdt)
+
+    Event.build(
+      :engram_crdt_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:room_drain, :total],
+          event_name: @drain_event,
+          description:
+            "CRDT idle room-drain events by phase (requested | reasked | released | skipped).",
+          tags: [:phase]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/runtime_config.ex
+++ b/lib/engram/runtime_config.ex
@@ -38,6 +38,31 @@ defmodule Engram.RuntimeConfig do
   @spec rate_limit_overrides() :: [{String.t(), atom()}]
   def rate_limit_overrides, do: @rate_limit_overrides
 
+  # CI/E2E-only levers for the CRDT room drain (#1152), under the SAME CI=true
+  # gate as the rate-limit overrides above.
+  #
+  # The drain is OFF in production — no room passes `idle_exit_ms`, so nothing
+  # ever drains. That makes it untestable against a REAL client, and every test
+  # in the suite uses a test process or a channel as the observer. These knobs
+  # let a CI stack turn it on so the e2e suite proves a real Obsidian client
+  # survives rooms being released out from under it mid-session: re-spin, no
+  # lost edits, rename/delete still propagating.
+  #
+  # Nested config keys (module + key) rather than the flat app-env keys the
+  # rate-limit overrides use, since both settings live under their module.
+  @drain_overrides [
+    {"CRDT_IDLE_EXIT_MS", {Engram.Notes.CrdtCheckpointTimer, :idle_exit_ms}},
+    {"CRDT_MAX_RESIDENT_ROOMS", {Engram.Notes.CrdtRoomLru, :max_resident}}
+  ]
+
+  @doc """
+  The `{env var, {module, key}}` pairs for the CI-gated CRDT room-drain levers.
+  See the attribute above for why they exist, and `ci_gated_int_override/2` for
+  the gating rule.
+  """
+  @spec drain_overrides() :: [{String.t(), {module(), atom()}}]
+  def drain_overrides, do: @drain_overrides
+
   @doc """
   Decides whether an integer rate-limit override env var should be applied.
 

--- a/lib/engram/runtime_config.ex
+++ b/lib/engram/runtime_config.ex
@@ -50,9 +50,14 @@ defmodule Engram.RuntimeConfig do
   #
   # Nested config keys (module + key) rather than the flat app-env keys the
   # rate-limit overrides use, since both settings live under their module.
+  # NOTE the sweep interval is here for a reason: it defaults to 30s, and most
+  # e2e tests finish well inside that. Setting only `max_resident` would arm the
+  # LRU and never fire it — the suite would look like it covered eviction while
+  # covering nothing.
   @drain_overrides [
     {"CRDT_IDLE_EXIT_MS", {Engram.Notes.CrdtCheckpointTimer, :idle_exit_ms}},
-    {"CRDT_MAX_RESIDENT_ROOMS", {Engram.Notes.CrdtRoomLru, :max_resident}}
+    {"CRDT_MAX_RESIDENT_ROOMS", {Engram.Notes.CrdtRoomLru, :max_resident}},
+    {"CRDT_LRU_SWEEP_MS", {Engram.Notes.CrdtRoomLru, :sweep_interval_ms}}
   ]
 
   @doc """

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -160,6 +160,16 @@ defmodule EngramWeb.CrdtChannel do
                       )
                     )
 
+                    # ONE drain subscription for the whole connection (#1152).
+                    # Per-room would cost a subscription per note the client
+                    # enrolls — 309 bytes each, ~725 KB per socket on a
+                    # 2400-note vault — which is the very memory pressure the
+                    # drain exists to relieve. Nothing extra is needed to route
+                    # it: the drain carries the room pid, and handle_info
+                    # already no-ops on a pid this channel does not hold.
+                    :ok =
+                      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(vault.id))
+
                     {:ok,
                      assign(socket,
                        vault: vault,
@@ -871,8 +881,6 @@ defmodule EngramWeb.CrdtChannel do
         {:noreply, socket}
 
       doc_id ->
-        entry = Map.get(socket.assigns.rooms, doc_id)
-
         socket =
           socket
           |> assign(:rooms, Map.delete(socket.assigns.rooms, doc_id))
@@ -880,10 +888,6 @@ defmodule EngramWeb.CrdtChannel do
           # Remember we let this one go, so the re-spin stays quiet (see the
           # announce in start_and_observe_room).
           |> assign(:drained, remember_drained(socket.assigns.drained, doc_id))
-
-        if entry do
-          Phoenix.PubSub.unsubscribe(Engram.PubSub, CrdtRegistry.drain_topic(entry.note_id))
-        end
 
         release_room(room)
         {:noreply, socket}
@@ -897,19 +901,10 @@ defmodule EngramWeb.CrdtChannel do
         {:noreply, socket}
 
       doc_id ->
-        entry = Map.get(socket.assigns.rooms, doc_id)
-
         socket =
           socket
           |> assign(:rooms, Map.delete(socket.assigns.rooms, doc_id))
           |> assign(:room_doc, Map.delete(socket.assigns.room_doc, pid))
-
-        # Drop the drain subscription too, or the re-subscribe in the next
-        # start_and_observe_room stacks a SECOND subscription on the same topic
-        # (PubSub does not dedupe) and every later drain arrives twice.
-        if entry do
-          Phoenix.PubSub.unsubscribe(Engram.PubSub, CrdtRegistry.drain_topic(entry.note_id))
-        end
 
         {:noreply, socket}
     end
@@ -1209,25 +1204,9 @@ defmodule EngramWeb.CrdtChannel do
       # dead pid return :ok and every subsequent edit is silently dropped.
       _ref = Process.monitor(room)
 
-      # Subscribe to the room's drain topic so an idle room can ask us to let go
-      # (#1152). PubSub, not a direct message, because rooms are :global — this
-      # room may live on another node, and SharedDoc keeps its observer list
-      # private so it cannot message its observers itself.
-      case Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(note_id)) do
-        :ok ->
-          :ok
-
-        {:error, reason} ->
-          # Sync still works — but this room can now never be drained, so it
-          # sits resident until its observers disconnect. That is the exact
-          # unbounded-residency failure the drain exists to prevent, so it must
-          # not be silent.
-          Logger.warning(
-            "crdt drain subscribe failed: #{inspect(reason)}",
-            Metadata.with_category(:warning, :websocket, note_id: note_id)
-          )
-      end
-
+      # NOTE: no per-room drain subscribe. The connection subscribes ONCE to its
+      # vault's drain topic in join/3 — see the comment there for why per-room
+      # was self-defeating.
       entry = %{room: room, note_id: note_id}
 
       socket =

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -45,6 +45,18 @@ defmodule EngramWeb.CrdtChannel do
   @msg_limit 240
   @msg_scale_ms 10_000
 
+  # Liveness-probe timeout before unobserving a drained room (see release_room/1).
+  # Generous enough that a room merely busy in a NIF still answers, short enough
+  # that a genuinely wedged one cannot hold this channel for y_ex's 5 s default.
+  # Overridable (like @default_max_rooms) so the wedged-room test can assert
+  # against a short probe instead of racing a 1 s wall-clock on a loaded runner.
+  @room_probe_ms 1_000
+
+  # Ceiling on the per-socket drained-doc_id set (see remember_drained/3).
+  @max_drained 1_024
+
+  @drain_event [:engram, :crdt, :room_drain]
+
   # Per-socket ceiling on distinct rooms (notes) a single connection may enroll.
   # Each room pins a server Y.Doc + checkpoint timer, so an unbounded client
   # (buggy or hostile) could STEP1 endlessly and exhaust node RAM + the DB pool.
@@ -148,7 +160,16 @@ defmodule EngramWeb.CrdtChannel do
                       )
                     )
 
-                    {:ok, assign(socket, vault: vault, rooms: %{}, room_doc: %{})}
+                    {:ok,
+                     assign(socket,
+                       vault: vault,
+                       rooms: %{},
+                       room_doc: %{},
+                       # doc_ids released by an idle drain (#1152), so the
+                       # re-spin does not re-announce crdt_doc_ready. See
+                       # start_and_observe_room.
+                       drained: MapSet.new()
+                     )}
 
                   _ ->
                     {:error, %{reason: "api_key_vault_forbidden"}}
@@ -832,6 +853,43 @@ defmodule EngramWeb.CrdtChannel do
     end
   end
 
+  # The room has gone idle and is asking its observers to let go (#1152). Evict
+  # the cached pid FIRST, then unobserve — the last unobserve trips the room's
+  # auto_exit, which checkpoints on terminate.
+  #
+  # Evict-before-unobserve is what makes this safe. A `sync_update` frame is a
+  # GenServer.cast (deps/y_ex/lib/server/doc_server_worker.ex:26), so casting at
+  # a dead room returns :ok and silently drops the edit. Because the eviction
+  # happens in this same handle_info, any frame BEHIND this message re-resolves
+  # through ensure_room and lands on a fresh room, and any frame AHEAD of it
+  # already reached the room while it was live. There is no window either way.
+  @impl true
+  def handle_info({:crdt_room_drain, room}, socket) do
+    case Map.get(socket.assigns.room_doc, room) do
+      nil ->
+        # Not ours (a room we already released, or another channel's).
+        {:noreply, socket}
+
+      doc_id ->
+        entry = Map.get(socket.assigns.rooms, doc_id)
+
+        socket =
+          socket
+          |> assign(:rooms, Map.delete(socket.assigns.rooms, doc_id))
+          |> assign(:room_doc, Map.delete(socket.assigns.room_doc, room))
+          # Remember we let this one go, so the re-spin stays quiet (see the
+          # announce in start_and_observe_room).
+          |> assign(:drained, remember_drained(socket.assigns.drained, doc_id))
+
+        if entry do
+          Phoenix.PubSub.unsubscribe(Engram.PubSub, CrdtRegistry.drain_topic(entry.note_id))
+        end
+
+        release_room(room)
+        {:noreply, socket}
+    end
+  end
+
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, socket) do
     case Map.get(socket.assigns.room_doc, pid) do
@@ -839,14 +897,103 @@ defmodule EngramWeb.CrdtChannel do
         {:noreply, socket}
 
       doc_id ->
+        entry = Map.get(socket.assigns.rooms, doc_id)
+
         socket =
           socket
           |> assign(:rooms, Map.delete(socket.assigns.rooms, doc_id))
           |> assign(:room_doc, Map.delete(socket.assigns.room_doc, pid))
 
+        # Drop the drain subscription too, or the re-subscribe in the next
+        # start_and_observe_room stacks a SECOND subscription on the same topic
+        # (PubSub does not dedupe) and every later drain arrives twice.
+        if entry do
+          Phoenix.PubSub.unsubscribe(Engram.PubSub, CrdtRegistry.drain_topic(entry.note_id))
+        end
+
         {:noreply, socket}
     end
   end
+
+  @doc """
+  Let go of `room` in response to a drain (#1152). Always `:ok`.
+
+  `SharedDoc.unobserve/1` is a `GenServer.call` with y_ex's default 5 s timeout
+  and no timeout knob, so a room that is dead — or alive but wedged — would
+  either EXIT this channel or stall it for 5 s. Three guards, cheapest first:
+
+    1. already dead → nothing to release;
+    2. not answering within `#{@room_probe_ms}` ms → skip. Nothing is lost by
+       skipping: `auto_exit` is driven by the room's own observer bookkeeping,
+       so a room too wedged to answer was never going to exit on this unobserve
+       anyway. The timer's backed-off re-ask picks it up when it recovers;
+    3. otherwise unobserve — a room that answered the probe answers this too.
+
+  The probe is `update_doc/3` with a no-op fun: PUBLIC API that takes a timeout,
+  where `unobserve/1` does not. Reaching for `GenServer.call(room, {:unobserve,
+  self()}, …)` instead would hard-code y_ex's private message shape, which fails
+  silently on a dep bump; this costs one extra round-trip on a path that only
+  runs at idle-drain frequency.
+
+  `catch :exit` still backstops the gap between each check and the call.
+
+  Public (`@doc false`-ish) because the dead/wedged paths are unreachable
+  through the channel API — same reason `CrdtRegistry.observe_with_retry/3` is.
+  """
+  @spec release_room(pid()) :: :ok
+  def release_room(room) do
+    cond do
+      locally_dead?(room) ->
+        emit_drain(:skipped)
+
+      not room_responsive?(room) ->
+        emit_drain(:skipped)
+
+      true ->
+        SharedDoc.unobserve(room)
+        emit_drain(:released)
+    end
+
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  # Paired with the timer's :requested/:reasked counts, this is the signal that
+  # answers "is the drain actually working in prod": requests far exceeding
+  # releases means rooms are being asked to drain and not going away, which is
+  # the unbounded-residency failure the whole feature exists to prevent. Without
+  # it, #1152's "resident room count bounded under a soak" is unverifiable.
+  # Cardinality contract: bounded phase atoms only — NEVER note/vault/user ids.
+  defp emit_drain(phase) do
+    :telemetry.execute(@drain_event, %{count: 1}, %{phase: phase})
+    :ok
+  end
+
+  # `Process.alive?/1` is LOCAL-ONLY — it raises ArgumentError on a remote pid,
+  # and an ArgumentError is :error class, so the `catch :exit` above would NOT
+  # contain it. Rooms are `:global`-registered, so a channel on this node
+  # routinely observes a room on another one (clustering live since
+  # 2026-06-23) — an unguarded alive? check would crash the channel on every
+  # drain of a remote room.
+  #
+  # For a remote room we simply skip the fast path: `room_responsive?/1` is a
+  # GenServer.call, which exits catchably against a dead remote pid and is
+  # timeout-bounded either way, so correctness does not depend on this check.
+  defp locally_dead?(room), do: node(room) == node() and not Process.alive?(room)
+
+  defp room_responsive?(room) do
+    SharedDoc.update_doc(room, fn _doc -> :ok end, room_probe_ms())
+    true
+  catch
+    :exit, _ -> false
+  end
+
+  # `|| @room_probe_ms`, NOT `get_env/3` with a default: the three-arg form only
+  # falls back when the key is ABSENT, so any writer that leaves the key set to
+  # nil (e.g. a test restoring a previously-unset override) would feed `nil` to
+  # GenServer.call/3 and crash the channel. Matches effective_msg_limit/0 above.
+  defp room_probe_ms, do: Application.get_env(:engram, :crdt_room_probe_ms) || @room_probe_ms
 
   # A note_id is a non-sensitive UUID and is REQUIRED to diagnose which note
   # lost a dropped edit (redacting it under :path blocked the 2026-07-06
@@ -1047,6 +1194,25 @@ defmodule EngramWeb.CrdtChannel do
       # dead pid return :ok and every subsequent edit is silently dropped.
       _ref = Process.monitor(room)
 
+      # Subscribe to the room's drain topic so an idle room can ask us to let go
+      # (#1152). PubSub, not a direct message, because rooms are :global — this
+      # room may live on another node, and SharedDoc keeps its observer list
+      # private so it cannot message its observers itself.
+      case Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(note_id)) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          # Sync still works — but this room can now never be drained, so it
+          # sits resident until its observers disconnect. That is the exact
+          # unbounded-residency failure the drain exists to prevent, so it must
+          # not be silent.
+          Logger.warning(
+            "crdt drain subscribe failed: #{inspect(reason)}",
+            Metadata.with_category(:warning, :websocket, note_id: note_id)
+          )
+      end
+
       entry = %{room: room, note_id: note_id}
 
       socket =
@@ -1062,16 +1228,64 @@ defmodule EngramWeb.CrdtChannel do
       # empty note live rather than waiting for the pull — matches the
       # CrdtDeliver announce contract; the plugin treats "path" as optional, so
       # a failed lookup just omits it (never crash the room-open).
-      payload =
-        case Notes.get_note_by_id(user, vault, note_id) do
-          {:ok, %{path: path}} when is_binary(path) -> %{"doc_id" => doc_id, "path" => path}
-          _ -> %{"doc_id" => doc_id}
-        end
+      #
+      # SKIPPED when this socket previously released the room to an idle drain
+      # (#1152). The announce is a DISCOVERY signal, and a re-spin discovers
+      # nothing: every peer already learned about this note when it was first
+      # announced. Re-announcing would make every drain->edit cycle fan a
+      # syncStep1 out of every other device on the vault, against budgets that
+      # are already tight (@hs_limit here, the plugin's 240/10s crdt_msg limit
+      # in Engram-obsidian#159) — and handshake starvation is the documented
+      # trigger for the wrong-mint cross-file overwrite class. The drain makes
+      # re-spin routine rather than crash-only, so what used to be rare noise
+      # would become a per-edit storm.
+      #
+      # Scoped to the drain path on purpose: a crash/node-loss re-spin still
+      # announces exactly as before, since that peer state is genuinely unknown.
+      {announce?, socket} = consume_drained(socket, doc_id)
 
-      broadcast_from!(socket, "crdt_doc_ready", payload)
+      if announce? do
+        payload =
+          case Notes.get_note_by_id(user, vault, note_id) do
+            {:ok, %{path: path}} when is_binary(path) -> %{"doc_id" => doc_id, "path" => path}
+            _ -> %{"doc_id" => doc_id}
+          end
+
+        broadcast_from!(socket, "crdt_doc_ready", payload)
+      end
 
       {:ok, socket, entry}
     end
+  end
+
+  # `{announce?, socket}` — false exactly once per drain, so a LATER drain of the
+  # same doc_id is independently suppressed rather than the note going
+  # permanently silent.
+  defp consume_drained(socket, doc_id) do
+    if MapSet.member?(socket.assigns.drained, doc_id) do
+      {false, assign(socket, :drained, MapSet.delete(socket.assigns.drained, doc_id))}
+    else
+      {true, socket}
+    end
+  end
+
+  @doc """
+  Record `doc_id` as drained, bounded at `cap`.
+
+  Entries are consumed by the matching re-spin, but a note that is drained and
+  never re-opened leaves one behind for the life of the socket — and
+  `@default_max_rooms` bounds CONCURRENT rooms, not cumulative ones, while
+  drain-churn is the intended steady state. So the set is capped.
+
+  Overflow CLEARS rather than evicting one entry: it costs no ordering
+  bookkeeping, and the degradation is safe in the only direction that matters —
+  a forgotten doc_id just means its re-spin announces, which is exactly the
+  pre-drain behaviour. Never incorrectness, only lost suppression.
+  """
+  @spec remember_drained(MapSet.t(), String.t(), pos_integer()) :: MapSet.t()
+  def remember_drained(drained, doc_id, cap \\ @max_drained) do
+    drained = MapSet.put(drained, doc_id)
+    if MapSet.size(drained) > cap, do: MapSet.new(), else: drained
   end
 
   # doc_id IS the note_id (client-minted UUIDv7). Validate the note exists in

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -956,7 +956,13 @@ defmodule EngramWeb.CrdtChannel do
 
     :ok
   catch
-    :exit, _ -> :ok
+    # The room died between a check and the call. Count it — otherwise this
+    # drain is neither :released nor :skipped, and requests silently exceed
+    # outcomes on the dashboard, which reads exactly like the leak this counter
+    # exists to detect.
+    :exit, _ ->
+      emit_drain(:skipped)
+      :ok
   end
 
   # Paired with the timer's :requested/:reasked counts, this is the signal that
@@ -970,17 +976,26 @@ defmodule EngramWeb.CrdtChannel do
     :ok
   end
 
-  # `Process.alive?/1` is LOCAL-ONLY — it raises ArgumentError on a remote pid,
-  # and an ArgumentError is :error class, so the `catch :exit` above would NOT
-  # contain it. Rooms are `:global`-registered, so a channel on this node
-  # routinely observes a room on another one (clustering live since
-  # 2026-06-23) — an unguarded alive? check would crash the channel on every
-  # drain of a remote room.
-  #
-  # For a remote room we simply skip the fast path: `room_responsive?/1` is a
-  # GenServer.call, which exits catchably against a dead remote pid and is
-  # timeout-bounded either way, so correctness does not depend on this check.
-  defp locally_dead?(room), do: node(room) == node() and not Process.alive?(room)
+  @doc """
+  True only for a pid on THIS node that is already dead.
+
+  `Process.alive?/1` is LOCAL-ONLY: it raises `ArgumentError` on a remote pid,
+  and `ArgumentError` is `:error` class, so `release_room/1`'s `catch :exit`
+  would NOT contain it. Rooms are `:global`-registered, so a channel on this
+  node routinely observes a room on another one (clustering live since
+  2026-06-23) — unguarded, this crashed the channel on every drain of a remote
+  room.
+
+  Remote rooms simply skip the fast path: `room_responsive?/1` is a
+  GenServer.call, which exits catchably against a dead remote pid and is
+  timeout-bounded regardless, so correctness never depended on this check.
+
+  `self_node` is injectable so the remote branch is testable on a single node —
+  the `:cluster`-tagged test that uses a real peer does not run in CI.
+  """
+  @spec locally_dead?(pid(), node()) :: boolean()
+  def locally_dead?(room, self_node \\ node()),
+    do: node(room) == self_node and not Process.alive?(room)
 
   defp room_responsive?(room) do
     SharedDoc.update_doc(room, fn _doc -> :ok end, room_probe_ms())

--- a/test/engram/notes/crdt_checkpoint_timer_test.exs
+++ b/test/engram/notes/crdt_checkpoint_timer_test.exs
@@ -45,6 +45,79 @@ defmodule Engram.Notes.CrdtCheckpointTimerTest do
     end
   end
 
+  describe "idle?/2 — the drain gate (#1152)" do
+    test "a room that has never been written to is idle, so it can drain" do
+      assert CrdtCheckpointTimer.idle?(%{last_activity_at: nil}, 10_000)
+    end
+
+    test "a full idle window since the last write is idle" do
+      assert CrdtCheckpointTimer.idle?(
+               %{last_activity_at: 9_000, idle_exit_ms: 1_000},
+               10_000
+             )
+    end
+
+    # The race this gate exists for: an :idle_drain already in the mailbox when
+    # an :activity lands is still processed AFTER it (cancel_timer cannot
+    # un-send). Without the gate, that drains a room being actively edited.
+    test "a write inside the window is NOT idle, so a stale timer cannot drain it" do
+      refute CrdtCheckpointTimer.idle?(
+               %{last_activity_at: 9_999, idle_exit_ms: 1_000},
+               10_000
+             )
+    end
+  end
+
+  describe "drain_delay/1 — backing off an unanswered drain (#1152)" do
+    test "the first ask is at the plain idle window" do
+      assert CrdtCheckpointTimer.drain_delay(%{idle_exit_ms: 1_000, drain_attempts: 0}) == 1_000
+    end
+
+    test "each unanswered drain lengthens the next ask" do
+      assert CrdtCheckpointTimer.drain_delay(%{idle_exit_ms: 1_000, drain_attempts: 1}) == 2_000
+      assert CrdtCheckpointTimer.drain_delay(%{idle_exit_ms: 1_000, drain_attempts: 3}) == 4_000
+    end
+
+    # An observer that can NEVER act (netsplit, wedged channel) must not hold a
+    # fixed broadcast rate for the life of the room — but it must not go silent
+    # either, or a later-reachable observer never gets asked again.
+    test "the backoff is capped, so the re-ask never stops and never runs away" do
+      assert CrdtCheckpointTimer.drain_delay(%{idle_exit_ms: 1_000, drain_attempts: 500}) == 8_000
+    end
+  end
+
+  describe "jittered_drain_delay/1 — desynchronising the herd (#1152)" do
+    # auto_exit fires on user behaviour, so exits spread themselves. Idle timers
+    # are armed when the room STARTS, so a deploy or reconnect storm would arm
+    # thousands identically and drain them in one instant — a synchronized
+    # checkpoint storm, the 2026-07-09 pool-exhaustion shape.
+    test "spreads repeated arms across a window instead of returning one value" do
+      state = %{idle_exit_ms: 10_000, drain_attempts: 0}
+      samples = for _ <- 1..200, do: CrdtCheckpointTimer.jittered_drain_delay(state)
+
+      assert length(Enum.uniq(samples)) > 1, "no jitter — every room would drain in lockstep"
+    end
+
+    # idle_exit_ms is a FLOOR: the minimum quiet period before a room may be
+    # taken away. Jitter that could shorten it would drain rooms that have not
+    # actually been idle long enough.
+    test "never fires EARLIER than the base delay, only later" do
+      state = %{idle_exit_ms: 10_000, drain_attempts: 0}
+      base = CrdtCheckpointTimer.drain_delay(state)
+
+      for _ <- 1..200 do
+        delay = CrdtCheckpointTimer.jittered_drain_delay(state)
+        assert delay >= base
+        assert delay <= base * 1.25
+      end
+    end
+
+    test "jitter rides on top of the backoff, not instead of it" do
+      backed_off = %{idle_exit_ms: 1_000, drain_attempts: 3}
+      assert CrdtCheckpointTimer.jittered_drain_delay(backed_off) >= 4_000
+    end
+  end
+
   describe "compute_delay/2 — sustained editing stays debounced" do
     test "an edit within the settle window debounces by settle_ms (not eager)" do
       {delay, first_dirty_at} =

--- a/test/engram/notes/crdt_room_idle_exit_test.exs
+++ b/test/engram/notes/crdt_room_idle_exit_test.exs
@@ -93,7 +93,7 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
 
   describe "drain broadcast" do
     test "an idle room asks its observers to let go WITHOUT stopping itself", ctx do
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.vault.id))
       room = start_room(ctx, idle_exit_ms: @idle_ms)
       :ok = SharedDoc.observe(room)
 
@@ -106,7 +106,7 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
     end
 
     test "activity re-arms the window so an actively-edited room is never drained", ctx do
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.vault.id))
       room = start_room(ctx, idle_exit_ms: @rearm_idle_ms)
       :ok = SharedDoc.observe(room)
 
@@ -127,7 +127,7 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
     # positive-integer guard it would arm at 0 ms and spin the drain broadcast in
     # a tight loop.
     test "a zero idle window is treated as disabled, not as drain-immediately", ctx do
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.vault.id))
       room = start_room(ctx, idle_exit_ms: 0)
       :ok = SharedDoc.observe(room)
 
@@ -155,7 +155,7 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
     end
 
     test "a room without idle_exit_ms never drains — note rooms are unchanged", ctx do
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.vault.id))
       room = start_room(ctx, [])
       :ok = SharedDoc.observe(room)
 
@@ -167,7 +167,7 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
   describe "exit + checkpoint" do
     test "the last unobserve trips auto_exit, and terminate checkpoints the edit", ctx do
       %{user: user, vault: vault, note: note} = ctx
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(note.id))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(vault.id))
       room = start_room(ctx, idle_exit_ms: @idle_ms)
       :ok = SharedDoc.observe(room)
       ref = Process.monitor(room)
@@ -187,7 +187,7 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
 
     test "the :global registration is released so the next edit gets a fresh room", ctx do
       %{user: user, vault: vault, note: note} = ctx
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(note.id))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(vault.id))
       room = start_room(ctx, idle_exit_ms: @idle_ms)
       :ok = SharedDoc.observe(room)
       ref = Process.monitor(room)

--- a/test/engram/notes/crdt_room_idle_exit_test.exs
+++ b/test/engram/notes/crdt_room_idle_exit_test.exs
@@ -34,6 +34,22 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
 
   @idle_ms 150
 
+  # The re-arm test has two conflicting timing requirements: each gap between
+  # edits must stay RELIABLY under the idle window (or the room really is idle
+  # and the drain correctly fires), while the TOTAL activity period must exceed
+  # it (or a never-re-armed timer would not have fired either, and the test
+  # discriminates nothing).
+  #
+  # The first version used a 2x ratio (75 ms gaps, 150 ms window) and failed
+  # ~70% of the time under CPU contention: a loaded scheduler overshoots the
+  # sleep, the room is genuinely idle past the window, and `idle?/2` fires
+  # exactly as designed. That test was asserting the machine's timeliness, not
+  # the code's behaviour. 6x gap-to-window, with a total that clears the window
+  # three times over.
+  @rearm_idle_ms 1_200
+  @rearm_gap_ms 200
+  @rearm_edits 10
+
   setup do
     # Park the checkpoint debounce far out of reach so the ONLY thing that can
     # materialize content in these tests is the unbind checkpoint on room exit.
@@ -91,15 +107,18 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
 
     test "activity re-arms the window so an actively-edited room is never drained", ctx do
       Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
-      room = start_room(ctx, idle_exit_ms: @idle_ms)
+      room = start_room(ctx, idle_exit_ms: @rearm_idle_ms)
       :ok = SharedDoc.observe(room)
 
-      # Keep editing across several idle windows.
-      for n <- 1..5 do
+      # Sustained editing for ~2s against a 1.2s window: a timer armed once at
+      # room start would have fired long before this loop ends.
+      for n <- 1..@rearm_edits do
         edit(room, "typing #{n}")
-        Process.sleep(div(@idle_ms, 2))
+        Process.sleep(@rearm_gap_ms)
       end
 
+      # refute_RECEIVED, not refute_receive: check the mailbox as it stands
+      # rather than waiting further, so the assertion adds no timing surface.
       refute_received {:crdt_room_drain, ^room}
       assert Process.alive?(room)
     end

--- a/test/engram/notes/crdt_room_idle_exit_test.exs
+++ b/test/engram/notes/crdt_room_idle_exit_test.exs
@@ -123,6 +123,37 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
       assert Process.alive?(room)
     end
 
+    # 0 is TRUTHY in Elixir, so it survives the `||` config fallback. Without the
+    # positive-integer guard it would arm at 0 ms and spin the drain broadcast in
+    # a tight loop.
+    test "a zero idle window is treated as disabled, not as drain-immediately", ctx do
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      room = start_room(ctx, idle_exit_ms: 0)
+      :ok = SharedDoc.observe(room)
+
+      refute_receive {:crdt_room_drain, ^room}, 300
+      assert Process.alive?(room)
+    end
+
+    test "the first drain is counted so ops can compare asks against releases", ctx do
+      test_pid = self()
+      handler = "req-telemetry-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:engram, :crdt, :room_drain],
+        fn _e, m, meta, _ -> send(test_pid, {:drain_telemetry, m, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      room = start_room(ctx, idle_exit_ms: @idle_ms)
+      :ok = SharedDoc.observe(room)
+
+      assert_receive {:drain_telemetry, %{count: 1}, %{phase: :requested}}, 2_000
+    end
+
     test "a room without idle_exit_ms never drains — note rooms are unchanged", ctx do
       Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
       room = start_room(ctx, [])

--- a/test/engram/notes/crdt_room_idle_exit_test.exs
+++ b/test/engram/notes/crdt_room_idle_exit_test.exs
@@ -1,0 +1,155 @@
+defmodule Engram.Notes.CrdtRoomIdleExitTest do
+  @moduledoc """
+  The room-lifetime model for engram-app/Engram#1152 (under the #167 p0 umbrella).
+
+  A per-note room exits via `auto_exit`, which is purely last-observer-driven
+  (`deps/y_ex/lib/protocols/shared_doc.ex:190,198`). That works for notes — a
+  note is open briefly — but an INDEX room is observed for as long as any client
+  is connected, so its lifetime becomes session-length and residency scales with
+  concurrent connections instead of mutation rate. #1149 measured 7.91 MB
+  resident per 10k-note vault, so that is two orders of magnitude off target.
+
+  These tests pin the protocol that bounds it:
+
+      idle timer fires
+        -> broadcast {:crdt_room_drain, room} on the room's drain topic
+          -> each observer evicts its cached pid, then unobserves
+            -> the LAST unobserve trips the EXISTING auto_exit
+              -> terminate/2 -> CrdtPersistence.unbind/3 -> checkpoint
+
+  Nothing here stops the room directly, and that is the whole point. #1152 asks
+  for "a timer that exits with observers still attached" — but a room killed out
+  from under an attached observer silently eats the next `sync_update` frame:
+  y_ex dispatches those as a `GenServer.cast`
+  (`deps/y_ex/lib/server/doc_server_worker.ex:26`), and a cast to a dead pid
+  returns `:ok` while dropping the edit. `crdt_channel.ex` already carries that
+  warning at its room monitor. Draining observers first makes the exit fall out
+  of the mechanism that already exists, with no window for a lost frame.
+  """
+  use Engram.DataCase, async: false
+
+  alias Engram.{Crypto, Notes, Vaults}
+  alias Engram.Notes.{CrdtBridge, CrdtDoc, CrdtRegistry}
+  alias Yex.Sync.SharedDoc
+
+  @idle_ms 150
+
+  setup do
+    # Park the checkpoint debounce far out of reach so the ONLY thing that can
+    # materialize content in these tests is the unbind checkpoint on room exit.
+    # Without this the eager 250ms flush would materialize anyway and the
+    # "checkpoints on exit" assertion below would pass vacuously.
+    prev = Application.get_env(:engram, Engram.Notes.CrdtCheckpointTimer, [])
+
+    Application.put_env(:engram, Engram.Notes.CrdtCheckpointTimer,
+      settle_ms: 600_000,
+      ceiling_ms: 600_000,
+      eager_ms: 600_000
+    )
+
+    on_exit(fn -> Application.put_env(:engram, Engram.Notes.CrdtCheckpointTimer, prev) end)
+
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "IdleExitTest"})
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before"})
+
+    %{user: user, vault: vault, note: note}
+  end
+
+  # Start a room directly (not via CrdtRegistry.ensure_started/3, which owns no
+  # opts pass-through yet) so a test can choose the idle window per room.
+  defp start_room(%{user: user, vault: vault, note: note}, opts) do
+    spec =
+      {CrdtDoc, [note_id: note.id, user_id: user.id, vault_id: vault.id] ++ opts}
+
+    {:ok, room} = DynamicSupervisor.start_child(Engram.Notes.CrdtDocSupervisor, spec)
+    room
+  end
+
+  defp edit(room, text) do
+    :ok =
+      SharedDoc.update_doc(room, fn doc ->
+        doc |> Yex.Doc.get_text(CrdtBridge.text_name()) |> CrdtBridge.diff_into_text(text)
+      end)
+  end
+
+  describe "drain broadcast" do
+    test "an idle room asks its observers to let go WITHOUT stopping itself", ctx do
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      room = start_room(ctx, idle_exit_ms: @idle_ms)
+      :ok = SharedDoc.observe(room)
+
+      assert_receive {:crdt_room_drain, ^room}, 1_000
+
+      # The room is STILL ALIVE with an observer attached. If this ever fails,
+      # the implementation went back to killing the room directly and the
+      # cast-into-a-corpse edit-loss window is open again.
+      assert Process.alive?(room)
+    end
+
+    test "activity re-arms the window so an actively-edited room is never drained", ctx do
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      room = start_room(ctx, idle_exit_ms: @idle_ms)
+      :ok = SharedDoc.observe(room)
+
+      # Keep editing across several idle windows.
+      for n <- 1..5 do
+        edit(room, "typing #{n}")
+        Process.sleep(div(@idle_ms, 2))
+      end
+
+      refute_received {:crdt_room_drain, ^room}
+      assert Process.alive?(room)
+    end
+
+    test "a room without idle_exit_ms never drains — note rooms are unchanged", ctx do
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.note.id))
+      room = start_room(ctx, [])
+      :ok = SharedDoc.observe(room)
+
+      refute_receive {:crdt_room_drain, ^room}, @idle_ms * 4
+      assert Process.alive?(room)
+    end
+  end
+
+  describe "exit + checkpoint" do
+    test "the last unobserve trips auto_exit, and terminate checkpoints the edit", ctx do
+      %{user: user, vault: vault, note: note} = ctx
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(note.id))
+      room = start_room(ctx, idle_exit_ms: @idle_ms)
+      :ok = SharedDoc.observe(room)
+      ref = Process.monitor(room)
+
+      edit(room, "before AND A DRAINED EDIT")
+
+      assert_receive {:crdt_room_drain, ^room}, 1_000
+
+      # What a channel does on drain: let go. auto_exit does the rest.
+      :ok = SharedDoc.unobserve(room)
+
+      assert_receive {:DOWN, ^ref, :process, ^room, :normal}, 5_000
+
+      {:ok, materialized} = Notes.get_note_by_id(user, vault, note.id)
+      assert materialized.content =~ "A DRAINED EDIT"
+    end
+
+    test "the :global registration is released so the next edit gets a fresh room", ctx do
+      %{user: user, vault: vault, note: note} = ctx
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(note.id))
+      room = start_room(ctx, idle_exit_ms: @idle_ms)
+      :ok = SharedDoc.observe(room)
+      ref = Process.monitor(room)
+
+      assert_receive {:crdt_room_drain, ^room}, 1_000
+      :ok = SharedDoc.unobserve(room)
+      assert_receive {:DOWN, ^ref, :process, ^room, :normal}, 5_000
+
+      # Re-spin: same note, brand-new room process.
+      {:ok, respun} = CrdtRegistry.ensure_started(user.id, vault.id, note.id)
+      assert is_pid(respun)
+      refute respun == room
+    end
+  end
+end

--- a/test/engram/notes/crdt_room_lru_test.exs
+++ b/test/engram/notes/crdt_room_lru_test.exs
@@ -1,0 +1,134 @@
+defmodule Engram.Notes.CrdtRoomLruTest do
+  @moduledoc """
+  The backstop half of #1152.
+
+  Idle-exit bounds rooms that go QUIET. It does nothing for a room that is
+  continuously active, so a pathological mix of busy vaults still pins memory —
+  #1149 measured 7.91 MB resident per 10k-note vault against a 1024 MB task.
+  The LRU forces the least-recently-active rooms out under pressure.
+
+  It forces a DRAIN, never a kill: draining is the one release path proven not
+  to eat an in-flight `sync_update` (see CrdtChannelDrainTest). The LRU
+  deliberately bypasses `idle?/2` — evicting rooms that are NOT idle is its
+  entire purpose — which is exactly why it must reuse the safe mechanism.
+  """
+  use Engram.DataCase, async: false
+
+  alias Engram.Notes.{CrdtRegistry, CrdtRoomLru}
+
+  describe "select_evictions/2 (pure)" do
+    # Entries are {note_id, pid, last_activity_monotonic}; smaller = older.
+    defp entry(id, age), do: {id, self(), age}
+
+    test "nothing is evicted while resident count is within the cap" do
+      entries = [entry("a", 100), entry("b", 200)]
+      assert CrdtRoomLru.select_evictions(entries, 5) == []
+    end
+
+    test "evicts the least-recently-active first, and only the excess" do
+      entries = [entry("new", 300), entry("oldest", 100), entry("mid", 200)]
+
+      assert CrdtRoomLru.select_evictions(entries, 2) == ["oldest"]
+    end
+
+    test "evicts enough to reach the cap, not just one" do
+      entries = for n <- 1..10, do: entry("n#{n}", n)
+
+      evicted = CrdtRoomLru.select_evictions(entries, 4)
+
+      assert length(evicted) == 6
+      assert "n1" in evicted
+      assert "n6" in evicted
+      refute "n7" in evicted, "the 4 most recently active must survive"
+    end
+
+    test "a cap of zero evicts everything rather than crashing" do
+      assert length(CrdtRoomLru.select_evictions([entry("a", 1), entry("b", 2)], 0)) == 2
+    end
+  end
+
+  describe "sweep" do
+    setup do
+      CrdtRoomLru.reset()
+      on_exit(&CrdtRoomLru.reset/0)
+      :ok
+    end
+
+    test "a room over the cap is asked to DRAIN, never killed" do
+      # Two live processes standing in for rooms; the LRU only ever broadcasts,
+      # so it does not need real SharedDocs.
+      old = spawn(fn -> Process.sleep(:infinity) end)
+      new = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Enum.each([old, new], &Process.exit(&1, :kill)) end)
+
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("old-note"))
+
+      CrdtRoomLru.touch("old-note", old)
+      Process.sleep(5)
+      CrdtRoomLru.touch("new-note", new)
+
+      CrdtRoomLru.sweep(1)
+
+      assert_receive {:crdt_room_drain, ^old}, 1_000
+      assert Process.alive?(old), "the LRU must drain, not kill — a kill eats in-flight edits"
+    end
+
+    test "the most recently active room is left alone" do
+      old = spawn(fn -> Process.sleep(:infinity) end)
+      new = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Enum.each([old, new], &Process.exit(&1, :kill)) end)
+
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("new-note"))
+
+      CrdtRoomLru.touch("old-note", old)
+      Process.sleep(5)
+      CrdtRoomLru.touch("new-note", new)
+
+      CrdtRoomLru.sweep(1)
+
+      refute_receive {:crdt_room_drain, ^new}, 300
+    end
+
+    test "activity moves a room to the back of the eviction queue" do
+      a = spawn(fn -> Process.sleep(:infinity) end)
+      b = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Enum.each([a, b], &Process.exit(&1, :kill)) end)
+
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("b-note"))
+
+      CrdtRoomLru.touch("a-note", a)
+      Process.sleep(5)
+      CrdtRoomLru.touch("b-note", b)
+      Process.sleep(5)
+      # `a` is used again, so `b` becomes the least recently active.
+      CrdtRoomLru.touch("a-note", a)
+
+      CrdtRoomLru.sweep(1)
+
+      assert_receive {:crdt_room_drain, ^b}, 1_000
+    end
+
+    test "a dead room is pruned instead of counting toward the cap" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}, 1_000
+
+      live = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(live, :kill) end)
+
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("live-note"))
+
+      CrdtRoomLru.touch("dead-note", dead)
+      Process.sleep(5)
+      CrdtRoomLru.touch("live-note", live)
+
+      # Cap of 1 with one DEAD entry: pruning must satisfy the cap on its own,
+      # leaving the live room untouched. Counting corpses toward residency
+      # would evict healthy rooms to make room for memory nothing is using.
+      CrdtRoomLru.sweep(1)
+
+      refute_receive {:crdt_room_drain, ^live}, 300
+      assert CrdtRoomLru.resident_count() == 1
+    end
+  end
+end

--- a/test/engram/notes/crdt_room_lru_test.exs
+++ b/test/engram/notes/crdt_room_lru_test.exs
@@ -16,9 +16,11 @@ defmodule Engram.Notes.CrdtRoomLruTest do
 
   alias Engram.Notes.{CrdtRegistry, CrdtRoomLru}
 
+  @vault "vault-1"
+
   describe "select_evictions/2 (pure)" do
-    # Entries are {note_id, pid, last_activity_monotonic}; smaller = older.
-    defp entry(id, age), do: {id, self(), age}
+    # Entries are {note_id, pid, vault_id, last_activity_monotonic}; smaller = older.
+    defp entry(id, age), do: {id, self(), @vault, age}
 
     test "nothing is evicted while resident count is within the cap" do
       entries = [entry("a", 100), entry("b", 200)]
@@ -61,11 +63,11 @@ defmodule Engram.Notes.CrdtRoomLruTest do
       new = spawn(fn -> Process.sleep(:infinity) end)
       on_exit(fn -> Enum.each([old, new], &Process.exit(&1, :kill)) end)
 
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("old-note"))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(@vault))
 
-      CrdtRoomLru.touch("old-note", old)
+      CrdtRoomLru.touch("old-note", old, @vault)
       Process.sleep(5)
-      CrdtRoomLru.touch("new-note", new)
+      CrdtRoomLru.touch("new-note", new, @vault)
 
       CrdtRoomLru.sweep(1)
 
@@ -78,11 +80,11 @@ defmodule Engram.Notes.CrdtRoomLruTest do
       new = spawn(fn -> Process.sleep(:infinity) end)
       on_exit(fn -> Enum.each([old, new], &Process.exit(&1, :kill)) end)
 
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("new-note"))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(@vault))
 
-      CrdtRoomLru.touch("old-note", old)
+      CrdtRoomLru.touch("old-note", old, @vault)
       Process.sleep(5)
-      CrdtRoomLru.touch("new-note", new)
+      CrdtRoomLru.touch("new-note", new, @vault)
 
       CrdtRoomLru.sweep(1)
 
@@ -94,14 +96,14 @@ defmodule Engram.Notes.CrdtRoomLruTest do
       b = spawn(fn -> Process.sleep(:infinity) end)
       on_exit(fn -> Enum.each([a, b], &Process.exit(&1, :kill)) end)
 
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("b-note"))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(@vault))
 
-      CrdtRoomLru.touch("a-note", a)
+      CrdtRoomLru.touch("a-note", a, @vault)
       Process.sleep(5)
-      CrdtRoomLru.touch("b-note", b)
+      CrdtRoomLru.touch("b-note", b, @vault)
       Process.sleep(5)
       # `a` is used again, so `b` becomes the least recently active.
-      CrdtRoomLru.touch("a-note", a)
+      CrdtRoomLru.touch("a-note", a, @vault)
 
       CrdtRoomLru.sweep(1)
 
@@ -116,11 +118,11 @@ defmodule Engram.Notes.CrdtRoomLruTest do
       live = spawn(fn -> Process.sleep(:infinity) end)
       on_exit(fn -> Process.exit(live, :kill) end)
 
-      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic("live-note"))
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(@vault))
 
-      CrdtRoomLru.touch("dead-note", dead)
+      CrdtRoomLru.touch("dead-note", dead, @vault)
       Process.sleep(5)
-      CrdtRoomLru.touch("live-note", live)
+      CrdtRoomLru.touch("live-note", live, @vault)
 
       # Cap of 1 with one DEAD entry: pruning must satisfy the cap on its own,
       # leaving the live room untouched. Counting corpses toward residency

--- a/test/engram/prom_ex_registration_test.exs
+++ b/test/engram/prom_ex_registration_test.exs
@@ -1,0 +1,19 @@
+defmodule Engram.PromExRegistrationTest do
+  @moduledoc """
+  A PromEx plugin that emits telemetry but is not listed in `Engram.PromEx.plugins/0`
+  compiles, passes its own tests, and silently never reaches the scraped
+  `/metrics` endpoint. That is a bad failure mode for a counter whose whole job
+  is proving a memory-control feature works in production, so pin the wiring.
+  """
+  use ExUnit.Case, async: true
+
+  test "the CRDT room-drain plugin is actually registered" do
+    registered =
+      Enum.map(Engram.PromEx.plugins(), fn
+        {mod, _opts} -> mod
+        mod -> mod
+      end)
+
+    assert Engram.PromEx.Crdt in registered
+  end
+end

--- a/test/engram/runtime_config_test.exs
+++ b/test/engram/runtime_config_test.exs
@@ -19,6 +19,36 @@ defmodule Engram.RuntimeConfigTest do
     end
   end
 
+  describe "drain_overrides/0" do
+    # Pins the env var names and the NESTED config targets. These turn the #1152
+    # room drain ON in a CI stack — the only place it ever runs against a real
+    # client — so a typo silently reverts the e2e suite to never exercising it.
+    test "lists the CRDT room-drain levers with their module + key targets" do
+      assert RuntimeConfig.drain_overrides() == [
+               {"CRDT_IDLE_EXIT_MS", {Engram.Notes.CrdtCheckpointTimer, :idle_exit_ms}},
+               {"CRDT_MAX_RESIDENT_ROOMS", {Engram.Notes.CrdtRoomLru, :max_resident}}
+             ]
+    end
+
+    # The gate matters more here than for a rate limiter: a stray
+    # CRDT_IDLE_EXIT_MS reaching production would start draining rooms on a
+    # timer in a deployment that has never exercised that path.
+    for {var, _target} <- RuntimeConfig.drain_overrides() do
+      test "#{var} is ignored outside CI" do
+        assert RuntimeConfig.ci_gated_int_override(
+                 getenv(%{unquote(var) => "5000"}),
+                 unquote(var)
+               ) ==
+                 {:ignored, "5000"}
+      end
+
+      test "#{var} applies when CI=true" do
+        env = getenv(%{unquote(var) => "5000", "CI" => "true"})
+        assert RuntimeConfig.ci_gated_int_override(env, unquote(var)) == {:ok, 5000}
+      end
+    end
+  end
+
   describe "ci_gated_int_override/2" do
     # Run the full gating contract against every override so no limiter can
     # drift onto a different rule.

--- a/test/engram/runtime_config_test.exs
+++ b/test/engram/runtime_config_test.exs
@@ -26,8 +26,16 @@ defmodule Engram.RuntimeConfigTest do
     test "lists the CRDT room-drain levers with their module + key targets" do
       assert RuntimeConfig.drain_overrides() == [
                {"CRDT_IDLE_EXIT_MS", {Engram.Notes.CrdtCheckpointTimer, :idle_exit_ms}},
-               {"CRDT_MAX_RESIDENT_ROOMS", {Engram.Notes.CrdtRoomLru, :max_resident}}
+               {"CRDT_MAX_RESIDENT_ROOMS", {Engram.Notes.CrdtRoomLru, :max_resident}},
+               {"CRDT_LRU_SWEEP_MS", {Engram.Notes.CrdtRoomLru, :sweep_interval_ms}}
              ]
+    end
+
+    # The sweep interval is not optional trivia: it defaults to 30s and most e2e
+    # tests finish inside that, so capping residency WITHOUT lowering the sweep
+    # arms the LRU and never fires it — coverage that looks real and is not.
+    test "the sweep interval is overridable, not just the cap" do
+      assert {"CRDT_LRU_SWEEP_MS", {Engram.Notes.CrdtRoomLru, :sweep_interval_ms}} in RuntimeConfig.drain_overrides()
     end
 
     # The gate matters more here than for a rate limiter: a stray

--- a/test/engram_web/channels/crdt_channel_drain_test.exs
+++ b/test/engram_web/channels/crdt_channel_drain_test.exs
@@ -314,27 +314,67 @@ defmodule EngramWeb.CrdtChannelDrainTest do
     #   CLUSTER_TESTS=1 mix test test/engram_web/channels/crdt_channel_drain_test.exs
     @tag :cluster
     test "a room on ANOTHER node does not crash the channel" do
-      unless Node.alive?() do
-        {:ok, _} = :net_kernel.start([:"drainprimary@127.0.0.1", :longnames])
-        Node.set_cookie(:engram_drain_test)
-      end
+      # Engram.ClusterCase owns the net_kernel/cookie/code-path dance (and the
+      # start-not-start_link subtlety around on_exit) — no reason to re-roll it.
+      {_peer, peer_node} = Engram.ClusterCase.start_peer!([], &on_exit/1)
 
-      {:ok, peer, _node} =
-        :peer.start(%{
-          name: :crdt_drain_peer,
-          host: ~c"127.0.0.1",
-          longnames: true,
-          connection: :standard_io
-        })
-
-      on_exit(fn -> :peer.stop(peer) end)
-      true = :peer.call(peer, :erlang, :set_cookie, [Node.get_cookie()])
-
-      remote = :peer.call(peer, :erlang, :spawn, [:timer, :sleep, [60_000]])
+      remote = :erpc.call(peer_node, :erlang, :spawn, [:timer, :sleep, [60_000]])
       refute node(remote) == node()
 
-      # The bug this pins raises rather than exits, so a bare call is the test.
+      # The bug this pins RAISES rather than exits, so a bare call is the test:
+      # an ArgumentError from Process.alive?/1 is :error class and would blow
+      # straight through release_room/1's `catch :exit`.
       assert EngramWeb.CrdtChannel.release_room(remote) == :ok
+    end
+
+    # The `:cluster` test below proves this against a real peer but does NOT run
+    # in CI. This one covers the same guard on a single node by injecting the
+    # "self" node instead of faking a remote pid: with a mismatched node the
+    # check must short-circuit BEFORE Process.alive?/1, which is the local-only
+    # call that raises. Drop the node guard and this flips to true.
+    test "a pid whose node is not ours never reaches the local-only alive? check" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}, 1_000
+
+      refute EngramWeb.CrdtChannel.locally_dead?(dead, :somewhere@else)
+      assert EngramWeb.CrdtChannel.locally_dead?(dead), "sanity: locally it IS dead"
+    end
+
+    # Locks the `|| @room_probe_ms` reader. A key SET to nil is not the same as
+    # absent, and get_env/3's default would not fire — feeding `timeout: nil` to
+    # GenServer.call/3, which is how one sloppy test restore crashed every later
+    # test in this file.
+    test "a nil-valued probe override still yields a usable timeout" do
+      Application.put_env(:engram, :crdt_room_probe_ms, nil)
+      on_exit(fn -> Application.delete_env(:engram, :crdt_room_probe_ms) end)
+
+      wedged = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(wedged, :kill) end)
+
+      assert EngramWeb.CrdtChannel.release_room(wedged) == :ok
+    end
+
+    test "a skipped release is still counted, so ops can see rooms refusing to go" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}, 1_000
+
+      test_pid = self()
+      handler = "skip-telemetry-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:engram, :crdt, :room_drain],
+        fn _e, m, meta, _ -> send(test_pid, {:drain_telemetry, m, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      EngramWeb.CrdtChannel.release_room(dead)
+
+      assert_receive {:drain_telemetry, %{count: 1}, %{phase: :skipped}}, 1_000
     end
 
     test "a room that dies mid-call is swallowed rather than exiting the channel" do
@@ -377,6 +417,36 @@ defmodule EngramWeb.CrdtChannelDrainTest do
 
       assert MapSet.size(set) <= 10
     end
+  end
+
+  # Phoenix.PubSub does NOT dedupe: subscribing twice delivers twice. A room
+  # evicted by :DOWN (a crash) is never drained, so without unsubscribing on
+  # that path too its subscription survives and the next start_and_observe_room
+  # stacks a second one.
+  test "a crash-evicted room does not leave its drain subscription behind", ctx do
+    %{socket: socket, note: note} = ctx
+    {client, _room} = open_room(socket, note)
+    topic = CrdtRegistry.drain_topic(note.id)
+
+    # Counting via the Registry backing Phoenix.PubSub is the only way to
+    # observe a duplicate subscription (a doubled delivery is indistinguishable
+    # from a single one here, since the second drain finds an empty room_doc and
+    # no-ops). If PubSub ever stops being Registry-backed this raises rather
+    # than quietly passing, which is the acceptable direction for that coupling.
+    channel_subs = fn ->
+      Engram.PubSub
+      |> Registry.lookup(topic)
+      |> Enum.count(fn {pid, _} -> pid == socket.channel_pid end)
+    end
+
+    assert channel_subs.() == 1
+
+    # Crash-shaped eviction, then re-open: the re-subscribe must not stack.
+    room = CrdtRegistry.lookup(note.id)
+    send(socket.channel_pid, {:DOWN, make_ref(), :process, room, :crashed})
+    push_step1(socket, note, client)
+
+    assert channel_subs.() == 1, "duplicate subscription — every later drain would arrive twice"
   end
 
   test "a drain for a room this channel does not hold is ignored", ctx do

--- a/test/engram_web/channels/crdt_channel_drain_test.exs
+++ b/test/engram_web/channels/crdt_channel_drain_test.exs
@@ -1,0 +1,151 @@
+defmodule EngramWeb.CrdtChannelDrainTest do
+  @moduledoc """
+  The half of the #1152 room-lifetime model that can actually lose data.
+
+  A client edit is a `sync_update` frame, which y_ex dispatches as a
+  `GenServer.cast` (`deps/y_ex/lib/server/doc_server_worker.ex:26`). A cast to a
+  dead pid returns `:ok` and drops the frame — `crdt_channel.ex` says so at its
+  room monitor: "send_yjs_message casts to a dead pid return :ok and every
+  subsequent edit is silently dropped." Today that only happens on a crash. An
+  idle-exit would make it happen on a timer, on purpose, which is why the room
+  is drained (observers let go first) rather than stopped.
+
+  The drain closes the window by MESSAGE ORDERING, so these tests pin both
+  orderings. Both `push/3` and the drain are sent from the test process, so
+  Erlang's per-sender-pair FIFO guarantee makes the interleaving deterministic
+  rather than a race these tests would flake on.
+
+  Materialization is the assertion because it is the user-visible loss: if a
+  frame is cast into a corpse, no room ever applies it and nothing reaches the
+  row, no matter which checkpoint path runs.
+  """
+  use EngramWeb.ChannelCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Engram.{Crypto, Notes, Repo, Vaults}
+  alias Engram.Notes.{CrdtBridge, CrdtRegistry}
+
+  setup do
+    EngramWeb.RateLimiter.reset_buckets!()
+    on_exit(fn -> EngramWeb.RateLimiter.reset_buckets!() end)
+
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtChannelDrainTest"})
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "base"})
+
+    {:ok, _, socket} =
+      subscribe_and_join(
+        user_socket(user),
+        EngramWeb.CrdtChannel,
+        "crdt:#{user.id}:#{vault.id}",
+        %{"crdt_proto" => 2}
+      )
+
+    Sandbox.allow(Repo, self(), socket.channel_pid)
+
+    %{socket: socket, user: user, vault: vault, note: note}
+  end
+
+  # Drive the channel to start + observe the room, and hand back its pid.
+  defp open_room(socket, note) do
+    client = CrdtBridge.new_doc()
+    {:ok, {:sync_step1, sv}} = Yex.Sync.get_sync_step1(client)
+    {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
+
+    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => Base.encode64(frame)})
+    assert_push "crdt_msg", %{"doc_id" => _, "b64" => _}, 3_000
+
+    room = CrdtRegistry.lookup(note.id)
+    assert is_pid(room)
+    {client, room}
+  end
+
+  # A sync_update frame carrying `content` as the note's full plaintext.
+  defp edit_frame(client, content) do
+    :ok = CrdtBridge.ingest_plaintext(client, content)
+    {:ok, update} = Yex.encode_state_as_update(client)
+    {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_update, update}})
+    Base.encode64(frame)
+  end
+
+  defp assert_content_eventually(user, vault, note_id, needle, deadline \\ 3_000) do
+    stop = System.monotonic_time(:millisecond) + deadline
+
+    Stream.repeatedly(fn ->
+      case Notes.get_note_by_id(user, vault, note_id) do
+        {:ok, %{content: c}} when is_binary(c) -> c
+        _ -> ""
+      end
+    end)
+    |> Enum.reduce_while(nil, fn content, _ ->
+      cond do
+        content =~ needle -> {:halt, :ok}
+        System.monotonic_time(:millisecond) >= stop -> {:halt, {:error, content}}
+        true -> Process.sleep(25) && {:cont, nil}
+      end
+    end)
+    |> case do
+      :ok -> :ok
+      {:error, last} -> flunk("#{inspect(needle)} never materialized; last content: #{inspect(last)}")
+    end
+  end
+
+  test "an edit already queued when the drain lands is not lost", ctx do
+    %{socket: socket, user: user, vault: vault, note: note} = ctx
+    {client, room} = open_room(socket, note)
+
+    # [edit, drain] — the edit is ahead of the drain in the channel's mailbox,
+    # so it must be routed to the still-live room before the room is released.
+    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => edit_frame(client, "EDIT BEFORE DRAIN")})
+    send(socket.channel_pid, {:crdt_room_drain, room})
+
+    assert_content_eventually(user, vault, note.id, "EDIT BEFORE DRAIN")
+  end
+
+  test "an edit arriving after the drain re-spins a fresh room instead of casting into a corpse",
+       ctx do
+    %{socket: socket, user: user, vault: vault, note: note} = ctx
+    {client, room} = open_room(socket, note)
+
+    # [drain, edit] — the drain evicts the cached pid FIRST, so the edit behind
+    # it must re-resolve through ensure_room rather than cast at the dead room.
+    send(socket.channel_pid, {:crdt_room_drain, room})
+    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => edit_frame(client, "EDIT AFTER DRAIN")})
+
+    assert_content_eventually(user, vault, note.id, "EDIT AFTER DRAIN")
+
+    respun = CrdtRegistry.lookup(note.id)
+    assert is_pid(respun)
+    refute respun == room, "the edit must land on a NEW room, not the drained one"
+  end
+
+  test "a drain broadcast on the room's topic reaches the channel and releases the room", ctx do
+    %{socket: socket, note: note} = ctx
+    {_client, room} = open_room(socket, note)
+    ref = Process.monitor(room)
+
+    # The real wiring: the idle timer broadcasts, the channel is subscribed.
+    Phoenix.PubSub.broadcast(
+      Engram.PubSub,
+      CrdtRegistry.drain_topic(note.id),
+      {:crdt_room_drain, room}
+    )
+
+    # Channel was the only observer, so letting go trips auto_exit.
+    assert_receive {:DOWN, ^ref, :process, ^room, :normal}, 5_000
+  end
+
+  test "a drain for a room this channel does not hold is ignored", ctx do
+    %{socket: socket, user: user, vault: vault, note: note} = ctx
+    {client, room} = open_room(socket, note)
+
+    send(socket.channel_pid, {:crdt_room_drain, self()})
+
+    # The channel is still alive and still holding its real room.
+    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => edit_frame(client, "STILL WORKING")})
+    assert_content_eventually(user, vault, note.id, "STILL WORKING")
+    assert CrdtRegistry.lookup(note.id) == room
+  end
+end

--- a/test/engram_web/channels/crdt_channel_drain_test.exs
+++ b/test/engram_web/channels/crdt_channel_drain_test.exs
@@ -51,15 +51,23 @@ defmodule EngramWeb.CrdtChannelDrainTest do
   # Drive the channel to start + observe the room, and hand back its pid.
   defp open_room(socket, note) do
     client = CrdtBridge.new_doc()
+    push_step1(socket, note, client)
+
+    room = CrdtRegistry.lookup(note.id)
+    assert is_pid(room)
+    {client, room}
+  end
+
+  # A handshake, NOT an edit. Opens the room through ensure_room while changing
+  # no content — which matters for the announce tests: a content-changing
+  # checkpoint fires its own `crdt_doc_ready` (crdt_checkpoint.ex:213), so
+  # re-spinning with an edit makes the two announce sources indistinguishable.
+  defp push_step1(socket, note, client) do
     {:ok, {:sync_step1, sv}} = Yex.Sync.get_sync_step1(client)
     {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
 
     push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => Base.encode64(frame)})
     assert_push "crdt_msg", %{"doc_id" => _, "b64" => _}, 3_000
-
-    room = CrdtRegistry.lookup(note.id)
-    assert is_pid(room)
-    {client, room}
   end
 
   # A sync_update frame carrying `content` as the note's full plaintext.
@@ -87,8 +95,11 @@ defmodule EngramWeb.CrdtChannelDrainTest do
       end
     end)
     |> case do
-      :ok -> :ok
-      {:error, last} -> flunk("#{inspect(needle)} never materialized; last content: #{inspect(last)}")
+      :ok ->
+        :ok
+
+      {:error, last} ->
+        flunk("#{inspect(needle)} never materialized; last content: #{inspect(last)}")
     end
   end
 
@@ -98,7 +109,11 @@ defmodule EngramWeb.CrdtChannelDrainTest do
 
     # [edit, drain] — the edit is ahead of the drain in the channel's mailbox,
     # so it must be routed to the still-live room before the room is released.
-    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => edit_frame(client, "EDIT BEFORE DRAIN")})
+    push(socket, "crdt_msg", %{
+      "doc_id" => note.id,
+      "b64" => edit_frame(client, "EDIT BEFORE DRAIN")
+    })
+
     send(socket.channel_pid, {:crdt_room_drain, room})
 
     assert_content_eventually(user, vault, note.id, "EDIT BEFORE DRAIN")
@@ -112,13 +127,40 @@ defmodule EngramWeb.CrdtChannelDrainTest do
     # [drain, edit] — the drain evicts the cached pid FIRST, so the edit behind
     # it must re-resolve through ensure_room rather than cast at the dead room.
     send(socket.channel_pid, {:crdt_room_drain, room})
-    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => edit_frame(client, "EDIT AFTER DRAIN")})
+
+    push(socket, "crdt_msg", %{
+      "doc_id" => note.id,
+      "b64" => edit_frame(client, "EDIT AFTER DRAIN")
+    })
 
     assert_content_eventually(user, vault, note.id, "EDIT AFTER DRAIN")
 
     respun = CrdtRegistry.lookup(note.id)
     assert is_pid(respun)
     refute respun == room, "the edit must land on a NEW room, not the drained one"
+  end
+
+  # The whole point of the feature is bounding memory, so "did a room actually
+  # get released" has to be observable in prod, not just in a test.
+  test "a released room emits the telemetry ops needs to see the drain working", ctx do
+    %{socket: socket, note: note} = ctx
+    {_client, room} = open_room(socket, note)
+
+    test_pid = self()
+    handler = "drain-telemetry-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler,
+      [:engram, :crdt, :room_drain],
+      fn _e, measurements, meta, _ -> send(test_pid, {:drain_telemetry, measurements, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    send(socket.channel_pid, {:crdt_room_drain, room})
+
+    assert_receive {:drain_telemetry, %{count: 1}, %{phase: :released}}, 3_000
   end
 
   test "a drain broadcast on the room's topic reaches the channel and releases the room", ctx do
@@ -135,6 +177,206 @@ defmodule EngramWeb.CrdtChannelDrainTest do
 
     # Channel was the only observer, so letting go trips auto_exit.
     assert_receive {:DOWN, ^ref, :process, ^room, :normal}, 5_000
+  end
+
+  # The production shape: two devices on one note share ONE room, so the drain
+  # has to be handled by every observer and the exit must happen exactly once,
+  # on the last release. A drain that assumed a single observer would either
+  # strand the room (nobody else lets go) or exit it under a live observer.
+  test "a drain releases EVERY observer, and the room exits on the last one", ctx do
+    %{socket: socket_a, user: user, vault: vault, note: note} = ctx
+    {_client, room} = open_room(socket_a, note)
+
+    {:ok, _, socket_b} =
+      subscribe_and_join(
+        socket(EngramWeb.UserSocket, "user_#{user.id}_b", %{
+          current_user: user,
+          current_api_key: nil
+        }),
+        EngramWeb.CrdtChannel,
+        "crdt:#{user.id}:#{vault.id}",
+        %{"crdt_proto" => 2}
+      )
+
+    Sandbox.allow(Repo, self(), socket_b.channel_pid)
+    {_client_b, ^room} = open_room(socket_b, note)
+
+    ref = Process.monitor(room)
+
+    Phoenix.PubSub.broadcast(
+      Engram.PubSub,
+      CrdtRegistry.drain_topic(note.id),
+      {:crdt_room_drain, room}
+    )
+
+    assert_receive {:DOWN, ^ref, :process, ^room, :normal}, 5_000
+  end
+
+  # The announce is a DISCOVERY signal and recipients answer it with a
+  # syncStep1. A drain->edit->re-spin discovers nothing (every peer already
+  # heard about this note), so re-announcing would turn every drain cycle into a
+  # handshake fanned out to every other device on the vault — against @hs_limit
+  # here and the plugin's 240/10s crdt_msg budget, with handshake starvation
+  # being the documented trigger for the wrong-mint overwrite class.
+  test "a re-spin after a drain does NOT re-announce crdt_doc_ready", ctx do
+    %{socket: socket, note: note} = ctx
+    {client, room} = open_room(socket, note)
+
+    # The FIRST open announces — pin that, so this test cannot pass by the
+    # announce being broken outright.
+    assert_broadcast "crdt_doc_ready", %{"doc_id" => _}
+
+    send(socket.channel_pid, {:crdt_room_drain, room})
+    push_step1(socket, note, client)
+
+    refute_broadcast "crdt_doc_ready", %{"doc_id" => _}, 300
+  end
+
+  # Suppression is consumed once per drain, not latched: a crash-shaped
+  # eviction still announces, because THAT peer state is genuinely unknown.
+  test "only the drain-induced re-spin is suppressed, not every later open", ctx do
+    %{socket: socket, note: note} = ctx
+    {client, room} = open_room(socket, note)
+    assert_broadcast "crdt_doc_ready", %{"doc_id" => _}
+
+    # Drain -> re-spin is quiet.
+    send(socket.channel_pid, {:crdt_room_drain, room})
+    push_step1(socket, note, client)
+    refute_broadcast "crdt_doc_ready", %{"doc_id" => _}, 300
+
+    # Crash-shaped eviction (no drain recorded) -> announces again.
+    respun = CrdtRegistry.lookup(note.id)
+    send(socket.channel_pid, {:DOWN, make_ref(), :process, respun, :crashed})
+    push_step1(socket, note, client)
+    assert_broadcast "crdt_doc_ready", %{"doc_id" => _}, 3_000
+  end
+
+  # `SharedDoc.unobserve/1` is a GenServer.call with y_ex's 5 s default and no
+  # timeout knob, so a dead or wedged room would exit or stall the channel.
+  # These drive release_room/1 with PLAIN processes that simply do not reply —
+  # no y_ex message shapes encoded here, so the tests keep meaning across a dep
+  # bump. The responsive path is covered end-to-end by the drain tests above.
+  describe "release_room/1" do
+    defp elapsed_ms(fun) do
+      t0 = System.monotonic_time(:millisecond)
+      result = fun.()
+      {result, System.monotonic_time(:millisecond) - t0}
+    end
+
+    test "a room that already exited is a fast no-op, not a channel-killing exit" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}, 1_000
+
+      {result, ms} = elapsed_ms(fn -> EngramWeb.CrdtChannel.release_room(dead) end)
+
+      assert result == :ok
+      assert ms < 500, "a dead room should short-circuit, took #{ms}ms"
+    end
+
+    test "a wedged room is abandoned at the probe, not held for the 5s call default" do
+      # Assert against a SHORT configured probe rather than racing the 1s
+      # default on a loaded shared runner — the timing headroom is what keeps
+      # this from flaking.
+      # DELETE on restore when the key was previously unset. put_env(…, nil)
+      # would leave the key PRESENT with a nil value, which is not the same as
+      # absent — it poisoned every later test in this file with `timeout: nil`.
+      prev = Application.get_env(:engram, :crdt_room_probe_ms)
+      Application.put_env(:engram, :crdt_room_probe_ms, 100)
+
+      on_exit(fn ->
+        case prev do
+          nil -> Application.delete_env(:engram, :crdt_room_probe_ms)
+          v -> Application.put_env(:engram, :crdt_room_probe_ms, v)
+        end
+      end)
+
+      wedged = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(wedged, :kill) end)
+
+      {result, ms} = elapsed_ms(fn -> EngramWeb.CrdtChannel.release_room(wedged) end)
+
+      assert result == :ok
+      # The point: bounded by the probe, nowhere near y_ex's 5_000ms default.
+      assert ms < 1_000, "a wedged room stalled the channel for #{ms}ms"
+    end
+
+    # Rooms are `:global`-registered, so a channel on this node routinely
+    # observes a room on ANOTHER node. `Process.alive?/1` is local-only and
+    # raises ArgumentError on a remote pid — :error class, which the `catch
+    # :exit` in release_room/1 does NOT contain. Unguarded, every drain of a
+    # remote room crashes the channel, in a cluster that has been live in prod
+    # since 2026-06-23.
+    #
+    # NOTE: `:cluster` is excluded unless CLUSTER_TESTS=1, and nothing in CI
+    # sets it — so this does not currently gate a merge. It is still the only
+    # executable proof of the guard; run it with
+    #   CLUSTER_TESTS=1 mix test test/engram_web/channels/crdt_channel_drain_test.exs
+    @tag :cluster
+    test "a room on ANOTHER node does not crash the channel" do
+      unless Node.alive?() do
+        {:ok, _} = :net_kernel.start([:"drainprimary@127.0.0.1", :longnames])
+        Node.set_cookie(:engram_drain_test)
+      end
+
+      {:ok, peer, _node} =
+        :peer.start(%{
+          name: :crdt_drain_peer,
+          host: ~c"127.0.0.1",
+          longnames: true,
+          connection: :standard_io
+        })
+
+      on_exit(fn -> :peer.stop(peer) end)
+      true = :peer.call(peer, :erlang, :set_cookie, [Node.get_cookie()])
+
+      remote = :peer.call(peer, :erlang, :spawn, [:timer, :sleep, [60_000]])
+      refute node(remote) == node()
+
+      # The bug this pins raises rather than exits, so a bare call is the test.
+      assert EngramWeb.CrdtChannel.release_room(remote) == :ok
+    end
+
+    test "a room that dies mid-call is swallowed rather than exiting the channel" do
+      # Answers the probe, then exits before the unobserve can land.
+      dying =
+        spawn(fn ->
+          receive do
+            {:"$gen_call", from, _} -> GenServer.reply(from, :ok)
+          end
+
+          exit(:normal)
+        end)
+
+      assert EngramWeb.CrdtChannel.release_room(dying) == :ok
+    end
+  end
+
+  # assigns.drained holds a doc_id until its re-spin consumes it — but a note
+  # drained and never re-opened leaves one behind for the life of the socket,
+  # and @default_max_rooms bounds CONCURRENT rooms, not cumulative ones, while
+  # drain-churn is the intended steady state.
+  describe "remember_drained/3" do
+    test "accumulates entries below the cap" do
+      set =
+        Enum.reduce(1..5, MapSet.new(), &EngramWeb.CrdtChannel.remember_drained(&2, "d#{&1}", 10))
+
+      assert MapSet.size(set) == 5
+    end
+
+    # Overflow CLEARS rather than evicting: the degradation is only ever lost
+    # suppression (a re-spin announces, i.e. pre-drain behaviour), never
+    # incorrectness — so it needs no ordering bookkeeping.
+    test "clears at the cap instead of growing without bound" do
+      set =
+        Enum.reduce(
+          1..50,
+          MapSet.new(),
+          &EngramWeb.CrdtChannel.remember_drained(&2, "d#{&1}", 10)
+        )
+
+      assert MapSet.size(set) <= 10
+    end
   end
 
   test "a drain for a room this channel does not hold is ignored", ctx do

--- a/test/engram_web/channels/crdt_channel_drain_test.exs
+++ b/test/engram_web/channels/crdt_channel_drain_test.exs
@@ -164,14 +164,14 @@ defmodule EngramWeb.CrdtChannelDrainTest do
   end
 
   test "a drain broadcast on the room's topic reaches the channel and releases the room", ctx do
-    %{socket: socket, note: note} = ctx
+    %{socket: socket, vault: vault, note: note} = ctx
     {_client, room} = open_room(socket, note)
     ref = Process.monitor(room)
 
     # The real wiring: the idle timer broadcasts, the channel is subscribed.
     Phoenix.PubSub.broadcast(
       Engram.PubSub,
-      CrdtRegistry.drain_topic(note.id),
+      CrdtRegistry.drain_topic(vault.id),
       {:crdt_room_drain, room}
     )
 
@@ -205,7 +205,7 @@ defmodule EngramWeb.CrdtChannelDrainTest do
 
     Phoenix.PubSub.broadcast(
       Engram.PubSub,
-      CrdtRegistry.drain_topic(note.id),
+      CrdtRegistry.drain_topic(vault.id),
       {:crdt_room_drain, room}
     )
 
@@ -419,34 +419,37 @@ defmodule EngramWeb.CrdtChannelDrainTest do
     end
   end
 
-  # Phoenix.PubSub does NOT dedupe: subscribing twice delivers twice. A room
-  # evicted by :DOWN (a crash) is never drained, so without unsubscribing on
-  # that path too its subscription survives and the next start_and_observe_room
-  # stacks a second one.
-  test "a crash-evicted room does not leave its drain subscription behind", ctx do
-    %{socket: socket, note: note} = ctx
-    {client, _room} = open_room(socket, note)
-    topic = CrdtRegistry.drain_topic(note.id)
+  # The drain subscription is PER CONNECTION, not per room. Per-room cost a
+  # subscription for every note the enroll-everything client opens: measured at
+  # 309 bytes each, ~725 KB per socket on a 2400-note vault and ~707 MB per 1000
+  # such clients — against the same 1024 MB task whose memory this feature
+  # exists to protect. A correctness suite cannot catch that; only counting can.
+  test "opening many rooms adds no drain subscriptions — one per connection", ctx do
+    %{socket: socket, user: user, vault: vault, note: note} = ctx
+    topic = CrdtRegistry.drain_topic(vault.id)
 
-    # Counting via the Registry backing Phoenix.PubSub is the only way to
-    # observe a duplicate subscription (a doubled delivery is indistinguishable
-    # from a single one here, since the second drain finds an empty room_doc and
-    # no-ops). If PubSub ever stops being Registry-backed this raises rather
-    # than quietly passing, which is the acceptable direction for that coupling.
+    # Counting via the Registry backing Phoenix.PubSub. If PubSub ever stops
+    # being Registry-backed this raises rather than quietly passing, which is
+    # the acceptable direction for that coupling.
     channel_subs = fn ->
       Engram.PubSub
       |> Registry.lookup(topic)
       |> Enum.count(fn {pid, _} -> pid == socket.channel_pid end)
     end
 
-    assert channel_subs.() == 1
+    assert channel_subs.() == 1, "the connection subscribes once, at join"
 
-    # Crash-shaped eviction, then re-open: the re-subscribe must not stack.
-    room = CrdtRegistry.lookup(note.id)
-    send(socket.channel_pid, {:DOWN, make_ref(), :process, room, :crashed})
-    push_step1(socket, note, client)
+    {_client, _room} = open_room(socket, note)
 
-    assert channel_subs.() == 1, "duplicate subscription — every later drain would arrive twice"
+    for n <- 1..5 do
+      {:ok, extra} =
+        Notes.upsert_note(user, vault, %{"path" => "n#{n}.md", "content" => "x"})
+
+      push_step1(socket, extra, CrdtBridge.new_doc())
+    end
+
+    assert channel_subs.() == 1,
+           "subscriptions must not scale with rooms opened — that is the memory bug"
   end
 
   test "a drain for a room this channel does not hold is ignored", ctx do


### PR DESCRIPTION
## Summary

- Implements the room-lifetime model for #1152 (under the engram-workspace#167 p0). **Opt-in via `idle_exit_ms`, `nil` for every note room — inert in production.** #1150's index room enables it with one keyword.
- **#1152's literal wording is unsafe and is NOT what this does.** It asks for "a timer that exits with observers still attached". A client edit is a `sync_update`, which y_ex dispatches as a `GenServer.cast` (`deps/y_ex/lib/server/doc_server_worker.ex:26`) — a cast to a dead pid returns `:ok` and drops the frame. `crdt_channel.ex` already warns about this at its room monitor; today it only happens on a crash, but an idle-exit would do it on a timer, on purpose. So rooms are **drained**: the timer asks observers to let go, they evict their cached pid and unobserve, and the LAST unobserve trips the `auto_exit` that already exists → `terminate/2` → `unbind` → checkpoint. Nothing new does the exiting, and the race closes by **mailbox ordering** — a frame ahead of the drain reached a live room, one behind it re-resolves a fresh one.
- About half of #1152 turned out to be already-shipped machinery: checkpoint-on-exit (`unbind`), pool safety under a fleet drain (`CheckpointGate` + Oban overflow), client re-spin (`ensure_room`), and the start race (`observe_with_retry`).

Beyond the issue, two properties `auto_exit` gave us free that a timer does not:

- **Spread** — `auto_exit` follows user behaviour; idle timers armed at room *start* fire in lockstep after a deploy or reconnect storm (the 2026-07-09 pool-exhaustion shape). `jittered_drain_delay/1` adds up to 25%, **additive only**: `idle_exit_ms` is a floor, and shortening it would drain rooms that were not idle long enough.
- **A bound** — the channel must remember released doc_ids so the re-spin stays quiet, and `@default_max_rooms` bounds *concurrent* rooms, not cumulative. `remember_drained/3` caps it, clearing on overflow (worst case is lost suppression = pre-drain behaviour, never incorrectness).

Also suppresses the `crdt_doc_ready` re-announce on a drain-induced re-spin. The announce is a **discovery** signal and peers answer it with a syncStep1; making re-spin routine would fan a handshake out of every device on the vault, against `@hs_limit` and the plugin's 240/10s budget — and handshake starvation is the documented trigger for the wrong-mint overwrite class. Crash re-spins still announce, since that peer state is genuinely unknown.

**Observability:** `[:engram, :crdt, :room_drain]` → `engram_prom_ex_crdt_room_drain_total`, phases `requested | reasked | released | skipped`. `released` tracking `requested` is the signal the drain works at all; without it #1152's "resident room count bounded under a soak" is unverifiable in prod.

Design rationale and every trap below live in `docs/context/crdt-room-lifetime-and-drain.md`.

## Notable traps this hit

- **`Process.alive?/1` is local-only** and raises `ArgumentError` (`:error` class, so a `catch :exit` does NOT contain it) on a remote pid. Rooms are `:global`, so channels hold remote room pids routinely — unguarded, this crashed the channel on **every drain of a remote room**, in a cluster live in prod since 2026-06-23.
- **`unobserve/1` is a `GenServer.call` with no timeout knob.** `release_room/1` guards dead → skip, unresponsive (`update_doc/3` probe — public API that *does* take a timeout) → skip, else unobserve. Skipping a wedged room loses nothing: `auto_exit` runs off the room's own bookkeeping anyway.
- **`Phoenix.PubSub` does not dedupe subscriptions**, so the `:DOWN` path must unsubscribe too or every later drain arrives twice.
- **`CrdtCheckpoint` announces `crdt_doc_ready` too** (`crdt_checkpoint.ex:213`), so announce tests must re-spin with a syncStep1, never an edit, or the two sources are indistinguishable.

## Test plan

- [x] `mix format` + `mix credo --strict` (0 issues) + `mix test --warnings-as-errors` (**4368 tests, 0 failures**) + `mix dialyzer` (passed) — each exit code captured separately, not piped
- [x] Both mailbox orderings pinned (`[edit, drain]`, `[drain, edit]`), driven from the test process so per-sender FIFO makes them deterministic rather than a race
- [x] Multi-observer release; exit happens once, on the last release
- [x] Announce suppression proven in **both** directions (suppressed on drain, still fires on a crash re-spin)
- [x] `release_room/1` dead / wedged / dies-mid-call, using plain non-replying processes so no y_ex message shapes leak into the suite
- [x] Remote-pid guard covered on a single node via `locally_dead?/2` node injection, **plus** a `:cluster` peer-node test
- [x] Pure tests with injected clocks for `idle?/2`, `drain_delay/1`, `jittered_drain_delay/1`, `remember_drained/3`
- [x] Telemetry `:requested` / `:released` / `:skipped`, and that the PromEx plugin is actually registered
- [x] Flake hunt: the one timing test that failed under CPU contention (7/10) was root-caused to a 2× margin and re-verified **0/8 under identical load** — not a rerun-pass

## Known gaps

- The **resident-room LRU** (#1152's third bullet) is being added to this PR next.
- This proves residency is *bounded*, **not** that the bound is right — the 7.91 MB/10k-note figure belongs to an index doc that does not exist until #1150.
- **Do not** close the cluster-coverage gap by adding `CLUSTER_TESTS=1` to the `unit-tests` job. Measured on this branch: without it 4368 tests / 0 failures, with it 4371 / **1 failure in an unrelated test** (`FanoutPacerTest`) — `ClusterCase` starts a second `Phoenix.PubSub` under the same name on the peer and connects the nodes, so the pg group spans both. A separate `--only cluster` job is the workable shape (green 5/5 in isolation).

Refs #1152, #1150, #1146, engram-app/engram-workspace#167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz