### PR TITLE
fix(ci): build the image cache on disk, not in a 4GB tmpfs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4598,17 +4598,25 @@ jobs:
       # node-compile caches other jobs leave in /tmp and the export ran out of
       # space mid-push: "no space left on device" AFTER 89s of pushing layers,
       # which cancels the whole build. The root filesystem had 35GB free the
-      # entire time. runner.workspace is on that disk, and — being per-runner —
+      # entire time. RUNNER_TEMP is on that disk, and — being per-runner —
       # it also stops two concurrent image builds on one VM from sharing a
       # single fixed cache path.
+      #
+      # runner.temp, not runner.workspace: the latter is undocumented (the
+      # runner context exposes name/os/arch/temp/tool_cache/debug/environment)
+      # and an empty expansion here would silently aim the cache at /buildx-cache.
+      # This job only runs on a main PUSH, so it cannot be proven on the PR —
+      # which is exactly when you take the documented spelling. On these
+      # runners RUNNER_TEMP is <runner>/_work/_temp: per-runner, and on the
+      # ext4 root with 34GB free.
       - name: Restore buildx cache
         if: steps.version.outputs.image_exists != 'true'
         uses: runs-on/cache@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
         with:
-          path: ${{ runner.workspace }}/buildx-cache
+          path: ${{ runner.temp }}/buildx-cache
           # v2: the cached archive records the absolute path it was saved
-          # from, so the /tmp -> workspace move needs a new key rather than a
-          # restore that half-lands. Costs exactly one cold build.
+          # from, so moving off /tmp needs a new key rather than a restore
+          # that half-lands. Costs exactly one cold build.
           key: buildx-v2-${{ runner.os }}-${{ hashFiles('Dockerfile', 'mix.lock', 'frontend/bun.lock') }}
           restore-keys: |
             buildx-v2-${{ runner.os }}-
@@ -4629,8 +4637,8 @@ jobs:
           provenance: false
           sbom: false
           platforms: linux/amd64
-          cache-from: type=local,src=${{ runner.workspace }}/buildx-cache
-          cache-to: type=local,dest=${{ runner.workspace }}/buildx-cache-new,mode=max
+          cache-from: type=local,src=${{ runner.temp }}/buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/buildx-cache-new,mode=max
           tags: ${{ steps.version.outputs.tags }}
           build-args: |
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
@@ -4652,9 +4660,9 @@ jobs:
       - name: Rotate buildx cache
         if: steps.version.outputs.image_exists != 'true' && always()
         run: |
-          if [ -d "${{ runner.workspace }}/buildx-cache-new" ]; then
-            rm -rf "${{ runner.workspace }}/buildx-cache"
-            mv "${{ runner.workspace }}/buildx-cache-new" "${{ runner.workspace }}/buildx-cache"
+          if [ -d "${{ runner.temp }}/buildx-cache-new" ]; then
+            rm -rf "${{ runner.temp }}/buildx-cache"
+            mv "${{ runner.temp }}/buildx-cache-new" "${{ runner.temp }}/buildx-cache"
           fi
 
       # Lift SENTRY_AUTH_TOKEN into a step output so the next two steps

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4592,14 +4592,26 @@ jobs:
       # same ~10 Mbps ceiling. Restore AND save must move together (an S3
       # save paired with a GitHub restore is a guaranteed miss); they are the
       # same action plus its post step, so swapping the `uses:` moves both.
+      # NOT /tmp: on the self-hosted runners /tmp is a 4GB RAM-backed tmpfs,
+      # and this scheme deliberately holds TWO copies of a ~1.2GB cache at
+      # once (src + dest, swapped after the build). Add the ~600MB of bunx /
+      # node-compile caches other jobs leave in /tmp and the export ran out of
+      # space mid-push: "no space left on device" AFTER 89s of pushing layers,
+      # which cancels the whole build. The root filesystem had 35GB free the
+      # entire time. runner.workspace is on that disk, and — being per-runner —
+      # it also stops two concurrent image builds on one VM from sharing a
+      # single fixed cache path.
       - name: Restore buildx cache
         if: steps.version.outputs.image_exists != 'true'
         uses: runs-on/cache@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
         with:
-          path: /tmp/buildx-cache
-          key: buildx-${{ runner.os }}-${{ hashFiles('Dockerfile', 'mix.lock', 'frontend/bun.lock') }}
+          path: ${{ runner.workspace }}/buildx-cache
+          # v2: the cached archive records the absolute path it was saved
+          # from, so the /tmp -> workspace move needs a new key rather than a
+          # restore that half-lands. Costs exactly one cold build.
+          key: buildx-v2-${{ runner.os }}-${{ hashFiles('Dockerfile', 'mix.lock', 'frontend/bun.lock') }}
           restore-keys: |
-            buildx-${{ runner.os }}-
+            buildx-v2-${{ runner.os }}-
 
       # ONE build, pushed to GHCR (3 tags) + ECR (1-2 tags). Buildx pushes
       # layers per-registry but the underlying build runs once. Sentry
@@ -4617,8 +4629,8 @@ jobs:
           provenance: false
           sbom: false
           platforms: linux/amd64
-          cache-from: type=local,src=/tmp/buildx-cache
-          cache-to: type=local,dest=/tmp/buildx-cache-new,mode=max
+          cache-from: type=local,src=${{ runner.workspace }}/buildx-cache
+          cache-to: type=local,dest=${{ runner.workspace }}/buildx-cache-new,mode=max
           tags: ${{ steps.version.outputs.tags }}
           build-args: |
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
@@ -4640,9 +4652,9 @@ jobs:
       - name: Rotate buildx cache
         if: steps.version.outputs.image_exists != 'true' && always()
         run: |
-          if [ -d /tmp/buildx-cache-new ]; then
-            rm -rf /tmp/buildx-cache
-            mv /tmp/buildx-cache-new /tmp/buildx-cache
+          if [ -d "${{ runner.workspace }}/buildx-cache-new" ]; then
+            rm -rf "${{ runner.workspace }}/buildx-cache"
+            mv "${{ runner.workspace }}/buildx-cache-new" "${{ runner.workspace }}/buildx-cache"
           fi
 
       # Lift SENTRY_AUTH_TOKEN into a step output so the next two steps


### PR DESCRIPTION
## Why

`build-and-publish-image` failed on `main` (`6ca95aa4`) with `no space left on device`, **after** 89s of successfully pushing layers — the cache export blew up and cancelled the whole build. That blocks the 0.16.0 release: no image in ECR means a release tag would roll ECS onto an image that does not exist.

## Root cause

`/tmp` on the runner VM is a **4GB RAM-backed tmpfs**, set explicitly in `/etc/fstab` (`tmpfs /tmp tmpfs defaults,size=4G,...`):

```
/dev/mapper/ubuntu--vg-ubuntu--lv   76G   38G   35G  52% /
tmpfs                              4.0G  2.0G  2.1G  50% /tmp
```

The cache scheme deliberately keeps **two** copies of a ~1.2GB export at once (`src` + `dest`, swapped after the build), and **five runners** (`runner-1` … `runner-5`) share that single 4GB `/tmp`, where other jobs leave their own caches:

```
1.2G  /tmp/buildx-cache
229M  /tmp/bunx-1001-wrangler@latest
167M  /tmp/bunx-1001-@lhci
127M  /tmp/node-compile-cache
```

That is the 4GB. The root filesystem had 35GB free the entire time.

Not transient — it recurs on every cache-key miss and gets likelier as the image grows. A re-run is not a fix.

## Change

- Both cache paths move to `${{ runner.temp }}` (`<runner>/_work/_temp`), which is on the 76GB ext4 root.
- That path is **per-runner**, so it also removes a latent collision: five runners previously shared one fixed `/tmp/buildx-cache`. This workflow already documents that hazard for `PREV_DIR` ("concurrent runs share the host /tmp… one job's `rm -rf` yank another's worktree mid-run").
- Cache key gets a `v2-` prefix — the archive records the absolute path it was saved from, so moving off `/tmp` needs a fresh key rather than a restore that half-lands. Costs exactly one cold build.

## Verification — read this before merging

**This cannot be proven on the PR.** `build-and-publish-image` is gated on `github.ref == 'refs/heads/main' && github.event_name == 'push'`, so it does not run here. (An earlier version of this description claimed otherwise — that was wrong.)

That constraint is why the change uses `runner.temp` rather than `runner.workspace`: `runner.workspace` is not in the documented runner context, and an empty expansion would silently aim the cache at `/buildx-cache`. `runner.temp` is documented and verified on the box to resolve to a per-runner directory on the big disk.

The real verification is the main push after merge. If it fails, the blast radius is the same as today (no image published, no tag cut).

## Not in this PR

`/tmp/buildx-cache` on `runner-1` is now orphaned and holds 1.2GB of RAM until cleaned. The broader question — whether a 4GB RAM `/tmp` shared by five runners is the right shape at all — is worth a separate look.