### PR TITLE
fix(privacy): security + privacy audit remediation (web app)

### DIFF
--- a/.github/workflows/frontend-promote.yml
+++ b/.github/workflows/frontend-promote.yml
@@ -76,6 +76,9 @@ jobs:
           # committed frontend/.env.production; only these two are injected.
           VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY_PROD }}
           VITE_GIT_SHA: ${{ env.SHA }}
+          # Must match deploy-frontend exactly or this "byte-identical" rebuild
+          # would silently produce a bundle with crash reporting switched off.
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |

--- a/.github/workflows/frontend-promote.yml
+++ b/.github/workflows/frontend-promote.yml
@@ -79,6 +79,9 @@ jobs:
           # Must match deploy-frontend exactly or this "byte-identical" rebuild
           # would silently produce a bundle with crash reporting switched off.
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_FRONTEND }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4662,11 +4662,11 @@ jobs:
             # so it never moves on a non-release deploy. Same full 40-char
             # SHA the frontend and Sentry use, so all three agree.
             RELEASE_SHA=${{ github.sha }}
-            SENTRY_ORG=${{ vars.SENTRY_ORG }}
-            SENTRY_PROJECT=${{ vars.SENTRY_PROJECT_FRONTEND }}
+            # No SENTRY_ORG / SENTRY_PROJECT / sentry_auth_token either: this
+            # bundle no longer carries a DSN, so it emits no events, and
+            # uploading its source maps would spend the token on artifacts
+            # nothing will ever match. Both halves move to the SaaS build.
             HEX_MIRROR=${{ env.HEX_MIRROR }}
-          secrets: |
-            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
 
       # Atomically swap new cache over old. actions/cache@v6 has no built-in
       # rotation; without this step the cache grows unbounded across runs.
@@ -5221,6 +5221,14 @@ jobs:
           # user at all, so we send strictly less than that. URLs and console /
           # DOM breadcrumbs are scrubbed in sentry.ts before send.
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          # Symbolication follows the DSN. vite.config.ts gates the upload on
+          # `disable: !sentryAuthToken` and then deletes every *.map, so a build
+          # with a DSN and no token reports crashes as
+          # `at t (index-9f3a1c.js:1:48392)` — a stack with no frames, for the
+          # release the events are tagged with.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_FRONTEND }}
 
       - name: Upload frontend version (nightly, zero-traffic)
         working-directory: frontend

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5213,6 +5213,14 @@ jobs:
           # by design (ships in the browser), so a variable not a secret.
           VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY_PROD }}
           VITE_GIT_SHA: ${{ github.sha }}
+          # Sentry. The SaaS bundle reported NOWHERE while the self-host image
+          # shipped this same DSN — exactly backwards from the intent stated in
+          # sentry.ts and the Dockerfile. Disclosed in the privacy policy's
+          # sub-processor table ("Error monitoring and crash reporting | Error
+          # stack traces with PII scrubbing; user ID only"), and the SDK sets no
+          # user at all, so we send strictly less than that. URLs and console /
+          # DOM breadcrumbs are scrubbed in sentry.ts before send.
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
 
       - name: Upload frontend version (nightly, zero-traffic)
         working-directory: frontend

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4641,7 +4641,20 @@ jobs:
           cache-to: type=local,dest=${{ runner.temp }}/buildx-cache-new,mode=max
           tags: ${{ steps.version.outputs.tags }}
           build-args: |
-            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
+            # VITE_SENTRY_DSN is deliberately NOT passed. This image runs
+            # `bun run build:selfhost`, and the bundle it produces is what a
+            # SELF-HOSTER serves. Baking the SaaS DSN in meant every self-hosted
+            # browser reported crashes — with URLs, and therefore note paths — to
+            # our Sentry, from the one deployment whose whole promise is that
+            # data stays on the operator's own infrastructure. Nobody opted in.
+            # The Dockerfile already states this rule for its siblings
+            # ("so self-host bundles don't ship the SaaS-side token"); Sentry was
+            # the exception that slipped.
+            #
+            # Cost: staging-fastraid, which runs this same image, loses browser
+            # crash reporting. Backend Sentry is unaffected. Giving staging its
+            # reporting back means serving the DSN at RUNTIME (so the operator
+            # chooses) rather than baking it at build time.
             VITE_GIT_SHA=${{ github.sha }}
             # Backend counterpart to VITE_GIT_SHA. Baked into the image so
             # /api/health can report what code is actually running: `version`

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,12 @@ FROM oven/bun:1.3 AS frontend
 #       the browser.
 #   VITE_GIT_SHA    — release tag used by Sentry to symbolicate stack
 #       traces against the right source-map upload.
-#   SENTRY_ORG / SENTRY_PROJECT — used by @sentry/vite-plugin to
-#       address the right project when uploading source maps.
+# The image build deliberately does NOT take SENTRY_ORG / SENTRY_PROJECT /
+# SENTRY_AUTH_TOKEN: without an auth token @sentry/vite-plugin is disabled,
+# so this image uploads no source maps and ships none. Source-map upload is
+# the SaaS bundle's job (verify.yml + frontend-promote.yml).
 ARG VITE_SENTRY_DSN
 ARG VITE_GIT_SHA
-ARG SENTRY_ORG
-ARG SENTRY_PROJECT
 # Cloudflare Web Analytics beacon — public per-site identifier.
 # Build-arg so self-host bundles don't ship the SaaS-side token.
 ARG VITE_CF_BEACON_TOKEN
@@ -47,8 +47,6 @@ ARG VITE_POSTHOG_KEY
 ARG VITE_POSTHOG_HOST
 ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN} \
     VITE_GIT_SHA=${VITE_GIT_SHA} \
-    SENTRY_ORG=${SENTRY_ORG} \
-    SENTRY_PROJECT=${SENTRY_PROJECT} \
     VITE_CF_BEACON_TOKEN=${VITE_CF_BEACON_TOKEN} \
     VITE_POSTHOG_KEY=${VITE_POSTHOG_KEY} \
     VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}

--- a/config/config.exs
+++ b/config/config.exs
@@ -210,15 +210,19 @@ config :phoenix, :json_library, Jason
 # Filtered here rather than with `log: false` on the socket: this is the one
 # place every param-logging path routes through (Plug.Logger, socket connect,
 # any socket added later), so a new socket inherits the filter instead of
-# needing to remember the flag. Matching is substring-on-key, so "token"
-# also covers access_token / refresh_token / device_code-bearing keys.
+# needing to remember the flag.
+#
+# Matching is String.contains?/2 on the KEY (phoenix/logger.ex), not equality,
+# so each entry is a substring: "token" covers access_token / refresh_token,
+# and "code" covers device_code / user_code / code_verifier / code_challenge.
+# The RFC 8628 device code redeems into both tokens, so it is a bearer
+# credential in its own right for its 300s life — an earlier version of this
+# list claimed "token" covered it, which was wrong.
 config :phoenix, :filter_parameters, [
   "password",
   "token",
   "secret",
-  "code_verifier",
-  "code_challenge",
-  "client_secret",
+  "code",
   "authorization"
 ]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -203,6 +203,25 @@ config :logger, :default_formatter,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Phoenix logs socket connect params verbatim ("CONNECTED TO ... Parameters:
+# %{...}") at :info, and its default filter is ["password"] only — so the raw
+# WS auth token was printed on every connect, into CloudWatch and Loki.
+#
+# Filtered here rather than with `log: false` on the socket: this is the one
+# place every param-logging path routes through (Plug.Logger, socket connect,
+# any socket added later), so a new socket inherits the filter instead of
+# needing to remember the flag. Matching is substring-on-key, so "token"
+# also covers access_token / refresh_token / device_code-bearing keys.
+config :phoenix, :filter_parameters, [
+  "password",
+  "token",
+  "secret",
+  "code_verifier",
+  "code_challenge",
+  "client_secret",
+  "authorization"
+]
+
 # Key provider defaults (overridden by runtime.exs via env vars)
 config :engram,
   key_provider: Engram.Crypto.KeyProvider.Local,

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -35,6 +35,12 @@
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
-  Referrer-Policy: strict-origin-when-cross-origin
+  # `origin`, not `strict-origin-when-cross-origin`: the latter sends the FULL
+  # URL on same-origin requests, and credentials arrive here in URLs —
+  # /link?code= and /reset-password?token=. Every same-origin fetch made while
+  # one is still in the address bar (including the lazy route chunk, which
+  # loads BEFORE the page can scrub it) carried it into the edge access log.
+  # `origin` sends the scheme+host and nothing else, everywhere.
+  Referrer-Policy: origin
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(self "https://*.paddle.com")
   Content-Security-Policy-Report-Only: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' https://clerk.engram.page https://*.clerk.accounts.dev https://cdn.paddle.com https://*.paddle.com https://us-assets.i.posthog.com https://static.cloudflareinsights.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; worker-src 'self' blob:; connect-src 'self' https://api.engram.page https://clerk.engram.page https://*.clerk.accounts.dev https://us.i.posthog.com https://us-assets.i.posthog.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.paddle.com https://cloudflareinsights.com; frame-src 'self' https://*.paddle.com https://clerk.engram.page https://challenges.cloudflare.com

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -143,8 +143,15 @@ export const api = {
 		return res.json();
 	},
 
-	async del<T>(path: string): Promise<T> {
-		const res = await authFetch(path, { method: "DELETE" });
+	// DELETE takes an optional body. Not decorative: the account-delete flow
+	// needs to send a password, and a credential in a query string is written
+	// to every access log between the browser and Phoenix — plus Sentry's fetch
+	// breadcrumbs, which capture the URL.
+	async del<T>(path: string, body?: unknown): Promise<T> {
+		const res = await authFetch(path, {
+			method: "DELETE",
+			body: body === undefined ? undefined : JSON.stringify(body),
+		});
 		// 204 No Content is the conventional REST response for DELETE; tolerate
 		// empty bodies so callers don't have to differentiate.
 		if (res.status === 204 || res.headers.get("content-length") === "0") {

--- a/frontend/src/api/delete-self-credential.test.ts
+++ b/frontend/src/api/delete-self-credential.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The account-delete password must ride the request BODY.
+ *
+ * It used to be `DELETE /me?password=hunter2`, which is written to Phoenix's
+ * access log, the load balancer's, every proxy in between, browser history, and
+ * Sentry's fetch breadcrumb — a credential the user typed into a confirm
+ * dialog, spread across three log stores.
+ *
+ * The backend test that came with the fix does NOT pin this: `UsersController`
+ * reads Phoenix's merged body+query params, so it accepted a body before the
+ * change and still accepts a query string now. Reverting the frontend to the
+ * query form leaves the whole Elixir suite green. This is the test that fails.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authFetchMock } = vi.hoisted(() => ({ authFetchMock: vi.fn() }));
+
+// Partial mock: other modules in this import graph pull real exports off
+// `./base` (tracing flags), so replacing the whole module breaks them.
+vi.mock("./base", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./base")>()),
+	getApiBase: () => "https://api.engram.test",
+}));
+
+// The client's own fetch wrapper is the seam: assert on what reaches it.
+vi.stubGlobal("fetch", authFetchMock);
+
+beforeEach(() => {
+	authFetchMock.mockReset();
+	authFetchMock.mockResolvedValue({
+		ok: true,
+		status: 204,
+		headers: new Headers({ "content-length": "0" }),
+		json: async () => ({}),
+	});
+});
+
+describe("api.del carries a body", () => {
+	it("sends the payload as the request body, leaving the URL bare", async () => {
+		const { api } = await import("./client");
+
+		await api.del("/me", { password: "hunter2" });
+
+		const [url, init] = authFetchMock.mock.calls[0] ?? [];
+		expect(String(url)).not.toContain("hunter2");
+		expect(String(url)).not.toContain("password=");
+		expect(init?.method).toBe("DELETE");
+		expect(String(init?.body)).toContain("hunter2");
+	});
+
+	// The other three del() callers pass nothing; a body of `undefined` must
+	// stay a no-op rather than becoming the string "undefined".
+	it("sends no body when none is given", async () => {
+		const { api } = await import("./client");
+
+		await api.del("/connections/7");
+
+		const [, init] = authFetchMock.mock.calls[0] ?? [];
+		expect(init?.body).toBeUndefined();
+	});
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1123,7 +1123,11 @@ export function useUpdateProfile() {
 export function useDeleteSelf() {
 	return useMutation<void, Error, { password: string }>({
 		mutationFn: async ({ password }) => {
-			await api.del<void>(`/me?password=${encodeURIComponent(password)}`);
+			// Body, never the query string: a password in a URL lands in Phoenix's
+			// and the load balancer's access logs, in browser history, and in
+			// Sentry's fetch breadcrumb — none of which the user consented to
+			// when they typed it into a confirm dialog.
+			await api.del<void>("/me", { password });
 		},
 	});
 }

--- a/frontend/src/auth/credential-handoff.test.ts
+++ b/frontend/src/auth/credential-handoff.test.ts
@@ -54,6 +54,21 @@ describe("credential handoff", () => {
 		expect(takeCredential("code", "/link")).toBe("");
 	});
 
+	// React-router matches `/link/` and `/Link` to `path="/link"` but leaves
+	// `pathname` as written. The stash side reads location.pathname; the page
+	// names its own route. Without normalization those disagree and the code is
+	// dropped silently — and unrecoverably, since a rejected stash is removed.
+	it.each(["/link/", "/Link", "/LINK/"])("matches %s against /link", (arrival) => {
+		stashCredential("code", "ENGR-7X4K", arrival);
+		expect(takeCredential("code", "/link")).toBe("ENGR-7X4K");
+	});
+
+	// Normalizing must not make unrelated paths collide.
+	it("still rejects a genuinely different path", () => {
+		stashCredential("code", "ENGR-7X4K", "/linkedin");
+		expect(takeCredential("code", "/link")).toBe("");
+	});
+
 	// A tab left open across a deploy holds a stash written by the old build:
 	// a bare string with no stamp. Unverifiable means dropped — the user
 	// retypes, which is what they did before any of this existed.

--- a/frontend/src/auth/credential-handoff.test.ts
+++ b/frontend/src/auth/credential-handoff.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The sign-in handoff for URL-borne credentials.
+ *
+ * Stripping the device code and the reset token out of `return_to` kept them
+ * out of the address bar, history, and Clerk — and broke both flows, because
+ * the destination page read them from the URL that no longer had them. The
+ * signed-out arrival is the COMMON case for `/link`: the plugin opens
+ * `verification_uri_complete` for someone who has never signed in to that
+ * browser.
+ *
+ * sessionStorage carries them across instead: per-tab, dies with the tab, never
+ * sent with a request, never in history.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { stashCredential, stashCredentialsFrom, takeCredential } from "./credential-handoff";
+import { signInRedirectTarget } from "./sign-in-redirect";
+
+beforeEach(() => {
+	window.sessionStorage.clear();
+});
+
+describe("credential handoff", () => {
+	it("round-trips a value", () => {
+		stashCredential("code", "ENGR-7X4K");
+		expect(takeCredential("code")).toBe("ENGR-7X4K");
+	});
+
+	// Read-once: a credential must not outlive the flow it belongs to.
+	it("deletes on read", () => {
+		stashCredential("code", "ENGR-7X4K");
+		takeCredential("code");
+		expect(takeCredential("code")).toBe("");
+	});
+
+	it("returns empty for something never stashed", () => {
+		expect(takeCredential("token")).toBe("");
+	});
+
+	it("picks credentials out of a query string and ignores the rest", () => {
+		stashCredentialsFrom("?code=ENGR-7X4K&ref=newsletter");
+		expect(takeCredential("code")).toBe("ENGR-7X4K");
+		expect(takeCredential("ref")).toBe("");
+	});
+});
+
+describe("the redirect hands the credential over before stripping it", () => {
+	// The regression this exists for: strip-only meant a first-time linker
+	// landed on a bare /link with nothing prefilled, i.e. the retyping that
+	// RFC 8628's complete URL exists to avoid.
+	it("keeps the device code available after it leaves the URL", () => {
+		const target = signInRedirectTarget({
+			pathname: "/link",
+			search: "?code=ENGR-7X4K",
+			hash: "",
+		});
+
+		expect(target).not.toContain("ENGR-7X4K");
+		expect(takeCredential("code")).toBe("ENGR-7X4K");
+	});
+
+	it("does the same for a password-reset token", () => {
+		const target = signInRedirectTarget({
+			pathname: "/reset-password",
+			search: "?token=abc123secret",
+			hash: "",
+		});
+
+		expect(target).not.toContain("abc123secret");
+		expect(takeCredential("token")).toBe("abc123secret");
+	});
+
+	it("stashes nothing when there is no credential", () => {
+		signInRedirectTarget({ pathname: "/note/abc", search: "", hash: "" });
+		expect(takeCredential("code")).toBe("");
+		expect(takeCredential("token")).toBe("");
+	});
+});

--- a/frontend/src/auth/credential-handoff.test.ts
+++ b/frontend/src/auth/credential-handoff.test.ts
@@ -58,10 +58,13 @@ describe("credential handoff", () => {
 	// `pathname` as written. The stash side reads location.pathname; the page
 	// names its own route. Without normalization those disagree and the code is
 	// dropped silently — and unrecoverably, since a rejected stash is removed.
-	it.each(["/link/", "/Link", "/LINK/"])("matches %s against /link", (arrival) => {
-		stashCredential("code", "ENGR-7X4K", arrival);
-		expect(takeCredential("code", "/link")).toBe("ENGR-7X4K");
-	});
+	it.each(["/link/", "/Link", "/LINK/", "/link//", "/Link///"])(
+		"matches %s against /link",
+		(arrival) => {
+			stashCredential("code", "ENGR-7X4K", arrival);
+			expect(takeCredential("code", "/link")).toBe("ENGR-7X4K");
+		},
+	);
 
 	// Normalizing must not make unrelated paths collide.
 	it("still rejects a genuinely different path", () => {

--- a/frontend/src/auth/credential-handoff.test.ts
+++ b/frontend/src/auth/credential-handoff.test.ts
@@ -21,25 +21,51 @@ beforeEach(() => {
 
 describe("credential handoff", () => {
 	it("round-trips a value", () => {
-		stashCredential("code", "ENGR-7X4K");
-		expect(takeCredential("code")).toBe("ENGR-7X4K");
+		stashCredential("code", "ENGR-7X4K", "/link");
+		expect(takeCredential("code", "/link")).toBe("ENGR-7X4K");
 	});
 
 	// Read-once: a credential must not outlive the flow it belongs to.
 	it("deletes on read", () => {
-		stashCredential("code", "ENGR-7X4K");
-		takeCredential("code");
-		expect(takeCredential("code")).toBe("");
+		stashCredential("code", "ENGR-7X4K", "/link");
+		takeCredential("code", "/link");
+		expect(takeCredential("code", "/link")).toBe("");
 	});
 
 	it("returns empty for something never stashed", () => {
-		expect(takeCredential("token")).toBe("");
+		expect(takeCredential("token", "/reset-password")).toBe("");
+	});
+
+	// The stale-handoff bug. Abandon sign-in from /link?code=A, then reach
+	// /link again later in the same tab from the onboarding wizard's Obsidian
+	// branch — which wants an EMPTY input to type a fresh code into. The old
+	// code was consumed, prefilled, and auto-verified straight into "This code
+	// is invalid or has expired."
+	it("refuses a credential captured on a different path", () => {
+		stashCredential("code", "OLDX-CODE", "/link");
+		expect(takeCredential("code", "/reset-password")).toBe("");
+	});
+
+	// Rejecting still consumes: the page that just refused it is the only
+	// reader, so leaving it would surface it again on the next navigation.
+	it("drops a rejected credential rather than leaving it to resurface", () => {
+		stashCredential("code", "OLDX-CODE", "/link");
+		takeCredential("code", "/reset-password");
+		expect(takeCredential("code", "/link")).toBe("");
+	});
+
+	// A tab left open across a deploy holds a stash written by the old build:
+	// a bare string with no stamp. Unverifiable means dropped — the user
+	// retypes, which is what they did before any of this existed.
+	it("drops an unstamped stash from a previous build", () => {
+		window.sessionStorage.setItem("engram:handoff:code", "ENGR-7X4K");
+		expect(takeCredential("code", "/link")).toBe("");
 	});
 
 	it("picks credentials out of a query string and ignores the rest", () => {
-		stashCredentialsFrom("?code=ENGR-7X4K&ref=newsletter");
-		expect(takeCredential("code")).toBe("ENGR-7X4K");
-		expect(takeCredential("ref")).toBe("");
+		stashCredentialsFrom("?code=ENGR-7X4K&ref=newsletter", "/link");
+		expect(takeCredential("code", "/link")).toBe("ENGR-7X4K");
+		expect(takeCredential("ref", "/link")).toBe("");
 	});
 });
 
@@ -55,7 +81,7 @@ describe("the redirect hands the credential over before stripping it", () => {
 		});
 
 		expect(target).not.toContain("ENGR-7X4K");
-		expect(takeCredential("code")).toBe("ENGR-7X4K");
+		expect(takeCredential("code", "/link")).toBe("ENGR-7X4K");
 	});
 
 	it("does the same for a password-reset token", () => {
@@ -66,12 +92,20 @@ describe("the redirect hands the credential over before stripping it", () => {
 		});
 
 		expect(target).not.toContain("abc123secret");
-		expect(takeCredential("token")).toBe("abc123secret");
+		expect(takeCredential("token", "/reset-password")).toBe("abc123secret");
 	});
 
 	it("stashes nothing when there is no credential", () => {
 		signInRedirectTarget({ pathname: "/note/abc", search: "", hash: "" });
-		expect(takeCredential("code")).toBe("");
-		expect(takeCredential("token")).toBe("");
+		expect(takeCredential("code", "/note/abc")).toBe("");
+		expect(takeCredential("token", "/note/abc")).toBe("");
+	});
+
+	// `code` is a generic param — OAuth callbacks and promo links use it too.
+	// Only the device-link page reads it, so a `code` captured anywhere else
+	// must not reach it.
+	it("does not hand a code captured elsewhere to the device-link page", () => {
+		signInRedirectTarget({ pathname: "/some-vault", search: "?code=PROMO123", hash: "" });
+		expect(takeCredential("code", "/link")).toBe("");
 	});
 });

--- a/frontend/src/auth/credential-handoff.ts
+++ b/frontend/src/auth/credential-handoff.ts
@@ -15,8 +15,24 @@
  *
  * sessionStorage is the handoff. It is per-tab, dies with the tab, is not sent
  * with any request, and never enters history — so the credential survives the
- * redirect it has to survive, and nothing else. Read-once: `take` deletes on
- * read, so a code cannot linger after the flow it belongs to.
+ * redirect it has to survive, and nothing else. `take` deletes on read.
+ *
+ * Read-once is not the same as short-lived, and the reset token is the
+ * exception: ResetPasswordPage puts it BACK after reading, because a user who
+ * mistypes and reloads twice would otherwise be stranded with no way forward
+ * but re-opening the email. So an ABANDONED reset leaves its token in
+ * sessionStorage for the life of the tab. That is a deliberate trade against
+ * the address bar, which is worse in every way — history, Referer, and every
+ * Sentry event — but it means "cannot linger" holds for the device code and
+ * not for the token. The token is cleared the moment the reset succeeds.
+ *
+ * Each stash is STAMPED with the path it was captured on, and `take` returns
+ * nothing on a mismatch. Without that, a stash outlives its flow: abandon
+ * sign-in from `/link?code=A`, reach `/link` later in the same tab from the
+ * onboarding wizard, and the dead code is consumed, prefilled, and
+ * auto-verified into "This code is invalid or has expired." It also keeps a
+ * generic `code` param — OAuth callbacks, promo links — from being handed to
+ * the device-link page, which is the only reader of `code`.
  */
 
 const PREFIX = "engram:handoff:";
@@ -24,39 +40,51 @@ const PREFIX = "engram:handoff:";
 /** Query params that are credentials rather than navigation state. */
 export const CREDENTIAL_PARAMS = ["code", "token"] as const;
 
-export function stashCredential(name: string, value: string): void {
+export function stashCredential(name: string, value: string, pathname: string): void {
 	if (typeof window === "undefined" || !value) {
 		return;
 	}
 	try {
-		window.sessionStorage.setItem(PREFIX + name, value);
+		window.sessionStorage.setItem(PREFIX + name, JSON.stringify({ value, pathname }));
 	} catch {
 		// Storage disabled or full. The user retypes the code; losing the flow
 		// entirely would be worse than the inconvenience.
 	}
 }
 
-/** Read and remove. Returns "" when absent. */
-export function takeCredential(name: string): string {
+/** Read and remove. Returns "" when absent, or when the credential was
+ *  captured on a different path than `pathname`. Removes either way — a stash
+ *  the wrong page just rejected has no other consumer, and leaving it would let
+ *  it surface again on the next navigation. */
+export function takeCredential(name: string, pathname: string): string {
 	if (typeof window === "undefined") {
 		return "";
 	}
 	try {
-		const value = window.sessionStorage.getItem(PREFIX + name) ?? "";
+		const raw = window.sessionStorage.getItem(PREFIX + name);
 		window.sessionStorage.removeItem(PREFIX + name);
-		return value;
+		if (!raw) {
+			return "";
+		}
+		// A plain string is a stash written by the previous build, still in a
+		// tab that was open across the deploy. Unstamped means unverifiable,
+		// so drop it: the user retypes, which is what they did before any of
+		// this existed.
+		const parsed = JSON.parse(raw) as { value?: string; pathname?: string };
+		return parsed?.pathname === pathname ? (parsed.value ?? "") : "";
 	} catch {
 		return "";
 	}
 }
 
-/** Stash every credential param present in `search`, before it is stripped. */
-export function stashCredentialsFrom(search: string): void {
+/** Stash every credential param present in `search`, before it is stripped,
+ *  stamped with the path it arrived on. */
+export function stashCredentialsFrom(search: string, pathname: string): void {
 	const params = new URLSearchParams(search);
 	for (const name of CREDENTIAL_PARAMS) {
 		const value = params.get(name);
 		if (value) {
-			stashCredential(name, value);
+			stashCredential(name, value, pathname);
 		}
 	}
 }

--- a/frontend/src/auth/credential-handoff.ts
+++ b/frontend/src/auth/credential-handoff.ts
@@ -37,6 +37,18 @@
 
 const PREFIX = "engram:handoff:";
 
+/** Paths compare after normalization, because the two sides read it from
+ *  different places: the stash side takes `location.pathname` verbatim, while
+ *  the consuming page names its own route (`ROUTES.DEVICE_LINK`). React-router
+ *  matches `/link/` and `/Link` to `path="/link"` but leaves `pathname` as
+ *  written, so an arrival at `/link/?code=…` stashed under `/link/`, failed to
+ *  match `/link`, and the code was dropped — silently, and unrecoverably,
+ *  since a rejected stash is also removed. */
+function normalizePath(pathname: string): string {
+	const lower = pathname.toLowerCase();
+	return lower.length > 1 && lower.endsWith("/") ? lower.slice(0, -1) : lower;
+}
+
 /** Query params that are credentials rather than navigation state. */
 export const CREDENTIAL_PARAMS = ["code", "token"] as const;
 
@@ -45,7 +57,10 @@ export function stashCredential(name: string, value: string, pathname: string): 
 		return;
 	}
 	try {
-		window.sessionStorage.setItem(PREFIX + name, JSON.stringify({ value, pathname }));
+		window.sessionStorage.setItem(
+			PREFIX + name,
+			JSON.stringify({ value, pathname: normalizePath(pathname) }),
+		);
 	} catch {
 		// Storage disabled or full. The user retypes the code; losing the flow
 		// entirely would be worse than the inconvenience.
@@ -71,7 +86,7 @@ export function takeCredential(name: string, pathname: string): string {
 		// so drop it: the user retypes, which is what they did before any of
 		// this existed.
 		const parsed = JSON.parse(raw) as { value?: string; pathname?: string };
-		return parsed?.pathname === pathname ? (parsed.value ?? "") : "";
+		return parsed?.pathname === normalizePath(pathname) ? (parsed.value ?? "") : "";
 	} catch {
 		return "";
 	}

--- a/frontend/src/auth/credential-handoff.ts
+++ b/frontend/src/auth/credential-handoff.ts
@@ -1,0 +1,62 @@
+/**
+ * Carry a URL-borne credential across a sign-in redirect without putting it in
+ * the URL.
+ *
+ * Two credentials arrive as query params: the RFC 8628 device code on `/link`
+ * (the plugin opens `verification_uri_complete`) and the password-reset token.
+ * Both used to ride `return_to` through the sign-in page and on to Clerk as
+ * `forceRedirectUrl`, so they sat in the address bar, in history, and in the
+ * Referer of every same-origin request for the whole login journey.
+ *
+ * Stripping them from `return_to` fixed that and broke the flow: a signed-out
+ * user arriving from the plugin — the COMMON case, since they have never signed
+ * in to that browser — landed back on a bare `/link` with nothing prefilled,
+ * which is the retyping the complete URL exists to avoid.
+ *
+ * sessionStorage is the handoff. It is per-tab, dies with the tab, is not sent
+ * with any request, and never enters history — so the credential survives the
+ * redirect it has to survive, and nothing else. Read-once: `take` deletes on
+ * read, so a code cannot linger after the flow it belongs to.
+ */
+
+const PREFIX = "engram:handoff:";
+
+/** Query params that are credentials rather than navigation state. */
+export const CREDENTIAL_PARAMS = ["code", "token"] as const;
+
+export function stashCredential(name: string, value: string): void {
+	if (typeof window === "undefined" || !value) {
+		return;
+	}
+	try {
+		window.sessionStorage.setItem(PREFIX + name, value);
+	} catch {
+		// Storage disabled or full. The user retypes the code; losing the flow
+		// entirely would be worse than the inconvenience.
+	}
+}
+
+/** Read and remove. Returns "" when absent. */
+export function takeCredential(name: string): string {
+	if (typeof window === "undefined") {
+		return "";
+	}
+	try {
+		const value = window.sessionStorage.getItem(PREFIX + name) ?? "";
+		window.sessionStorage.removeItem(PREFIX + name);
+		return value;
+	} catch {
+		return "";
+	}
+}
+
+/** Stash every credential param present in `search`, before it is stripped. */
+export function stashCredentialsFrom(search: string): void {
+	const params = new URLSearchParams(search);
+	for (const name of CREDENTIAL_PARAMS) {
+		const value = params.get(name);
+		if (value) {
+			stashCredential(name, value);
+		}
+	}
+}

--- a/frontend/src/auth/credential-handoff.ts
+++ b/frontend/src/auth/credential-handoff.ts
@@ -45,8 +45,14 @@ const PREFIX = "engram:handoff:";
  *  match `/link`, and the code was dropped — silently, and unrecoverably,
  *  since a rejected stash is also removed. */
 function normalizePath(pathname: string): string {
-	const lower = pathname.toLowerCase();
-	return lower.length > 1 && lower.endsWith("/") ? lower.slice(0, -1) : lower;
+	// ALL trailing slashes, not one: `/link//` stripped once is still `/link/`,
+	// which misses `/link` and drops the code silently — the same failure this
+	// function exists to prevent, one slash further out.
+	let path = pathname.toLowerCase();
+	while (path.length > 1 && path.endsWith("/")) {
+		path = path.slice(0, -1);
+	}
+	return path;
 }
 
 /** Query params that are credentials rather than navigation state. */

--- a/frontend/src/auth/sign-in-redirect.test.ts
+++ b/frontend/src/auth/sign-in-redirect.test.ts
@@ -18,3 +18,51 @@ describe("signInRedirectTarget", () => {
 		).toBe("/sign-in?return_to=%2Fsettings%3Ftab%3Dbilling%23plan");
 	});
 });
+
+describe("credentials never ride the return_to", () => {
+	// The plugin sends users to /link?code=ENGR-7X4K. A signed-out arrival is
+	// redirected first, and return_to is handed to Clerk as forceRedirectUrl —
+	// so without stripping, the single-use device code sits in the address bar
+	// and in history for the whole login round trip, and goes to a third party
+	// on the way. The /link page's own address-bar scrub runs far too late to
+	// matter here: it only fires once the user is already signed in.
+	it("strips a device code from the preserved destination", () => {
+		const target = signInRedirectTarget({
+			pathname: "/link",
+			search: "?code=ENGR-7X4K",
+			hash: "",
+		});
+
+		expect(target).not.toContain("ENGR");
+		expect(target).not.toContain("code");
+		expect(decodeURIComponent(target)).toContain("/link");
+	});
+
+	// Same class: the reset token is the credential, and the page itself calls
+	// it that.
+	it("strips a password-reset token", () => {
+		const target = signInRedirectTarget({
+			pathname: "/reset-password",
+			search: "?token=abc123secret",
+			hash: "",
+		});
+
+		expect(target).not.toContain("abc123secret");
+		expect(decodeURIComponent(target)).toContain("/reset-password");
+	});
+
+	// Navigation state is not a credential — dropping it would lose the user's
+	// place for no gain.
+	it("keeps ordinary params", () => {
+		const target = signInRedirectTarget({
+			pathname: "/link",
+			search: "?code=SECRET&ref=newsletter",
+			hash: "#top",
+		});
+
+		const decoded = decodeURIComponent(target);
+		expect(decoded).toContain("ref=newsletter");
+		expect(decoded).toContain("#top");
+		expect(decoded).not.toContain("SECRET");
+	});
+});

--- a/frontend/src/auth/sign-in-redirect.ts
+++ b/frontend/src/auth/sign-in-redirect.ts
@@ -1,4 +1,5 @@
 import { ROUTES } from "../routes";
+import { CREDENTIAL_PARAMS, stashCredentialsFrom } from "./credential-handoff";
 
 // Build the sign-in URL for a signed-out user, preserving where they were
 // headed as an encoded `return_to` so the post-login redirect lands them
@@ -6,23 +7,25 @@ import { ROUTES } from "../routes";
 //
 // Shared by AuthGuard (protected routes) and CatchAllRoute (unknown paths)
 // so the two redirect surfaces can't drift apart.
-/** Query params that are credentials, not navigation state.
+/** Where to send a signed-out user, with credentials taken out of the URL.
  *
- *  `return_to` is round-tripped through the sign-in page and handed to Clerk
- *  as `forceRedirectUrl`, so anything in it survives in the address bar and in
- *  browser history for the whole login journey — and rides along to a third
- *  party. `/link?code=` (RFC 8628 device code) and `/reset-password?token=`
- *  are both single-use credentials that arrive by URL, so both would otherwise
- *  make that trip. Strip them: the destination is worth preserving, the
- *  credential is not, and a user who lands back on `/link` without a prefilled
- *  code simply types it, which is the flow that existed before. */
-const CREDENTIAL_PARAMS = ["code", "token"];
-
+ *  `return_to` is round-tripped through the sign-in page and handed to Clerk as
+ *  `forceRedirectUrl`, so anything in it sits in the address bar and in history
+ *  for the whole login journey, and goes to a third party on the way. The
+ *  device code (`/link?code=`) and the password-reset token both arrive that
+ *  way, so both are stripped — and stashed first, per credential-handoff, so
+ *  the destination page still gets them. */
 export function signInRedirectTarget(location: {
 	pathname: string;
 	search: string;
 	hash: string;
 }): string {
+	// Hand the credential to sessionStorage BEFORE stripping it, so the
+	// destination page can still use it. Done here rather than at the two call
+	// sites because this function is the single seam every sign-in redirect
+	// passes through — a third caller would otherwise silently drop the code.
+	stashCredentialsFrom(location.search);
+
 	const params = new URLSearchParams(location.search);
 	for (const key of CREDENTIAL_PARAMS) {
 		params.delete(key);

--- a/frontend/src/auth/sign-in-redirect.ts
+++ b/frontend/src/auth/sign-in-redirect.ts
@@ -6,12 +6,29 @@ import { ROUTES } from "../routes";
 //
 // Shared by AuthGuard (protected routes) and CatchAllRoute (unknown paths)
 // so the two redirect surfaces can't drift apart.
+/** Query params that are credentials, not navigation state.
+ *
+ *  `return_to` is round-tripped through the sign-in page and handed to Clerk
+ *  as `forceRedirectUrl`, so anything in it survives in the address bar and in
+ *  browser history for the whole login journey — and rides along to a third
+ *  party. `/link?code=` (RFC 8628 device code) and `/reset-password?token=`
+ *  are both single-use credentials that arrive by URL, so both would otherwise
+ *  make that trip. Strip them: the destination is worth preserving, the
+ *  credential is not, and a user who lands back on `/link` without a prefilled
+ *  code simply types it, which is the flow that existed before. */
+const CREDENTIAL_PARAMS = ["code", "token"];
+
 export function signInRedirectTarget(location: {
 	pathname: string;
 	search: string;
 	hash: string;
 }): string {
-	const returnTo = location.pathname + location.search + location.hash;
+	const params = new URLSearchParams(location.search);
+	for (const key of CREDENTIAL_PARAMS) {
+		params.delete(key);
+	}
+	const search = params.toString();
+	const returnTo = location.pathname + (search ? `?${search}` : "") + location.hash;
 	return returnTo && returnTo !== ROUTES.HOME
 		? `${ROUTES.SIGN_IN}?return_to=${encodeURIComponent(returnTo)}`
 		: ROUTES.SIGN_IN;

--- a/frontend/src/auth/sign-in-redirect.ts
+++ b/frontend/src/auth/sign-in-redirect.ts
@@ -24,7 +24,7 @@ export function signInRedirectTarget(location: {
 	// destination page can still use it. Done here rather than at the two call
 	// sites because this function is the single seam every sign-in redirect
 	// passes through — a third caller would otherwise silently drop the code.
-	stashCredentialsFrom(location.search);
+	stashCredentialsFrom(location.search, location.pathname);
 
 	const params = new URLSearchParams(location.search);
 	for (const key of CREDENTIAL_PARAMS) {

--- a/frontend/src/auth/use-wipe-crdt-on-user-change.test.ts
+++ b/frontend/src/auth/use-wipe-crdt-on-user-change.test.ts
@@ -34,3 +34,33 @@ describe("useWipeCrdtOnUserChange", () => {
 		expect(wipe).not.toHaveBeenCalled();
 	});
 });
+
+describe("search history is cleared with the same edge", () => {
+	// Recent searches are the user's own words ("severance agreement lawyer"),
+	// stored in localStorage under a key with no user in it and no expiry. On a
+	// shared machine the next person to open the search panel read them.
+	it("clears recent searches on sign-out", () => {
+		window.localStorage.setItem("engram:recent-searches", JSON.stringify(["severance lawyer"]));
+
+		const { rerender } = renderHook(
+			({ id }: { id: string | undefined }) => useWipeCrdtOnUserChange(id),
+			{ initialProps: { id: "u1" as string | undefined } },
+		);
+		rerender({ id: undefined });
+
+		expect(window.localStorage.getItem("engram:recent-searches")).toBeNull();
+	});
+
+	// A token refresh does not change the user id, so history must survive it —
+	// clearing on every render would look like the feature was broken.
+	it("keeps them while the same user stays signed in", () => {
+		window.localStorage.setItem("engram:recent-searches", JSON.stringify(["quarterly report"]));
+
+		const { rerender } = renderHook(({ id }) => useWipeCrdtOnUserChange(id), {
+			initialProps: { id: "u1" },
+		});
+		rerender({ id: "u1" });
+
+		expect(window.localStorage.getItem("engram:recent-searches")).toContain("quarterly report");
+	});
+});

--- a/frontend/src/auth/use-wipe-crdt-on-user-change.ts
+++ b/frontend/src/auth/use-wipe-crdt-on-user-change.ts
@@ -16,8 +16,10 @@ export function useWipeCrdtOnUserChange(userId: string | undefined): void {
 		}
 		if (prevRef.current !== undefined) {
 			// Search terms are the user's words and were surviving sign-out in
-			// localStorage under a key with no owner. Synchronous and cheap, so it
-			// goes first — an interrupted sign-out should not leave them behind.
+			// localStorage under a key with no owner. First and synchronous: the
+			// wipe below is async, so ordering only matters if the wipe throws
+			// SYNCHRONOUSLY, which .catch() would not catch. Cheap insurance on a
+			// sign-out path.
 			clearRecent();
 			wipeCrdtIndexedDb().catch((e) => console.warn("CRDT IndexedDB wipe failed", e));
 		}

--- a/frontend/src/auth/use-wipe-crdt-on-user-change.ts
+++ b/frontend/src/auth/use-wipe-crdt-on-user-change.ts
@@ -15,11 +15,11 @@ export function useWipeCrdtOnUserChange(userId: string | undefined): void {
 			return;
 		}
 		if (prevRef.current !== undefined) {
-			wipeCrdtIndexedDb().catch((e) => console.warn("CRDT IndexedDB wipe failed", e));
 			// Search terms are the user's words and were surviving sign-out in
 			// localStorage under a key with no owner. Synchronous and cheap, so it
-			// runs first — an interrupted sign-out should not leave them behind.
+			// goes first — an interrupted sign-out should not leave them behind.
 			clearRecent();
+			wipeCrdtIndexedDb().catch((e) => console.warn("CRDT IndexedDB wipe failed", e));
 		}
 		prevRef.current = userId;
 	}, [userId]);

--- a/frontend/src/auth/use-wipe-crdt-on-user-change.ts
+++ b/frontend/src/auth/use-wipe-crdt-on-user-change.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from "react";
 import { wipeCrdtIndexedDb } from "../crdt/idb-wipe";
+import { clearRecent } from "../layout/recent-searches";
 
-/** Delete all CRDT IndexedDB content when the authenticated user changes
+/** Delete all CRDT IndexedDB content — and the local search history — when the
+ *  authenticated user changes
  *  (switch or logout). Mirrors useClearQueryCacheOnUserChange: skips first
  *  mount, fires on any subsequent identity change. Fire-and-forget — the
  *  channel teardown (useChannel cleanup → stopCrdtSession) closes live DB
@@ -14,6 +16,10 @@ export function useWipeCrdtOnUserChange(userId: string | undefined): void {
 		}
 		if (prevRef.current !== undefined) {
 			wipeCrdtIndexedDb().catch((e) => console.warn("CRDT IndexedDB wipe failed", e));
+			// Search terms are the user's words and were surviving sign-out in
+			// localStorage under a key with no owner. Synchronous and cheap, so it
+			// runs first — an interrupted sign-out should not leave them behind.
+			clearRecent();
 		}
 		prevRef.current = userId;
 	}, [userId]);

--- a/frontend/src/crdt/idb-wipe.test.ts
+++ b/frontend/src/crdt/idb-wipe.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { forgetCrdtDbs, knownCrdtDbs, rememberCrdtDb } from "./idb-registry";
 import { wipeCrdtIndexedDb } from "./idb-wipe";
 import { CRDT_IDB_PREFIX } from "./manager";
+import { QUEUE_DB_NAME } from "./op-queue-persist";
 
 /** Collects deleteDatabase calls; every request succeeds on the first attempt. */
 function stubIndexedDb(opts: { enumerate?: string[] | null }): string[] {
@@ -51,7 +52,11 @@ describe("wipeCrdtIndexedDb", () => {
 			},
 		});
 		await wipeCrdtIndexedDb();
-		expect(deleted).toEqual([`${CRDT_IDB_PREFIX}v1/notes/a.md`, `${CRDT_IDB_PREFIX}v2/notes/b.md`]);
+		// The queue DB is always in the set — it is named, not discovered, because
+		// its name falls outside the prefix this sweep matches.
+		expect(deleted.sort()).toEqual(
+			[`${CRDT_IDB_PREFIX}v1/notes/a.md`, `${CRDT_IDB_PREFIX}v2/notes/b.md`, QUEUE_DB_NAME].sort(),
+		);
 	});
 
 	// #873. This used to assert a NO-OP, which was the bug: on Firefox <126 the
@@ -67,7 +72,7 @@ describe("wipeCrdtIndexedDb", () => {
 		const deleted = stubIndexedDb({ enumerate: null });
 		await wipeCrdtIndexedDb();
 
-		expect(deleted.sort()).toEqual([a, b].sort());
+		expect(deleted.sort()).toEqual([a, b, QUEUE_DB_NAME].sort());
 	});
 
 	// Neither source is complete on its own: enumeration sees docs written by a
@@ -84,7 +89,7 @@ describe("wipeCrdtIndexedDb", () => {
 		const deleted = stubIndexedDb({ enumerate: [onlyEnumerated, both, "clerk-telemetry"] });
 		await wipeCrdtIndexedDb();
 
-		expect(deleted.sort()).toEqual([onlyEnumerated, onlyRemembered, both].sort());
+		expect(deleted.sort()).toEqual([onlyEnumerated, onlyRemembered, both, QUEUE_DB_NAME].sort());
 		// "clerk-telemetry" is same-origin but not ours.
 		expect(deleted).not.toContain("clerk-telemetry");
 		// Exactly once each, despite `both` appearing in two sources.
@@ -145,11 +150,14 @@ describe("wipeCrdtIndexedDb", () => {
 			deleteDatabase: (name: string) => {
 				attempts.push(name);
 				const req: Record<string, unknown> = {};
-				if (attempts.length === 1) {
-					// First call: fire onblocked
+				// Keyed on the NAME, not the call index: the wipe deletes the
+				// op-queue database in the same pass, so "first call" is no longer
+				// this database.
+				const firstTryOfTarget =
+					name === DB_NAME && attempts.filter((n) => n === DB_NAME).length === 1;
+				if (firstTryOfTarget) {
 					queueMicrotask(() => (req.onblocked as () => void)?.());
 				} else {
-					// Second call: succeed
 					queueMicrotask(() => (req.onsuccess as () => void)?.());
 				}
 				return req;
@@ -168,7 +176,32 @@ describe("wipeCrdtIndexedDb", () => {
 
 		await wipePromise;
 
-		expect(attempts).toHaveLength(2);
-		expect(attempts).toEqual([DB_NAME, DB_NAME]);
+		// Twice for the blocked target, once for the queue DB alongside it.
+		expect(attempts.filter((n) => n === DB_NAME)).toEqual([DB_NAME, DB_NAME]);
+		expect(attempts).toContain(QUEUE_DB_NAME);
+	});
+});
+
+describe("the durable op-queue is wiped too", () => {
+	// It is named "engram-crdt-queue" — one character outside the
+	// "engram-crdt/" prefix the enumeration sweep matches on, so it was never
+	// deleted. Its entries carry note paths (create ops store `{ path }`), so
+	// on a shared machine a note path outlived the sign-out meant to clear it.
+	it("deletes the queue database even though it is outside CRDT_IDB_PREFIX", async () => {
+		const deleted = stubIndexedDb({ enumerate: [] });
+
+		await wipeCrdtIndexedDb();
+
+		expect(deleted).toContain(QUEUE_DB_NAME);
+	});
+
+	// Firefox <126 / older Safari: no enumeration, so the name has to come from
+	// somewhere that does not depend on the browser.
+	it("still deletes it when the browser cannot enumerate databases", async () => {
+		const deleted = stubIndexedDb({ enumerate: null });
+
+		await wipeCrdtIndexedDb();
+
+		expect(deleted).toContain(QUEUE_DB_NAME);
 	});
 });

--- a/frontend/src/crdt/idb-wipe.ts
+++ b/frontend/src/crdt/idb-wipe.ts
@@ -1,5 +1,6 @@
 import { forgetCrdtDbs, knownCrdtDbs } from "./idb-registry";
 import { CRDT_IDB_PREFIX } from "./manager";
+import { QUEUE_DB_NAME } from "./op-queue-persist";
 
 const BLOCKED_RETRY_ATTEMPTS = 5;
 const BLOCKED_RETRY_DELAY_MS = 300;
@@ -50,7 +51,13 @@ export async function wipeCrdtIndexedDb(): Promise<void> {
 		return;
 	}
 
-	const names = new Set<string>(knownCrdtDbs());
+	// The durable op-queue is named "engram-crdt-queue", which does NOT start
+	// with "engram-crdt/" — one character outside the prefix, so the sweep below
+	// never saw it. Its entries carry note paths, so it outlived sign-out on a
+	// shared machine. Named explicitly rather than by loosening the prefix,
+	// because a prefix that matches "engram-crdt*" would also match any future
+	// database someone names that way without thinking about wiping.
+	const names = new Set<string>([...knownCrdtDbs(), QUEUE_DB_NAME]);
 
 	if (typeof indexedDB.databases === "function") {
 		const dbs = await indexedDB.databases();

--- a/frontend/src/crdt/op-queue-persist.ts
+++ b/frontend/src/crdt/op-queue-persist.ts
@@ -109,3 +109,8 @@ export function createIndexedDbPersister(userId: string, vaultId: string): Persi
 		},
 	};
 }
+
+/** Exported so the sign-out wipe can name it. It sits outside CRDT_IDB_PREFIX
+ *  ("engram-crdt/") by one character, so the prefix sweep never matched it and
+ *  queued ops — which carry note paths — survived sign-out. */
+export const QUEUE_DB_NAME = DB_NAME;

--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { signInRedirectTarget } from "../auth/sign-in-redirect";
 import DeviceLinkPage from "./device-link-page";
 
 const { get, post } = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }));
@@ -120,6 +121,9 @@ function renderPage(entry = "/link") {
 
 afterEach(() => {
 	vi.clearAllMocks();
+	// A handoff is per-tab and survives a render; without this a stash from one
+	// test would be consumed by the next.
+	window.sessionStorage.clear();
 	billingPending.current = false;
 	vaultReadyArgs.last = null;
 	window.history.replaceState({}, "", "/link");
@@ -153,6 +157,35 @@ describe("DeviceLinkPage", () => {
 
 		await waitFor(() => expect(get).toHaveBeenCalledWith("/vaults?user_code=ENGR-7X4K"));
 		expect(await screen.findByRole("radio", { name: /personal/iu })).toBeInTheDocument();
+	});
+
+	// The signed-out arrival — the COMMON case, since the plugin opens
+	// verification_uri_complete for someone who has never signed in on this
+	// browser. Stripping the code out of `return_to` (so it never reaches the
+	// address bar, history, or Clerk) broke exactly this, and every other test
+	// in this file passes the code in the query string, so none of them noticed.
+	it("auto-verifies a code handed over from a sign-in redirect", async () => {
+		get.mockResolvedValue({ vaults: [{ id: 7, name: "Personal", note_count: 0 }] });
+		// What signInRedirectTarget does on the way to Clerk.
+		signInRedirectTarget({ pathname: "/link", search: "?code=ENGR-7X4K", hash: "" });
+
+		renderPage("/link");
+
+		await waitFor(() => expect(get).toHaveBeenCalledWith("/vaults?user_code=ENGR-7X4K"));
+		expect(await screen.findByRole("radio", { name: /personal/iu })).toBeInTheDocument();
+	});
+
+	// The stale-handoff regression. The wizard's Obsidian branch sends the user
+	// to a bare /link expecting an EMPTY field to type a fresh code into. An
+	// abandoned earlier attempt must not be consumed here and auto-verified
+	// into "This code is invalid or has expired."
+	it("ignores a handoff captured somewhere other than /link", async () => {
+		signInRedirectTarget({ pathname: "/some-vault", search: "?code=PROMO123", hash: "" });
+
+		renderPage("/link");
+
+		expect(screen.getByPlaceholderText(/XXXX-XXXX/iu)).toHaveValue("");
+		await waitFor(() => expect(get).not.toHaveBeenCalled());
 	});
 
 	// Authorizing is still an explicit act: auto-verify only lists the vaults.

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { setActiveVaultId } from "../api/active-vault";
 import { api } from "../api/client";
 import { type Connection, useBillingStatus, useConnections, useMe } from "../api/queries";
+import { takeCredential } from "../auth/credential-handoff";
 import { useAuthAdapter } from "../auth/use-auth-adapter";
 import { connectionId as obsidianConnectionId } from "../billing/existing-connections-panel";
 import { useConnectionCap } from "../billing/use-connection-cap";
@@ -64,7 +65,14 @@ function DeviceLinkPage() {
 	// Read from the ROUTER's location, not window.location: the scrub below
 	// goes through the router, so reading the raw window would leave the two
 	// disagreeing about whether the code is still in the URL.
-	const [urlCode] = useState(() => readCodeFromQuery(location.search));
+	// URL first, then the sign-in handoff. A signed-out arrival from the plugin
+	// is redirected before this page ever renders, and the redirect strips the
+	// code out of the URL — so for the most common case (first link, never
+	// signed in on this browser) the handoff IS the code.
+	const [urlCode] = useState(
+		() =>
+			readCodeFromQuery(location.search) || readCodeFromQuery(`?code=${takeCredential("code")}`),
+	);
 	// Did the plugin hand us the code, or did the user type it? Only the first
 	// skips RFC 8628's manual-entry speed bump, so only it needs the caution.
 	const arrivedWithCode = urlCode.length === 9;

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -16,6 +16,7 @@ import AuthPanel from "../layout/auth-panel";
 import AuthShell from "../layout/auth-shell";
 import { SyncStatusPill } from "../onboarding/sync-status-pill";
 import { useVaultReadyEvents } from "../onboarding/use-vault-ready-events";
+import { ROUTES } from "../routes";
 import { settingsHash, settingsTo } from "../settings/settings-hash";
 
 interface Vault {
@@ -71,7 +72,8 @@ function DeviceLinkPage() {
 	// signed in on this browser) the handoff IS the code.
 	const [urlCode] = useState(
 		() =>
-			readCodeFromQuery(location.search) || readCodeFromQuery(`?code=${takeCredential("code")}`),
+			readCodeFromQuery(location.search) ||
+			readCodeFromQuery(`?code=${takeCredential("code", ROUTES.DEVICE_LINK)}`),
 	);
 	// Did the plugin hand us the code, or did the user type it? Only the first
 	// skips RFC 8628's manual-entry speed bump, so only it needs the caution.

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useEffect, useState } from "react";
 import { Link, useLocation, useNavigate, useSearchParams } from "react-router";
 import { getApiBase, joinApiUrl } from "@/api/base";
+import { stashCredential, takeCredential } from "@/auth/credential-handoff";
 import { Button } from "@/components/ui/button";
 import AuthPanel from "@/layout/auth-panel";
 import AuthShell from "@/layout/auth-shell";
@@ -15,14 +16,35 @@ export default function ResetPasswordPage() {
 	// Captured once, then scrubbed from the URL. The token IS the credential
 	// that lets the bearer set this account's password, and while it sits in
 	// the address bar it is in browser history, in the Referer of anything the
-	// page loads, and attached to every Sentry event as request.url. Held in
-	// state so the scrub cannot pull it out from under the submit handler.
-	const [token] = useState(() => params.get("token") ?? "");
+	// page loads, and attached to every Sentry event as request.url.
+	//
+	// Falls back to the sessionStorage handoff, which covers two cases: a
+	// signed-out arrival that was redirected through sign-in (the redirect
+	// strips the token), and a RELOAD after the scrub. Scrubbing without the
+	// fallback stranded anyone who hit F5 after a "passwords do not match" —
+	// the token was gone from the URL and from history, and their only way
+	// forward was re-opening the email.
+	const [token] = useState(() => {
+		const fromUrl = params.get("token");
+		if (fromUrl) {
+			return fromUrl;
+		}
+		// Put it back: `take` deletes on read, and a user who reloads twice
+		// (mistype, reload, mistype, reload) would otherwise be stranded on the
+		// second one with no way forward but the email.
+		const held = takeCredential("token");
+		if (held) {
+			stashCredential("token", held);
+		}
+		return held;
+	});
 
 	useEffect(() => {
 		if (!params.has("token")) {
 			return;
 		}
+		// Stash before scrubbing so a reload can still find it.
+		stashCredential("token", params.get("token") ?? "");
 		const next = new URLSearchParams(location.search);
 		next.delete("token");
 		// Through the router, not window.history: this app runs on a data
@@ -61,6 +83,8 @@ export default function ResetPasswordPage() {
 			});
 
 			if (res.ok) {
+				// Spent. Nothing should be able to replay it from this tab.
+				takeCredential("token");
 				setDone(true);
 			} else {
 				const body = await res.json().catch(() => ({}));

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -10,10 +10,11 @@ import { destructiveAlert, fieldInput, heading } from "@/lib/ui-classes";
 import { cn } from "@/lib/utils";
 import { ROUTES } from "@/routes";
 
-// The path this page mounts on. A handoff is stamped with where it was
-// captured and only handed back on a match, so a reset token stashed here
-// cannot be consumed by /link, and vice versa.
-const RESET_PATH = "/reset-password";
+// The path this page mounts on — the same constant the router mounts it at, so
+// the two cannot drift. A handoff is stamped with where it was captured and
+// only handed back on a match, so a reset token stashed here cannot be consumed
+// by /link, and vice versa.
+const RESET_PATH = ROUTES.RESET_PASSWORD;
 
 export default function ResetPasswordPage() {
 	const [params] = useSearchParams();

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -1,5 +1,5 @@
-import { type FormEvent, useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { type FormEvent, useEffect, useState } from "react";
+import { Link, useLocation, useNavigate, useSearchParams } from "react-router";
 import { getApiBase, joinApiUrl } from "@/api/base";
 import { Button } from "@/components/ui/button";
 import AuthPanel from "@/layout/auth-panel";
@@ -10,7 +10,28 @@ import { ROUTES } from "@/routes";
 
 export default function ResetPasswordPage() {
 	const [params] = useSearchParams();
-	const token = params.get("token") ?? "";
+	const location = useLocation();
+	const navigate = useNavigate();
+	// Captured once, then scrubbed from the URL. The token IS the credential
+	// that lets the bearer set this account's password, and while it sits in
+	// the address bar it is in browser history, in the Referer of anything the
+	// page loads, and attached to every Sentry event as request.url. Held in
+	// state so the scrub cannot pull it out from under the submit handler.
+	const [token] = useState(() => params.get("token") ?? "");
+
+	useEffect(() => {
+		if (!params.has("token")) {
+			return;
+		}
+		const next = new URLSearchParams(location.search);
+		next.delete("token");
+		// Through the router, not window.history: this app runs on a data
+		// router, which does not observe a raw replaceState.
+		navigate(
+			{ pathname: location.pathname, search: next.toString(), hash: location.hash },
+			{ replace: true },
+		);
+	}, [params, location, navigate]);
 	const [password, setPassword] = useState("");
 	const [confirm, setConfirm] = useState("");
 	const [error, setError] = useState("");

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -2,12 +2,18 @@ import { type FormEvent, useEffect, useState } from "react";
 import { Link, useLocation, useNavigate, useSearchParams } from "react-router";
 import { getApiBase, joinApiUrl } from "@/api/base";
 import { stashCredential, takeCredential } from "@/auth/credential-handoff";
+
 import { Button } from "@/components/ui/button";
 import AuthPanel from "@/layout/auth-panel";
 import AuthShell from "@/layout/auth-shell";
 import { destructiveAlert, fieldInput, heading } from "@/lib/ui-classes";
 import { cn } from "@/lib/utils";
 import { ROUTES } from "@/routes";
+
+// The path this page mounts on. A handoff is stamped with where it was
+// captured and only handed back on a match, so a reset token stashed here
+// cannot be consumed by /link, and vice versa.
+const RESET_PATH = "/reset-password";
 
 export default function ResetPasswordPage() {
 	const [params] = useSearchParams();
@@ -32,9 +38,9 @@ export default function ResetPasswordPage() {
 		// Put it back: `take` deletes on read, and a user who reloads twice
 		// (mistype, reload, mistype, reload) would otherwise be stranded on the
 		// second one with no way forward but the email.
-		const held = takeCredential("token");
+		const held = takeCredential("token", RESET_PATH);
 		if (held) {
-			stashCredential("token", held);
+			stashCredential("token", held, RESET_PATH);
 		}
 		return held;
 	});
@@ -44,7 +50,7 @@ export default function ResetPasswordPage() {
 			return;
 		}
 		// Stash before scrubbing so a reload can still find it.
-		stashCredential("token", params.get("token") ?? "");
+		stashCredential("token", params.get("token") ?? "", RESET_PATH);
 		const next = new URLSearchParams(location.search);
 		next.delete("token");
 		// Through the router, not window.history: this app runs on a data
@@ -84,7 +90,7 @@ export default function ResetPasswordPage() {
 
 			if (res.ok) {
 				// Spent. Nothing should be able to replay it from this tab.
-				takeCredential("token");
+				takeCredential("token", RESET_PATH);
 				setDone(true);
 			} else {
 				const body = await res.json().catch(() => ({}));

--- a/frontend/src/features/auth/reset-password-page.test.tsx
+++ b/frontend/src/features/auth/reset-password-page.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * The password-reset token's lifecycle.
+ *
+ * The token IS the credential that lets its bearer set this account's
+ * password. While it sits in the address bar it is in browser history, in the
+ * Referer of everything the page loads, and on every Sentry event as
+ * request.url — so the page captures it once and scrubs it.
+ *
+ * Scrubbing it is the easy half. The hard half is that the page must still
+ * work afterwards: a reload after "passwords do not match" used to strand the
+ * user with no way forward but re-opening the email. That regression is what
+ * these tests exist for, and until now this page had no tests at all.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stashCredential } from "@/auth/credential-handoff";
+import ResetPasswordPage from "./ResetPasswordPage";
+
+// AuthShell renders ThemeToggle, which reads a theme context this suite has no
+// reason to provide. Same stub the device-link suite uses.
+vi.mock("@/theme/theme-toggle", () => ({
+	default: () => <button type="button">theme</button>,
+}));
+
+function LocationProbe() {
+	const { pathname, search } = useLocation();
+	return <span data-testid="location">{`${pathname}${search}`}</span>;
+}
+
+// Remounts on each render() call, which is how a reload is simulated: the
+// component's useState initialiser runs again against the same sessionStorage.
+function renderPage(entry: string) {
+	return render(
+		<MemoryRouter initialEntries={[entry]}>
+			<Routes>
+				<Route
+					path="/reset-password"
+					element={
+						<>
+							<ResetPasswordPage />
+							<LocationProbe />
+						</>
+					}
+				/>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+// fireEvent, not user-event: it is not a dependency of this package and the
+// sibling suites all use fireEvent.
+async function submitPasswords(value: string) {
+	fireEvent.change(screen.getByLabelText(/new password/iu), { target: { value } });
+	fireEvent.change(screen.getByLabelText(/confirm password/iu), { target: { value } });
+	fireEvent.click(screen.getByRole("button", { name: /set password/iu }));
+}
+
+/** The JSON body of the nth fetch call, with the index narrowed. */
+function sentBody(call: number): { token?: string; password?: string } {
+	const args = fetchMock.mock.calls[call];
+	if (!args) {
+		throw new Error(`no fetch call at index ${call}`);
+	}
+	return JSON.parse((args[1] as { body: string }).body);
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+	window.sessionStorage.clear();
+	vi.stubGlobal("fetch", fetchMock);
+	fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("ResetPasswordPage token handling", () => {
+	it("scrubs the token out of the URL", async () => {
+		renderPage("/reset-password?token=secret-tok");
+
+		await waitFor(() =>
+			expect(screen.getByTestId("location")).toHaveTextContent("/reset-password"),
+		);
+		expect(screen.getByTestId("location").textContent).not.toContain("secret-tok");
+	});
+
+	it("still submits the token it scrubbed", async () => {
+		renderPage("/reset-password?token=secret-tok");
+		await submitPasswords("hunter2hunter2");
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+		expect(sentBody(0).token).toBe("secret-tok");
+	});
+
+	// The regression: mistype, reload, and the token is gone from the URL AND
+	// from history. Twice, because `take` deletes on read — the first fix put
+	// it back, and this is what proves that.
+	it("survives two reloads after the scrub", async () => {
+		renderPage("/reset-password?token=secret-tok").unmount();
+		renderPage("/reset-password").unmount();
+		renderPage("/reset-password");
+
+		await submitPasswords("hunter2hunter2");
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+		expect(sentBody(0).token).toBe("secret-tok");
+	});
+
+	// Spent tokens must not be replayable from a tab left open.
+	it("clears the handoff once the reset succeeds", async () => {
+		renderPage("/reset-password?token=secret-tok");
+		await submitPasswords("hunter2hunter2");
+		await screen.findByText(/password updated/iu);
+
+		expect(window.sessionStorage.getItem("engram:handoff:token")).toBeNull();
+	});
+
+	// A failed submit is the mistype case — the token has to survive it, or the
+	// retry the user is about to make cannot work.
+	it("keeps the token available after a failed submit", async () => {
+		fetchMock.mockResolvedValue({ ok: false, json: async () => ({ error: "weak_password" }) });
+		renderPage("/reset-password?token=secret-tok");
+		await submitPasswords("hunter2hunter2");
+		await screen.findByRole("alert");
+
+		fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+		await submitPasswords("hunter2hunter2");
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		expect(sentBody(1).token).toBe("secret-tok");
+	});
+
+	// A fresh link opened in the same tab must win over the stale stash, or the
+	// user is silently resetting with a token they did not just click.
+	it("prefers a token in the URL over a held one", async () => {
+		renderPage("/reset-password?token=old-tok").unmount();
+		renderPage("/reset-password?token=new-tok");
+
+		await submitPasswords("hunter2hunter2");
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+		expect(sentBody(0).token).toBe("new-tok");
+	});
+
+	// Handoffs are stamped with the path they were captured on. A device code
+	// stashed by /link shares the sessionStorage prefix but not the stamp.
+	it("ignores a token stashed on another path", async () => {
+		stashCredential("token", "not-mine", "/link");
+		renderPage("/reset-password");
+
+		await submitPasswords("hunter2hunter2");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(await screen.findByRole("alert")).toHaveTextContent(/missing its token/iu);
+	});
+});

--- a/frontend/src/features/auth/reset-password-page.test.tsx
+++ b/frontend/src/features/auth/reset-password-page.test.tsx
@@ -15,6 +15,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stashCredential } from "@/auth/credential-handoff";
+import { signInRedirectTarget } from "@/auth/sign-in-redirect";
 import ResetPasswordPage from "./ResetPasswordPage";
 
 // AuthShell renders ThemeToggle, which reads a theme context this suite has no
@@ -144,6 +145,20 @@ describe("ResetPasswordPage token handling", () => {
 
 		await waitFor(() => expect(fetchMock).toHaveBeenCalled());
 		expect(sentBody(0).token).toBe("new-tok");
+	});
+
+	// Pins RESET_PATH against the OTHER side of the handoff. Every other test
+	// here stashes and takes through the page, which uses one constant for both
+	// — so they stay green for any value of it, including a wrong one. This one
+	// routes through signInRedirectTarget, which reads the real pathname.
+	it("accepts a token stashed by the sign-in redirect from this path", async () => {
+		signInRedirectTarget({ pathname: "/reset-password", search: "?token=redirect-tok", hash: "" });
+
+		renderPage("/reset-password");
+		await submitPasswords("hunter2hunter2");
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+		expect(sentBody(0).token).toBe("redirect-tok");
 	});
 
 	// Handoffs are stamped with the path they were captured on. A device code

--- a/frontend/src/layout/recent-searches.ts
+++ b/frontend/src/layout/recent-searches.ts
@@ -28,3 +28,21 @@ export function pushRecent(query: string): string[] {
 	window.localStorage.setItem(KEY, JSON.stringify(next));
 	return next;
 }
+
+/** Forget the search history.
+ *
+ *  These are the user's own words — "severance agreement lawyer" — stored under
+ *  a key with no user in it and no expiry. On a shared machine the next person
+ *  to open the search panel reads them. Called on identity change, alongside
+ *  the query-cache clear and the CRDT wipe. */
+export function clearRecent(): void {
+	if (typeof window === "undefined") {
+		return;
+	}
+	try {
+		window.localStorage.removeItem(KEY);
+	} catch {
+		// Storage disabled or full — nothing to clear, and failing the sign-out
+		// path over a cache would be worse.
+	}
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -140,7 +140,7 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 				{ path: ROUTES.SIGN_UP, element: <SignUpPage /> },
 				{ path: ROUTES.WAITLIST, element: <WaitlistPage /> },
 				// Public reset — the one-time token IS the credential.
-				{ path: "/reset-password", element: suspended(<ResetPasswordPage />) },
+				{ path: ROUTES.RESET_PASSWORD, element: suspended(<ResetPasswordPage />) },
 				// Dev-only connector QC gallery — spreads into nothing in production.
 				...(ConnectorQcPage
 					? [{ path: "/__qc/connectors", element: suspended(<ConnectorQcPage />) }]

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -8,5 +8,6 @@ export const ROUTES = {
 	SIGN_UP: "/sign-up",
 	WAITLIST: "/waitlist",
 	DEVICE_LINK: "/link",
+	RESET_PASSWORD: "/reset-password",
 	OAUTH_CONSENT: "/oauth/consent",
 } as const;

--- a/frontend/src/sentry-init-wiring.test.ts
+++ b/frontend/src/sentry-init-wiring.test.ts
@@ -1,0 +1,58 @@
+/**
+ * That `Sentry.init` receives the scrubbers — not merely that a factory
+ * exists which would produce them.
+ *
+ * `sentry-scrub.test.ts` asserts `sentryInitOptions()` returns
+ * `beforeBreadcrumb` / `beforeSend`. That guards the factory and nothing else:
+ * rewriting the call site as `Sentry.init({ dsn })` left that file green at
+ * 18/18 while every breadcrumb shipped unscrubbed. The gap is the call, so
+ * this file drives the real module and inspects what init was handed.
+ *
+ * Its own file because it needs `vi.resetModules()` plus a stubbed
+ * `import.meta.env` — the DSN is read at module scope, so the module has to be
+ * imported fresh, after the stub.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.doUnmock("@sentry/react");
+	vi.resetModules();
+});
+
+describe("Sentry.init wiring", () => {
+	it("hands init the scrubbers themselves", async () => {
+		const init = vi.fn();
+		vi.doMock("@sentry/react", () => ({ init, captureException: vi.fn() }));
+		vi.stubEnv("VITE_SENTRY_DSN", "https://key@example.ingest.sentry.io/1");
+		vi.resetModules();
+
+		const sentry = await import("./sentry");
+		await sentry.sentryReady;
+
+		expect(init).toHaveBeenCalledTimes(1);
+		const options = init.mock.calls[0]?.[0] as {
+			beforeBreadcrumb?: unknown;
+			beforeSend?: unknown;
+			sendDefaultPii?: boolean;
+		};
+		expect(options.beforeBreadcrumb).toBe(sentry.scrubBreadcrumb);
+		expect(options.beforeSend).toBe(sentry.scrubEvent);
+		expect(options.sendDefaultPii).toBe(false);
+	});
+
+	// Self-host ships no DSN. Importing the SDK at all would be a wasted chunk,
+	// and init'ing it would be reporting the user did not ask for.
+	it("does not initialise without a DSN", async () => {
+		const init = vi.fn();
+		vi.doMock("@sentry/react", () => ({ init, captureException: vi.fn() }));
+		vi.stubEnv("VITE_SENTRY_DSN", "");
+		vi.resetModules();
+
+		const sentry = await import("./sentry");
+		await sentry.sentryReady;
+
+		expect(init).not.toHaveBeenCalled();
+		expect(sentry.sentryReady).toBeNull();
+	});
+});

--- a/frontend/src/sentry-scrub.test.ts
+++ b/frontend/src/sentry-scrub.test.ts
@@ -13,6 +13,7 @@
  * shape of a route is enough to debug it; the contents belong to the user.
  */
 import { describe, expect, it } from "vitest";
+import { ROUTES } from "./routes";
 import { scrubBreadcrumb, scrubEvent, scrubUrl, sentryInitOptions } from "./sentry";
 
 describe("scrubUrl", () => {
@@ -47,6 +48,41 @@ describe("scrubUrl", () => {
 
 	it("does not leak a note title from an unresolved wikilink", () => {
 		expect(scrubUrl("/vault-slug/wiki/Divorce%20settlement%20draft")).not.toContain("Divorce");
+	});
+
+	// The bug this allowlist exists for. `/:slug` is the vault route and the
+	// slug is slugify(vault.name), so segment 1 on the app's most-travelled
+	// route IS user data. The wikilink test above passed throughout, because
+	// it only asserted on the note title and never looked at "vault-slug".
+	it("redacts the vault slug, which is a user-typed vault name", () => {
+		expect(scrubUrl("https://app.engram.page/divorce-2026/note-abc")).toBe(
+			"https://app.engram.page/:seg/:seg",
+		);
+		expect(scrubUrl("https://app.engram.page/my-therapy-vault")).toBe(
+			"https://app.engram.page/:seg",
+		);
+	});
+
+	it("still keeps our own first segments, which is the point of keeping any", () => {
+		expect(scrubUrl("/api/search")).toBe("/api/:seg");
+		expect(scrubUrl("/attachments/Medical/labs.pdf")).toBe("/attachments/:seg/:seg");
+		expect(scrubUrl("/onboard/billing")).toBe("/onboard/:seg");
+	});
+
+	// Drift guard. A route renamed in ROUTES without updating the allowlist
+	// would start being redacted (merely unhelpful), but a route REMOVED from
+	// ROUTES while a vault slug of the same name exists is the leak direction.
+	// Either way the two lists must agree, and this fails when they don't.
+	it("keeps every first segment declared in ROUTES", () => {
+		for (const route of Object.values(ROUTES)) {
+			const [, segment] = route.split("/");
+			if (!segment) {
+				continue;
+			}
+			expect(scrubUrl(`https://app.engram.page/${segment}/x`)).toBe(
+				`https://app.engram.page/${segment}/:seg`,
+			);
+		}
 	});
 
 	// A relative URL has to work: fetch breadcrumbs record whatever was passed
@@ -131,6 +167,19 @@ describe("scrubEvent", () => {
 		});
 
 		expect(JSON.stringify(out)).not.toContain("ENGR-7X4K");
+	});
+
+	// Header names are case-insensitive by spec. The scrub used to match the
+	// exact key `Referer`, which works only because httpContextIntegration
+	// happens to capitalize it that way.
+	it("scrubs a lowercased referer header too", () => {
+		const event = {
+			request: {
+				url: "https://app.engram.page/reset-password",
+				headers: { referer: "https://app.engram.page/reset-password?token=secret-tok" },
+			},
+		};
+		expect(scrubEvent(event).request.headers.referer).not.toContain("secret-tok");
 	});
 });
 

--- a/frontend/src/sentry-scrub.test.ts
+++ b/frontend/src/sentry-scrub.test.ts
@@ -98,6 +98,22 @@ describe("scrubUrl", () => {
 		}
 	});
 
+	// Fails closed. In a worker or SSR there is no `window`, so origin cannot be
+	// compared — and the safe answer is to treat the URL as ours and apply the
+	// allowlist, not to keep an unrecognised segment.
+	it("redacts an unknown first segment when there is no window to compare", () => {
+		const realWindow = globalThis.window;
+		// biome-ignore lint/performance/noDelete: restoring the global needs a true delete
+		delete (globalThis as { window?: unknown }).window;
+		try {
+			expect(scrubUrl("https://app.engram.page/divorce-2026/x")).toBe(
+				"https://app.engram.page/:seg/:seg",
+			);
+		} finally {
+			(globalThis as { window?: unknown }).window = realWindow;
+		}
+	});
+
 	// A relative URL has to work: fetch breadcrumbs record whatever was passed
 	// to fetch(), which in this app is usually "/api/...".
 	it("handles relative URLs, and keeps them relative", () => {

--- a/frontend/src/sentry-scrub.test.ts
+++ b/frontend/src/sentry-scrub.test.ts
@@ -20,13 +20,12 @@ describe("scrubUrl", () => {
 	// Host and first segment survive so a breadcrumb can still say WHICH
 	// endpoint failed; everything after is the user's.
 	it("keeps the host and first segment, redacts the rest", () => {
-		expect(scrubUrl("https://app.engram.page/attachments/Medical/labs.pdf")).toBe(
-			"https://app.engram.page/attachments/:seg/:seg",
-		);
+		const app = window.location.origin;
+		expect(scrubUrl(`${app}/attachments/Medical/labs.pdf`)).toBe(`${app}/attachments/:seg/:seg`);
 	});
 
 	it("does not leak a folder or filename", () => {
-		const out = scrubUrl("https://app.engram.page/attachments/Medical/2026-lab-results.pdf");
+		const out = scrubUrl(`${window.location.origin}/attachments/Medical/2026-lab-results.pdf`);
 		expect(out).not.toContain("Medical");
 		expect(out).not.toContain("lab-results");
 	});
@@ -55,15 +54,30 @@ describe("scrubUrl", () => {
 	// route IS user data. The wikilink test above passed throughout, because
 	// it only asserted on the note title and never looked at "vault-slug".
 	it("redacts the vault slug, which is a user-typed vault name", () => {
-		expect(scrubUrl("https://app.engram.page/divorce-2026/note-abc")).toBe(
-			"https://app.engram.page/:seg/:seg",
-		);
-		expect(scrubUrl("https://app.engram.page/my-therapy-vault")).toBe(
-			"https://app.engram.page/:seg",
-		);
+		const app = window.location.origin;
+		expect(scrubUrl(`${app}/divorce-2026/note-abc`)).toBe(`${app}/:seg/:seg`);
+		expect(scrubUrl(`${app}/my-therapy-vault`)).toBe(`${app}/:seg`);
+		// Relative is the same surface — that is what fetch breadcrumbs carry
+		// on self-host.
+		expect(scrubUrl("/divorce-2026/note-abc")).toBe("/:seg/:seg");
 	});
 
-	it("still keeps our own first segments, which is the point of keeping any", () => {
+	// On SaaS the API lives on its own host AND joinApiUrl strips the `/api`
+	// prefix, so these arrive as `/search`, `/folders`, `/notes`. Applying the
+	// route allowlist to them redacted every endpoint name in prod — and SaaS
+	// is the only deployment with a DSN, so that was the only behaviour that
+	// ran. A foreign origin cannot carry a vault slug in segment 1.
+	it("keeps the endpoint name on a foreign origin, and still redacts below it", () => {
+		expect(scrubUrl("https://api.engram.page/search?q=cancer")).toBe(
+			"https://api.engram.page/search?q=:v",
+		);
+		expect(scrubUrl("https://api.engram.page/notes/Medical/labs.md")).toBe(
+			"https://api.engram.page/notes/:seg/:seg",
+		);
+		expect(scrubUrl("https://api.engram.page/folders")).toBe("https://api.engram.page/folders");
+	});
+
+	it("still keeps our own route segments, which is the point of keeping any", () => {
 		expect(scrubUrl("/api/search")).toBe("/api/:seg");
 		expect(scrubUrl("/attachments/Medical/labs.pdf")).toBe("/attachments/:seg/:seg");
 		expect(scrubUrl("/onboard/billing")).toBe("/onboard/:seg");
@@ -74,14 +88,13 @@ describe("scrubUrl", () => {
 	// ROUTES while a vault slug of the same name exists is the leak direction.
 	// Either way the two lists must agree, and this fails when they don't.
 	it("keeps every first segment declared in ROUTES", () => {
+		const app = window.location.origin;
 		for (const route of Object.values(ROUTES)) {
 			const [, segment] = route.split("/");
 			if (!segment) {
 				continue;
 			}
-			expect(scrubUrl(`https://app.engram.page/${segment}/x`)).toBe(
-				`https://app.engram.page/${segment}/:seg`,
-			);
+			expect(scrubUrl(`${app}/${segment}/x`)).toBe(`${app}/${segment}/:seg`);
 		}
 	});
 
@@ -102,7 +115,7 @@ describe("scrubUrl", () => {
 	});
 
 	it("keeps the root path recognisable", () => {
-		expect(scrubUrl("https://app.engram.page/")).toBe("https://app.engram.page/");
+		expect(scrubUrl(`${window.location.origin}/`)).toBe(`${window.location.origin}/`);
 	});
 
 	// The fragment carries heading slugs derived from note body text.

--- a/frontend/src/sentry-scrub.test.ts
+++ b/frontend/src/sentry-scrub.test.ts
@@ -1,0 +1,63 @@
+/**
+ * URL scrubbing for Sentry.
+ *
+ * `Sentry.init({ integrations: [] })` does NOT disable the default
+ * integrations — the SDK merges that array with `getDefaultIntegrations()`, and
+ * only `defaultIntegrations: false` opts out. So `breadcrumbsIntegration` (fetch
+ * + console + DOM) and `httpContextIntegration` (`request.url`) have always
+ * been live.
+ *
+ * That matters here because URLs in this app carry the user's data: note and
+ * attachment paths (`/attachments/Medical/labs.pdf`), unresolved wikilink
+ * titles, and single-use credentials arriving as `?code=` / `?token=`. The
+ * shape of a route is enough to debug it; the contents belong to the user.
+ */
+import { describe, expect, it } from "vitest";
+import { scrubUrl } from "./sentry";
+
+describe("scrubUrl", () => {
+	it("replaces path segments, keeping the shape", () => {
+		expect(scrubUrl("https://app.engram.page/attachments/Medical/labs.pdf")).toBe(
+			"/:seg/:seg/:seg",
+		);
+	});
+
+	it("keeps query KEYS but never values", () => {
+		const out = scrubUrl("/vaults?user_code=ENGR-7X4K");
+		expect(out).toContain("user_code=");
+		expect(out).not.toContain("ENGR-7X4K");
+	});
+
+	// The two credentials that arrive by URL in this app. Both were live in
+	// Sentry's fetch breadcrumbs and in request.url before this existed.
+	it.each([
+		["/link?code=ENGR-7X4K", "ENGR-7X4K"],
+		["/reset-password?token=abc123secret", "abc123secret"],
+	])("strips the credential in %s", (url, secret) => {
+		expect(scrubUrl(url)).not.toContain(secret);
+	});
+
+	it("does not leak a note title from an unresolved wikilink", () => {
+		expect(scrubUrl("/vault-slug/wiki/Divorce%20settlement%20draft")).not.toContain("Divorce");
+	});
+
+	// A relative URL has to work: fetch breadcrumbs record whatever was passed
+	// to fetch(), which in this app is usually "/api/...".
+	it("handles relative URLs", () => {
+		expect(scrubUrl("/api/notes/Personal/Secret.md")).toBe("/:seg/:seg/:seg/:seg");
+	});
+
+	// Parsed against a base, so nearly any string resolves to a path and gets
+	// scrubbed. That is the safe direction: over-scrubbing costs debug detail,
+	// under-scrubbing costs the user's data. What matters is that it never
+	// throws inside beforeSend — a scrubber that raises would take the whole
+	// crash report with it.
+	it("scrubs rather than passes through an odd value, and never throws", () => {
+		expect(() => scrubUrl("not a url")).not.toThrow();
+		expect(scrubUrl("not a url")).not.toContain("not a url");
+	});
+
+	it("keeps the root path recognisable", () => {
+		expect(scrubUrl("https://app.engram.page/")).toBe("/");
+	});
+});

--- a/frontend/src/sentry-scrub.test.ts
+++ b/frontend/src/sentry-scrub.test.ts
@@ -13,13 +13,21 @@
  * shape of a route is enough to debug it; the contents belong to the user.
  */
 import { describe, expect, it } from "vitest";
-import { scrubUrl } from "./sentry";
+import { scrubBreadcrumb, scrubEvent, scrubUrl, sentryInitOptions } from "./sentry";
 
 describe("scrubUrl", () => {
-	it("replaces path segments, keeping the shape", () => {
+	// Host and first segment survive so a breadcrumb can still say WHICH
+	// endpoint failed; everything after is the user's.
+	it("keeps the host and first segment, redacts the rest", () => {
 		expect(scrubUrl("https://app.engram.page/attachments/Medical/labs.pdf")).toBe(
-			"/:seg/:seg/:seg",
+			"https://app.engram.page/attachments/:seg/:seg",
 		);
+	});
+
+	it("does not leak a folder or filename", () => {
+		const out = scrubUrl("https://app.engram.page/attachments/Medical/2026-lab-results.pdf");
+		expect(out).not.toContain("Medical");
+		expect(out).not.toContain("lab-results");
 	});
 
 	it("keeps query KEYS but never values", () => {
@@ -43,8 +51,8 @@ describe("scrubUrl", () => {
 
 	// A relative URL has to work: fetch breadcrumbs record whatever was passed
 	// to fetch(), which in this app is usually "/api/...".
-	it("handles relative URLs", () => {
-		expect(scrubUrl("/api/notes/Personal/Secret.md")).toBe("/:seg/:seg/:seg/:seg");
+	it("handles relative URLs, and keeps them relative", () => {
+		expect(scrubUrl("/api/notes/Personal/Secret.md")).toBe("/api/:seg/:seg/:seg");
 	});
 
 	// Parsed against a base, so nearly any string resolves to a path and gets
@@ -58,6 +66,81 @@ describe("scrubUrl", () => {
 	});
 
 	it("keeps the root path recognisable", () => {
-		expect(scrubUrl("https://app.engram.page/")).toBe("/");
+		expect(scrubUrl("https://app.engram.page/")).toBe("https://app.engram.page/");
+	});
+
+	// The fragment carries heading slugs derived from note body text.
+	it("drops the fragment entirely", () => {
+		expect(scrubUrl("/vault/notes#Divorce-settlement-heading")).not.toContain("Divorce");
+	});
+});
+
+describe("scrubBreadcrumb", () => {
+	// Console args are whatever a developer passed — an attachment path today,
+	// anything tomorrow. Not worth a privacy review on every future edit.
+	it("drops console breadcrumbs entirely", () => {
+		expect(scrubBreadcrumb({ category: "console", message: "attachment load failed" })).toBeNull();
+	});
+
+	// The DOM serializer reads title/alt/aria-label off the clicked element AND
+	// five ancestors. In this app those carry note paths, filenames and
+	// frontmatter values.
+	it.each(["ui.click", "ui.input"])("drops %s breadcrumbs", (category) => {
+		expect(scrubBreadcrumb({ category })).toBeNull();
+	});
+
+	it("keeps fetch breadcrumbs but scrubs the url", () => {
+		const crumb = scrubBreadcrumb({
+			category: "fetch",
+			data: { url: "https://app.engram.page/api/attachments/Medical/labs.pdf", status_code: 500 },
+		});
+
+		expect(crumb).not.toBeNull();
+		expect(crumb?.data?.url).not.toContain("Medical");
+		// The endpoint is still identifiable — over-scrubbing to "/:seg/:seg"
+		// made breadcrumbs useless at the moment reporting was switched on.
+		expect(crumb?.data?.url).toContain("/api/");
+		expect(crumb?.data?.status_code).toBe(500);
+	});
+
+	it("scrubs navigation from/to", () => {
+		const crumb = scrubBreadcrumb({
+			category: "navigation",
+			data: { from: "/link?code=ENGR-7X4K", to: "/vault/Personal/Secret.md" },
+		});
+
+		expect(crumb?.data?.from).not.toContain("ENGR-7X4K");
+		expect(crumb?.data?.to).not.toContain("Secret");
+	});
+});
+
+describe("scrubEvent", () => {
+	it("scrubs request.url", () => {
+		const out = scrubEvent({ request: { url: "/reset-password?token=abc123secret" } });
+		expect(JSON.stringify(out)).not.toContain("abc123secret");
+	});
+
+	// httpContextIntegration attaches headers too, and Referer is the full URL
+	// of the page while the credential is still in the address bar.
+	it("scrubs the Referer header, not just the url", () => {
+		const out = scrubEvent({
+			request: {
+				url: "/api/notes",
+				headers: { Referer: "https://app.engram.page/link?code=ENGR-7X4K" },
+			},
+		});
+
+		expect(JSON.stringify(out)).not.toContain("ENGR-7X4K");
+	});
+});
+
+describe("the scrubbers are actually wired into Sentry.init", () => {
+	// Without this, deleting the two hook lines from the options left every
+	// other test in this file green while everything shipped unscrubbed.
+	it("passes beforeBreadcrumb and beforeSend", () => {
+		const opts = sentryInitOptions("https://key@example.ingest.sentry.io/1");
+		expect(opts.beforeBreadcrumb).toBe(scrubBreadcrumb);
+		expect(opts.beforeSend).toBe(scrubEvent);
+		expect(opts.sendDefaultPii).toBe(false);
 	});
 });

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -166,9 +166,13 @@ export function scrubUrl(url: string): string {
 	//
 	// Relative URLs are the app's own (that is what fetch breadcrumbs carry on
 	// self-host), so they get the allowlist too.
+	// Fails CLOSED. With `window` absent (a worker, SSR, a test that stubs it
+	// away) an unknown origin is treated as ours, so the allowlist applies and
+	// an unrecognised first segment is redacted. The other direction would keep
+	// a vault slug in exactly the context nobody thought to check.
 	const relative = parsed.hostname === "x.invalid";
-	const ownOrigin =
-		relative || (typeof window !== "undefined" && parsed.origin === window.location.origin);
+	const noWindow = typeof window === "undefined";
+	const ownOrigin = relative || noWindow || parsed.origin === window.location.origin;
 	const segments = parsed.pathname.split("/");
 	const path = segments
 		.map((seg, i) => {

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -22,15 +22,14 @@ const KNOWN_FIRST_SEGMENTS = new Set<string>([
 	// Router literals with no ROUTES constant.
 	"onboard",
 	"settings",
-	"reset-password",
 	"note",
 	"__qc",
-	// Backend prefixes seen in fetch/xhr breadcrumb URLs.
+	// Backend prefixes the SPA actually fetches same-origin (self-host shape;
+	// on SaaS these live on the API host, which is not our origin and so keeps
+	// its first segment anyway).
 	"api",
 	"attachments",
 	"socket",
-	"webhooks",
-	".well-known",
 	// Vite build output.
 	"assets",
 ]);
@@ -150,11 +149,26 @@ export function scrubUrl(url: string): string {
 	// switched on: "/:seg/:seg" cannot tell /api/search from /api/folders, and
 	// dropping the origin hid which service answered.
 	//
-	// But "keep segment 1" is wrong for this router. `/:slug` (router.tsx) is
+	// But "keep segment 1" is wrong for OUR OWN ORIGIN. `/:slug` (router.tsx) is
 	// the VAULT route, and the slug is slugify(vault.name) — a user-typed name.
 	// A vault called "Divorce 2026" put `divorce-2026` into every navigation
 	// breadcrumb and every event's request.url, on the app's most-travelled
-	// route. An allowlist keeps the diagnostic value and closes that.
+	// route.
+	//
+	// The allowlist only applies there. On any OTHER origin a first segment
+	// cannot be a vault slug: SaaS calls the API on a separate host
+	// (`api.engram.page`), and `joinApiUrl` STRIPS the `/api` prefix when an
+	// apiBase is set (api/base.ts) — so those URLs read `/search`, `/folders`,
+	// `/notes`. Running the route allowlist over them redacted every endpoint
+	// name in prod, which is the exact "cannot tell /api/search from
+	// /api/folders" uselessness this function was written to avoid. And SaaS is
+	// the only deployment with a DSN, so that was the only behaviour that ran.
+	//
+	// Relative URLs are the app's own (that is what fetch breadcrumbs carry on
+	// self-host), so they get the allowlist too.
+	const relative = parsed.hostname === "x.invalid";
+	const ownOrigin =
+		relative || (typeof window !== "undefined" && parsed.origin === window.location.origin);
 	const segments = parsed.pathname.split("/");
 	const path = segments
 		.map((seg, i) => {
@@ -162,7 +176,7 @@ export function scrubUrl(url: string): string {
 				return seg;
 			}
 			if (i === 1) {
-				return KNOWN_FIRST_SEGMENTS.has(seg) ? seg : ":seg";
+				return !ownOrigin || KNOWN_FIRST_SEGMENTS.has(seg) ? seg : ":seg";
 			}
 			return ":seg";
 		})

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -18,38 +18,6 @@ import type { ErrorInfo } from "react";
 // an unhandled rejection.
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
 
-/** Console and DOM breadcrumbs are dropped outright, and every other kind has
- *  its URL scrubbed.
- *
- *  Console args are arbitrary values a developer passed to console.error —
- *  attachment paths today, anything tomorrow — and DOM breadcrumbs serialize
- *  `title`/`alt`/`aria-label` off the clicked element AND five ancestors, which
- *  in this app carry note paths, filenames and frontmatter values. Neither is
- *  worth a privacy review on every future edit. */
-function scrubBreadcrumb(crumb: Breadcrumb): Breadcrumb | null {
-	if (crumb.category === "console" || crumb.category?.startsWith("ui.")) {
-		return null;
-	}
-	if (typeof crumb.data?.url === "string") {
-		crumb.data.url = scrubUrl(crumb.data.url);
-	}
-	if (typeof crumb.data?.to === "string") {
-		crumb.data.to = scrubUrl(crumb.data.to);
-	}
-	if (typeof crumb.data?.from === "string") {
-		crumb.data.from = scrubUrl(crumb.data.from);
-	}
-	return crumb;
-}
-
-/** The event itself carries `request.url` via httpContextIntegration. */
-function scrubEvent<T extends { request?: { url?: string } }>(event: T): T {
-	if (event.request?.url) {
-		event.request.url = scrubUrl(event.request.url);
-	}
-	return event;
-}
-
 type SentrySdk = typeof import("@sentry/react");
 
 const earlyErrors: unknown[] = [];
@@ -63,23 +31,7 @@ if (sentryDsn) {
 export const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
 	? import("@sentry/react")
 			.then((Sentry) => {
-				Sentry.init({
-					dsn: sentryDsn,
-					environment: import.meta.env.MODE,
-					release: import.meta.env.VITE_GIT_SHA,
-					// `integrations: []` does NOT disable the defaults — the SDK
-					// MERGES this array with getDefaultIntegrations() and only
-					// `defaultIntegrations: false` opts out. So breadcrumbs and
-					// httpContext were live the whole time, which is what made the
-					// scrubbing below necessary rather than decorative.
-					integrations: [],
-					// sendDefaultPii=false (SDK default) keeps cookies + the
-					// Authorization header out of breadcrumbs even if the SDK's
-					// own scrubbing misses something. Restated for documentation.
-					sendDefaultPii: false,
-					beforeBreadcrumb: scrubBreadcrumb,
-					beforeSend: scrubEvent,
-				});
+				Sentry.init(sentryInitOptions(sentryDsn));
 				// The SDK's own global handlers are live from here; hand it the
 				// backlog and retire the temporary listeners.
 				window.removeEventListener("error", onEarlyError);
@@ -117,31 +69,6 @@ export const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
  * Sentry.ErrorBoundary makes. Route errors from useRouteError carry no component
  * stack, so they omit it and fall back to captureException.
  */
-/** Replace a URL's path segments and query VALUES with placeholders.
- *
- *  Note paths, titles, attachment filenames and single-use credentials all
- *  travel in URLs here (`/attachments/Medical/labs.pdf`, `?code=`, `?token=`),
- *  and the SDK attaches `request.url` to every event plus a breadcrumb to every
- *  fetch. Keeping the shape is enough to debug a route; the contents are the
- *  user's. Parsed against a dummy base so relative URLs (what fetch breadcrumbs
- *  actually carry) work; that also means nearly any string resolves and gets
- *  scrubbed, which is the safe direction. The catch is a last resort: throwing
- *  inside beforeSend would drop the crash report entirely. */
-export function scrubUrl(url: string): string {
-	let parsed: URL;
-	try {
-		parsed = new URL(url, "http://x.invalid");
-	} catch {
-		return url;
-	}
-	const path = parsed.pathname
-		.split("/")
-		.map((seg) => (seg ? ":seg" : seg))
-		.join("/");
-	const keys = [...parsed.searchParams.keys()];
-	const query = keys.length > 0 ? `?${keys.map((k) => `${k}=:v`).join("&")}` : "";
-	return path + query;
-}
 
 export async function captureError(
 	error: unknown,
@@ -162,4 +89,101 @@ export async function captureError(
 	} catch (e) {
 		console.warn("[sentry] capture failed:", e);
 	}
+}
+
+/** Replace a URL's path segments and query VALUES with placeholders.
+ *
+ *  Note paths, titles, attachment filenames and single-use credentials all
+ *  travel in URLs here (`/attachments/Medical/labs.pdf`, `?code=`, `?token=`),
+ *  and the SDK attaches `request.url` to every event plus a breadcrumb to every
+ *  fetch. Keeping the shape is enough to debug a route; the contents are the
+ *  user's. Parsed against a dummy base so relative URLs (what fetch breadcrumbs
+ *  actually carry) work; that also means nearly any string resolves and gets
+ *  scrubbed, which is the safe direction. The catch is a last resort: throwing
+ *  inside beforeSend would drop the crash report entirely. */
+export function scrubUrl(url: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(url, "http://x.invalid");
+	} catch {
+		return url;
+	}
+	// Keep the HOST and the FIRST path segment; redact the rest.
+	//
+	// Scrubbing everything made the output useless at the moment reporting was
+	// switched on: "/:seg/:seg" cannot tell /api/search from /api/folders, and
+	// dropping the origin hid which service answered. Neither the hostname nor
+	// a first segment like "api" or "attachments" is user data — the note path,
+	// the filename and the credential all live deeper — so keeping them costs
+	// nothing and restores the ability to see which endpoint failed.
+	const segments = parsed.pathname.split("/");
+	const path = segments.map((seg, i) => (seg && i > 1 ? ":seg" : seg)).join("/");
+	const keys = [...parsed.searchParams.keys()];
+	const query = keys.length > 0 ? `?${keys.map((k) => `${k}=:v`).join("&")}` : "";
+	const host = parsed.hostname === "x.invalid" ? "" : parsed.origin;
+	return host + path + query;
+}
+
+/** Console and DOM breadcrumbs are dropped outright, and every other kind has
+ *  its URL scrubbed.
+ *
+ *  Console args are arbitrary values a developer passed to console.error —
+ *  attachment paths today, anything tomorrow — and DOM breadcrumbs serialize
+ *  `title`/`alt`/`aria-label` off the clicked element AND five ancestors, which
+ *  in this app carry note paths, filenames and frontmatter values. Neither is
+ *  worth a privacy review on every future edit. */
+export function scrubBreadcrumb(crumb: Breadcrumb): Breadcrumb | null {
+	if (crumb.category === "console" || crumb.category?.startsWith("ui.")) {
+		return null;
+	}
+	if (typeof crumb.data?.url === "string") {
+		crumb.data.url = scrubUrl(crumb.data.url);
+	}
+	if (typeof crumb.data?.to === "string") {
+		crumb.data.to = scrubUrl(crumb.data.to);
+	}
+	if (typeof crumb.data?.from === "string") {
+		crumb.data.from = scrubUrl(crumb.data.from);
+	}
+	return crumb;
+}
+
+/** httpContextIntegration attaches `request.url` AND `request.headers`, and
+ *  those headers include `Referer` — which, while a `?token=` or `?code=` is
+ *  still in the address bar, is the full URL of the page. Scrubbing the url and
+ *  leaving the header would have missed the same credential by one field. */
+export function scrubEvent<
+	T extends { request?: { url?: string; headers?: Record<string, string> } },
+>(event: T): T {
+	if (event.request?.url) {
+		event.request.url = scrubUrl(event.request.url);
+	}
+	const referer = event.request?.headers?.Referer;
+	if (event.request?.headers && typeof referer === "string") {
+		event.request.headers.Referer = scrubUrl(referer);
+	}
+	return event;
+}
+
+/** The exact options passed to `Sentry.init`. Exported so a test can assert the
+ *  scrubbers are actually WIRED — with them inline, deleting the two hook lines
+ *  left every test green while DOM breadcrumbs (which serialize title/alt/
+ *  aria-label off the target and five ancestors) shipped again. */
+export function sentryInitOptions(dsn: string) {
+	return {
+		dsn,
+		environment: import.meta.env.MODE,
+		release: import.meta.env.VITE_GIT_SHA,
+		// `integrations: []` does NOT disable the defaults — the SDK MERGES this
+		// array with getDefaultIntegrations() and only `defaultIntegrations: false`
+		// opts out. So breadcrumbs and httpContext were live the whole time, which
+		// is what makes the scrubbing below necessary rather than decorative.
+		integrations: [],
+		// sendDefaultPii=false (SDK default) keeps cookies + the Authorization
+		// header out of breadcrumbs even if the SDK's own scrubbing misses
+		// something. Restated for documentation.
+		sendDefaultPii: false,
+		beforeBreadcrumb: scrubBreadcrumb,
+		beforeSend: scrubEvent,
+	};
 }

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -1,3 +1,4 @@
+import type { Breadcrumb } from "@sentry/react";
 import type { ErrorInfo } from "react";
 
 // Lazy Sentry singleton + crash reporter. Extracted from main.tsx so BOTH the
@@ -17,6 +18,38 @@ import type { ErrorInfo } from "react";
 // an unhandled rejection.
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
 
+/** Console and DOM breadcrumbs are dropped outright, and every other kind has
+ *  its URL scrubbed.
+ *
+ *  Console args are arbitrary values a developer passed to console.error —
+ *  attachment paths today, anything tomorrow — and DOM breadcrumbs serialize
+ *  `title`/`alt`/`aria-label` off the clicked element AND five ancestors, which
+ *  in this app carry note paths, filenames and frontmatter values. Neither is
+ *  worth a privacy review on every future edit. */
+function scrubBreadcrumb(crumb: Breadcrumb): Breadcrumb | null {
+	if (crumb.category === "console" || crumb.category?.startsWith("ui.")) {
+		return null;
+	}
+	if (typeof crumb.data?.url === "string") {
+		crumb.data.url = scrubUrl(crumb.data.url);
+	}
+	if (typeof crumb.data?.to === "string") {
+		crumb.data.to = scrubUrl(crumb.data.to);
+	}
+	if (typeof crumb.data?.from === "string") {
+		crumb.data.from = scrubUrl(crumb.data.from);
+	}
+	return crumb;
+}
+
+/** The event itself carries `request.url` via httpContextIntegration. */
+function scrubEvent<T extends { request?: { url?: string } }>(event: T): T {
+	if (event.request?.url) {
+		event.request.url = scrubUrl(event.request.url);
+	}
+	return event;
+}
+
 type SentrySdk = typeof import("@sentry/react");
 
 const earlyErrors: unknown[] = [];
@@ -34,11 +67,18 @@ export const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
 					dsn: sentryDsn,
 					environment: import.meta.env.MODE,
 					release: import.meta.env.VITE_GIT_SHA,
+					// `integrations: []` does NOT disable the defaults — the SDK
+					// MERGES this array with getDefaultIntegrations() and only
+					// `defaultIntegrations: false` opts out. So breadcrumbs and
+					// httpContext were live the whole time, which is what made the
+					// scrubbing below necessary rather than decorative.
 					integrations: [],
 					// sendDefaultPii=false (SDK default) keeps cookies + the
 					// Authorization header out of breadcrumbs even if the SDK's
 					// own scrubbing misses something. Restated for documentation.
 					sendDefaultPii: false,
+					beforeBreadcrumb: scrubBreadcrumb,
+					beforeSend: scrubEvent,
 				});
 				// The SDK's own global handlers are live from here; hand it the
 				// backlog and retire the temporary listeners.
@@ -77,6 +117,32 @@ export const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
  * Sentry.ErrorBoundary makes. Route errors from useRouteError carry no component
  * stack, so they omit it and fall back to captureException.
  */
+/** Replace a URL's path segments and query VALUES with placeholders.
+ *
+ *  Note paths, titles, attachment filenames and single-use credentials all
+ *  travel in URLs here (`/attachments/Medical/labs.pdf`, `?code=`, `?token=`),
+ *  and the SDK attaches `request.url` to every event plus a breadcrumb to every
+ *  fetch. Keeping the shape is enough to debug a route; the contents are the
+ *  user's. Parsed against a dummy base so relative URLs (what fetch breadcrumbs
+ *  actually carry) work; that also means nearly any string resolves and gets
+ *  scrubbed, which is the safe direction. The catch is a last resort: throwing
+ *  inside beforeSend would drop the crash report entirely. */
+export function scrubUrl(url: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(url, "http://x.invalid");
+	} catch {
+		return url;
+	}
+	const path = parsed.pathname
+		.split("/")
+		.map((seg) => (seg ? ":seg" : seg))
+		.join("/");
+	const keys = [...parsed.searchParams.keys()];
+	const query = keys.length > 0 ? `?${keys.map((k) => `${k}=:v`).join("&")}` : "";
+	return path + query;
+}
+
 export async function captureError(
 	error: unknown,
 	errorInfo?: ErrorInfo,

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -1,5 +1,39 @@
 import type { Breadcrumb } from "@sentry/react";
 import type { ErrorInfo } from "react";
+import { ROUTES } from "./routes";
+
+/** First path segments that are ours, not the user's.
+ *
+ *  Derived from ROUTES where possible so a new SPA route cannot silently start
+ *  being redacted (and a renamed one cannot silently start leaking). The rest
+ *  are segments with no ROUTES entry: router-literal paths, the API prefixes
+ *  fetch breadcrumbs carry, and Vite's asset dir.
+ *
+ *  Anything NOT here is treated as user data. That is the safe default — the
+ *  cost of a miss is one unhelpful ":seg" in a stack trace, versus a vault
+ *  name shipped to a third party. */
+const KNOWN_FIRST_SEGMENTS = new Set<string>([
+	// flatMap, not map+filter(Boolean): under noUncheckedIndexedAccess the
+	// index is `string | undefined` and filter(Boolean) does not narrow it.
+	...Object.values(ROUTES).flatMap((route) => {
+		const [, segment] = route.split("/");
+		return segment ? [segment] : [];
+	}),
+	// Router literals with no ROUTES constant.
+	"onboard",
+	"settings",
+	"reset-password",
+	"note",
+	"__qc",
+	// Backend prefixes seen in fetch/xhr breadcrumb URLs.
+	"api",
+	"attachments",
+	"socket",
+	"webhooks",
+	".well-known",
+	// Vite build output.
+	"assets",
+]);
 
 // Lazy Sentry singleton + crash reporter. Extracted from main.tsx so BOTH the
 // root boundary (main.tsx, catches bootstrap/app-shell throws above the router)
@@ -101,6 +135,7 @@ export async function captureError(
  *  actually carry) work; that also means nearly any string resolves and gets
  *  scrubbed, which is the safe direction. The catch is a last resort: throwing
  *  inside beforeSend would drop the crash report entirely. */
+
 export function scrubUrl(url: string): string {
 	let parsed: URL;
 	try {
@@ -108,16 +143,30 @@ export function scrubUrl(url: string): string {
 	} catch {
 		return url;
 	}
-	// Keep the HOST and the FIRST path segment; redact the rest.
+	// Keep the HOST and the first path segment ONLY when that segment is a
+	// route we ship; redact everything else.
 	//
 	// Scrubbing everything made the output useless at the moment reporting was
 	// switched on: "/:seg/:seg" cannot tell /api/search from /api/folders, and
-	// dropping the origin hid which service answered. Neither the hostname nor
-	// a first segment like "api" or "attachments" is user data — the note path,
-	// the filename and the credential all live deeper — so keeping them costs
-	// nothing and restores the ability to see which endpoint failed.
+	// dropping the origin hid which service answered.
+	//
+	// But "keep segment 1" is wrong for this router. `/:slug` (router.tsx) is
+	// the VAULT route, and the slug is slugify(vault.name) — a user-typed name.
+	// A vault called "Divorce 2026" put `divorce-2026` into every navigation
+	// breadcrumb and every event's request.url, on the app's most-travelled
+	// route. An allowlist keeps the diagnostic value and closes that.
 	const segments = parsed.pathname.split("/");
-	const path = segments.map((seg, i) => (seg && i > 1 ? ":seg" : seg)).join("/");
+	const path = segments
+		.map((seg, i) => {
+			if (!seg) {
+				return seg;
+			}
+			if (i === 1) {
+				return KNOWN_FIRST_SEGMENTS.has(seg) ? seg : ":seg";
+			}
+			return ":seg";
+		})
+		.join("/");
 	const keys = [...parsed.searchParams.keys()];
 	const query = keys.length > 0 ? `?${keys.map((k) => `${k}=:v`).join("&")}` : "";
 	const host = parsed.hostname === "x.invalid" ? "" : parsed.origin;
@@ -158,9 +207,16 @@ export function scrubEvent<
 	if (event.request?.url) {
 		event.request.url = scrubUrl(event.request.url);
 	}
-	const referer = event.request?.headers?.Referer;
-	if (event.request?.headers && typeof referer === "string") {
-		event.request.headers.Referer = scrubUrl(referer);
+	// Case-insensitive: httpContextIntegration capitalizes it today, but header
+	// names are case-insensitive by spec and an exact-key match is the same
+	// "missed it by one field" mode this function exists to close.
+	const headers = event.request?.headers;
+	if (headers) {
+		for (const key of Object.keys(headers)) {
+			if (key.toLowerCase() === "referer" && typeof headers[key] === "string") {
+				headers[key] = scrubUrl(headers[key]);
+			}
+		}
 	}
 	return event;
 }

--- a/frontend/src/viewer/attachment-img.tsx
+++ b/frontend/src/viewer/attachment-img.tsx
@@ -29,7 +29,8 @@ export default function AttachmentImg({ path, alt }: { path: string; alt?: strin
 				}
 				// A non-ApiError is a bug (e.g. createObjectURL), not a load failure.
 				if (!(err instanceof ApiError)) {
-					console.error("attachment image load failed", path, err);
+					// See attachment-page: the path is the user's folder structure.
+					console.error("attachment image load failed", err);
 				}
 				setError(err instanceof ApiError && err.status === 404 ? "missing" : "failed");
 			});

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -50,7 +50,10 @@ export default function AttachmentPage() {
 					return;
 				}
 				if (!(err instanceof ApiError)) {
-					console.error("attachment load failed", path, err);
+					// Path withheld: an attachment path is folder structure plus a filename
+					// ("Medical/2026-lab-results.pdf"), and console args become Sentry
+					// breadcrumbs as well as sitting in a console the user may screenshot.
+					console.error("attachment load failed", err);
 				}
 				setError(err instanceof ApiError && err.status === 404 ? "missing" : "failed");
 			});

--- a/lib/engram/links/rewriter.ex
+++ b/lib/engram/links/rewriter.ex
@@ -544,7 +544,10 @@ defmodule Engram.Links.Rewriter do
     :exit, reason ->
       Logger.error(
         "link rewrite room push exited",
-        Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
+        Metadata.with_category(:error, :sync,
+          note_id: note_id,
+          reason: Metadata.safe_exit_reason(reason)
+        )
       )
 
       {:error, :room_gone}

--- a/lib/engram/logger/metadata.ex
+++ b/lib/engram/logger/metadata.ex
@@ -76,6 +76,13 @@ defmodule Engram.Logger.Metadata do
 
   def safe_reason(%mod{}), do: inspect(mod)
 
+  # Atoms are the single most common reason shape in this codebase
+  # (`:not_found`, `:timeout`, `:version_conflict`) and cannot carry note
+  # content — nothing on these paths interns user text as an atom. Without this
+  # they all collapsed to "unknown", which is the failure mode that makes
+  # on-call route around a filter instead of trusting it.
+  def safe_reason(reason) when is_atom(reason), do: inspect(reason)
+
   # A rescue always binds a struct, but this is called from a shared logging
   # module and its @spec invites `catch :exit, reason`. `hmac_ref/1` in
   # notes.ex got a fallback in the same commit for exactly this reason — "a log

--- a/lib/engram/logger/metadata.ex
+++ b/lib/engram/logger/metadata.ex
@@ -24,24 +24,65 @@ defmodule Engram.Logger.Metadata do
   nor `:message` is in its set, so Loki and CloudWatch print it verbatim. (The
   Sentry metadata allowlist in `Engram.Application` is separate and narrower.)
 
-  So the filter is on the exception TYPE. Allowlisted types keep their message
-  because it is our own text or the database's; everything else contributes its
-  class only.
+  So the filter is on the exception TYPE. An allowlist, not a denylist: a new
+  exception type in Elixir or a dependency defaults to safe-and-useless rather
+  than to leaking.
 
-  An allowlist, not a denylist: a new exception type in Elixir or a dependency
-  defaults to safe-and-useless rather than to leaking.
+  ## What is NOT allowlisted, and why
+
+  The first version of this list said allowlisted messages were "our own text
+  or the database's". Three of its five entries were traced to their
+  `message/1` and shown to render user data:
+
+    * `Ecto.StaleEntryError` → `inspect(changeset.data)`, i.e. the WHOLE
+      `%Note{}` including `:content`. `Engram.Notes.Note` has no
+      `@derive Inspect`, and `utf8_backfill_test.exs` asserts exactly that the
+      struct inspects its plaintext. This is the round-3 defect —
+      `Exception.message/1` renders `inspect(term)` — reintroduced by name in
+      the fix for it.
+    * `Ecto.QueryError` → renders the query with PINNED PARAMS verbatim.
+    * `Postgrex.Error` → `message` (which quotes an offending value), plus
+      `build_query/1` (the SQL) and `build_detail/1` (Postgres `DETAIL`, i.e.
+      "Failing row contains (…)").
+
+  Postgres is still the most useful signal on this path, so it is rendered
+  STRUCTURALLY from fields that are codes rather than values. Never
+  `Exception.message/1`.
   """
+  # Only types whose message/1 was read in deps/ and confirmed to contain no
+  # value from the row, the query, or the changeset.
   @safe_message_exceptions [
-    Postgrex.Error,
-    DBConnection.ConnectionError,
+    # Constraint NAMES only.
     Ecto.ConstraintError,
-    Ecto.StaleEntryError,
-    Ecto.QueryError
+    # Operator text ("tcp recv: closed"). One latent path renders
+    # `inspect(other)` on a bad pool return, which cannot hold note content.
+    DBConnection.ConnectionError
   ]
 
-  @spec safe_reason(Exception.t() | struct()) :: String.t()
+  @spec safe_reason(Exception.t() | struct() | any()) :: String.t()
   def safe_reason(%mod{} = e) when mod in @safe_message_exceptions, do: Exception.message(e)
+
+  # Severity + SQLSTATE + the atom name. Everything a responder actually greps
+  # for, and no field that can hold a row value.
+  def safe_reason(%Postgrex.Error{postgres: %{} = pg}) do
+    [Map.get(pg, :severity), Map.get(pg, :pg_code), Map.get(pg, :code)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map_join(" ", &to_string/1)
+    |> case do
+      "" -> "Postgrex.Error"
+      rendered -> rendered
+    end
+  end
+
   def safe_reason(%mod{}), do: inspect(mod)
+
+  # A rescue always binds a struct, but this is called from a shared logging
+  # module and its @spec invites `catch :exit, reason`. `hmac_ref/1` in
+  # notes.ex got a fallback in the same commit for exactly this reason — "a log
+  # helper must not be the thing that breaks it" — and the reasoning was not
+  # carried one function over. A FunctionClauseError raised from inside an
+  # isolation rescue defeats the isolation.
+  def safe_reason(_other), do: "unknown"
 
   def with_category(level, category, metadata \\ []) do
     unless Category.valid?(category) do

--- a/lib/engram/logger/metadata.ex
+++ b/lib/engram/logger/metadata.ex
@@ -91,6 +91,53 @@ defmodule Engram.Logger.Metadata do
   # isolation rescue defeats the isolation.
   def safe_reason(_other), do: "unknown"
 
+  @doc """
+  Where a raise happened, with no argument values.
+
+  `Exception.format_stacktrace/1` is NOT safe to log. BEAM puts the failing
+  call's actual ARGUMENT LIST in the top frame for `FunctionClauseError`,
+  `UndefinedFunctionError` and any BIF/NIF `badarg`, and the formatter inspects
+  each one at `:printable_limit` (4096 bytes) — so a `FunctionClauseError` in
+  `Crypto.hmac_content_hash(key, text)` prints ~4 KB of the note body.
+
+  This renders `Module.function/arity` per frame and nothing else. Locations
+  answer "where"; the values were never the part that helped.
+  """
+  @spec format_location(Exception.stacktrace()) :: String.t()
+  def format_location(stacktrace) when is_list(stacktrace) do
+    stacktrace
+    |> Enum.take(5)
+    |> Enum.map_join(" <- ", fn
+      {mod, fun, arity, _loc} when is_integer(arity) -> "#{inspect(mod)}.#{fun}/#{arity}"
+      {mod, fun, args, _loc} when is_list(args) -> "#{inspect(mod)}.#{fun}/#{length(args)}"
+      _other -> "?"
+    end)
+  end
+
+  def format_location(_other), do: "?"
+
+  @doc """
+  A log-safe rendering of a `catch :exit, reason` value.
+
+  `inspect(reason)` is not safe here for the same reason a raw stacktrace is
+  not: an exit from a crashed GenServer is `{exception, stacktrace}`, and a
+  `GenServer.call` timeout is `{:timeout, {GenServer, :call, [pid, request, _]}}`
+  — where `request` on these paths is a Yjs frame or note content, rendered at
+  `:printable_limit`.
+
+  Keeps the shape and the location, drops every value.
+  """
+  @spec safe_exit_reason(any()) :: String.t()
+  def safe_exit_reason({%{__exception__: true} = e, stacktrace}) when is_list(stacktrace),
+    do: "#{safe_reason(e)} at #{format_location(stacktrace)}"
+
+  def safe_exit_reason({:timeout, {mod, fun, args}}) when is_list(args),
+    do: "timeout in #{inspect(mod)}.#{fun}/#{length(args)}"
+
+  def safe_exit_reason({tag, _payload}) when is_atom(tag), do: inspect(tag)
+  def safe_exit_reason(reason) when is_atom(reason), do: inspect(reason)
+  def safe_exit_reason(_other), do: "unknown"
+
   def with_category(level, category, metadata \\ []) do
     unless Category.valid?(category) do
       raise ArgumentError, "unknown log category: #{inspect(category)}"

--- a/lib/engram/logger/metadata.ex
+++ b/lib/engram/logger/metadata.ex
@@ -10,6 +10,39 @@ defmodule Engram.Logger.Metadata do
   alias Engram.Logger.Category
 
   @spec with_category(Logger.level(), atom(), keyword()) :: keyword()
+  @doc """
+  A log-safe rendering of a rescued exception.
+
+  `Exception.message/1` is not "our own text". `CaseClauseError`, `MatchError`,
+  `KeyError`, `Protocol.UndefinedError` and `Jason.EncodeError` all render
+  `inspect(term)` of the value that blew up — and in this codebase the terms
+  flowing through a rescue are frequently note content, a path, or a search
+  query.
+
+  Moving such a message into metadata does NOT make it safe:
+  `Engram.Logger.RedactFilter` scrubs by KEY, and neither `:error`, `:reason`
+  nor `:message` is in its set, so Loki and CloudWatch print it verbatim. (The
+  Sentry metadata allowlist in `Engram.Application` is separate and narrower.)
+
+  So the filter is on the exception TYPE. Allowlisted types keep their message
+  because it is our own text or the database's; everything else contributes its
+  class only.
+
+  An allowlist, not a denylist: a new exception type in Elixir or a dependency
+  defaults to safe-and-useless rather than to leaking.
+  """
+  @safe_message_exceptions [
+    Postgrex.Error,
+    DBConnection.ConnectionError,
+    Ecto.ConstraintError,
+    Ecto.StaleEntryError,
+    Ecto.QueryError
+  ]
+
+  @spec safe_reason(Exception.t() | struct()) :: String.t()
+  def safe_reason(%mod{} = e) when mod in @safe_message_exceptions, do: Exception.message(e)
+  def safe_reason(%mod{}), do: inspect(mod)
+
   def with_category(level, category, metadata \\ []) do
     unless Category.valid?(category) do
       raise ArgumentError, "unknown log category: #{inspect(category)}"

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3309,20 +3309,34 @@ defmodule Engram.Notes do
   # pass a fn that runs a real failing Repo query (a plain `raise` will NOT
   # exercise the savepoint, since it never enters 25P02).
   @doc false
+  # A short, non-reversible handle for log lines. Base64 of the path HMAC,
+  # truncated — enough to correlate two lines about the same note, useless for
+  # recovering the path.
+  defp hmac_ref(%{path_hmac: hmac}) when is_binary(hmac),
+    do: hmac |> Base.encode64() |> binary_part(0, 12)
+
+  defp hmac_ref(_entry), do: "unknown"
+
   @spec process_batch_entry_rescued(map(), list(), (-> {map(), list()})) :: {map(), list()}
   def process_batch_entry_rescued(entry, rows, fun) do
     fun.()
   rescue
     e ->
-      # Path AND exception reason go in the message string, not metadata
-      # alone: neither `:path` nor `:error` is in the Sentry LoggerHandler
-      # metadata allowlist (application.ex), and the console formatter's
-      # allowlist (config.exs) drops them too. Interpolating keeps both
-      # Sentry-visible (on-call sees WHY it raised) AND greppable/testable
-      # in the plain-text console/CI logs. Metadata copies kept for prod's
-      # metadata: :all JSON formatter (Loki structured fields).
+      # The note ID, never the path. This used to interpolate `entry.path`
+      # DELIBERATELY, to route it past the Sentry metadata allowlist so on-call
+      # could see it — which is precisely the thing the allowlist exists to
+      # prevent. RedactFilter and the Sentry scrubber both stop at metadata;
+      # a message body is unfiltered, so that comment was describing a way
+      # around the redaction rather than a reason to bypass it. A path is
+      # folder structure plus a title, and Sentry is a third party.
+      #
+      # The exception reason still interpolates — that is our own text — and
+      # the path stays in metadata, where prod's JSON formatter puts it into
+      # Loki (ours) and the allowlist keeps it out of Sentry (not ours).
+      # On-call correlates on the path HMAC, which is already how this module
+      # indexes paths: non-reversible, and it joins to the same row.
       Logger.error(
-        "batch entry raised, degrading note: #{entry.path} (#{Exception.message(e)})",
+        "batch entry raised, degrading note path_hmac=#{hmac_ref(entry)} (#{Exception.message(e)})",
         Metadata.with_category(:error, :sync,
           path: entry.path,
           error: Exception.message(e)

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3334,24 +3334,30 @@ defmodule Engram.Notes do
       # around the redaction rather than a reason to bypass it. A path is
       # folder structure plus a title, and Sentry is a third party.
       #
-      # Only the exception CLASS goes in the body. `Exception.message/1` is not
-      # "our own text": CaseClauseError, MatchError, Protocol.UndefinedError,
-      # Jason.EncodeError and Postgrex.Error all render `inspect(term)` of the
-      # offending value, and this rescue wraps frontmatter parsing, CRDT merge
-      # and encryption — every one of which handles note content. A raise over
-      # a note body printed the body:
+      # `Exception.message/1` is not "our own text": CaseClauseError,
+      # MatchError, KeyError, Protocol.UndefinedError and Jason.EncodeError all
+      # render `inspect(term)` of the offending value, and this rescue wraps
+      # frontmatter parsing, CRDT merge and encryption — every one of which
+      # handles note content. A raise over a note body printed the body:
       #
       #   batch entry raised ... (no case clause matching:
       #     {:parsed, "Dear diary, the biopsy came back positive."})
       #
-      # The full message stays in metadata under `error`, where RedactFilter
-      # and the Sentry allowlist can gate it. On-call correlates on the path
-      # HMAC: non-reversible, and it joins to the same row.
+      # Moving it to metadata does NOT fix that. `:error` is not in
+      # RedactFilter's key set, so Loki and CloudWatch get it verbatim. (It is
+      # absent from the Sentry metadata allowlist in application.ex, so Sentry
+      # alone was safe — but "not sent to a third party" is not the bar; the
+      # bar is not logged at all.)
+      #
+      # So the reason is filtered by exception TYPE, in both places. On-call
+      # correlates on the path HMAC: non-reversible, joins to the same row.
+      reason = Metadata.safe_reason(e)
+
       Logger.error(
-        "batch entry raised, degrading note path_hmac=#{hmac_ref(entry)} (#{inspect(e.__struct__)})",
+        "batch entry raised, degrading note path_hmac=#{hmac_ref(entry)} (#{reason})",
         Metadata.with_category(:error, :sync,
           path: entry.path,
-          error: Exception.message(e)
+          error: reason
         )
       )
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3241,6 +3241,18 @@ defmodule Engram.Notes do
     end
   end
 
+  # A short, non-reversible handle for log lines. Base64 of the path HMAC,
+  # truncated — enough to correlate two lines about the same note, useless for
+  # recovering the path.
+  #
+  # binary_slice, not binary_part: the latter raises below 12 chars. Today the
+  # HMAC is always SHA-256 (44 chars), but this sits INSIDE a rescue whose only
+  # job is isolation, and a log helper must not be the thing that breaks it.
+  defp hmac_ref(%{path_hmac: hmac}) when is_binary(hmac),
+    do: hmac |> Base.encode64() |> binary_slice(0..11)
+
+  defp hmac_ref(_entry), do: "unknown"
+
   defp process_batch_entry(%{result: nil} = entry, existing_by_hmac, user, vault, now, rows) do
     process_batch_entry_rescued(entry, rows, fn ->
       case Map.get(existing_by_hmac, entry.path_hmac) do
@@ -3309,14 +3321,6 @@ defmodule Engram.Notes do
   # pass a fn that runs a real failing Repo query (a plain `raise` will NOT
   # exercise the savepoint, since it never enters 25P02).
   @doc false
-  # A short, non-reversible handle for log lines. Base64 of the path HMAC,
-  # truncated — enough to correlate two lines about the same note, useless for
-  # recovering the path.
-  defp hmac_ref(%{path_hmac: hmac}) when is_binary(hmac),
-    do: hmac |> Base.encode64() |> binary_part(0, 12)
-
-  defp hmac_ref(_entry), do: "unknown"
-
   @spec process_batch_entry_rescued(map(), list(), (-> {map(), list()})) :: {map(), list()}
   def process_batch_entry_rescued(entry, rows, fun) do
     fun.()
@@ -3330,13 +3334,21 @@ defmodule Engram.Notes do
       # around the redaction rather than a reason to bypass it. A path is
       # folder structure plus a title, and Sentry is a third party.
       #
-      # The exception reason still interpolates — that is our own text — and
-      # the path stays in metadata, where prod's JSON formatter puts it into
-      # Loki (ours) and the allowlist keeps it out of Sentry (not ours).
-      # On-call correlates on the path HMAC, which is already how this module
-      # indexes paths: non-reversible, and it joins to the same row.
+      # Only the exception CLASS goes in the body. `Exception.message/1` is not
+      # "our own text": CaseClauseError, MatchError, Protocol.UndefinedError,
+      # Jason.EncodeError and Postgrex.Error all render `inspect(term)` of the
+      # offending value, and this rescue wraps frontmatter parsing, CRDT merge
+      # and encryption — every one of which handles note content. A raise over
+      # a note body printed the body:
+      #
+      #   batch entry raised ... (no case clause matching:
+      #     {:parsed, "Dear diary, the biopsy came back positive."})
+      #
+      # The full message stays in metadata under `error`, where RedactFilter
+      # and the Sentry allowlist can gate it. On-call correlates on the path
+      # HMAC: non-reversible, and it joins to the same row.
       Logger.error(
-        "batch entry raised, degrading note path_hmac=#{hmac_ref(entry)} (#{Exception.message(e)})",
+        "batch entry raised, degrading note path_hmac=#{hmac_ref(entry)} (#{inspect(e.__struct__)})",
         Metadata.with_category(:error, :sync,
           path: entry.path,
           error: Exception.message(e)

--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -101,16 +101,21 @@ defmodule Engram.Notes.CrdtCheckpoint do
     # raise here so unbind/checkpoint always degrades to :ok — the tail-WAL is
     # untouched (nothing pruned), so the flush replays on the next room bind.
     err ->
-      # safe_reason/1 + a bare stacktrace, not Exception.format/3. This path
-      # projects the CRDT doc into notes.content, so note plaintext is in scope,
-      # and CaseClauseError/MatchError/KeyError all render `inspect(term)` into
-      # a message BODY — the one place RedactFilter does not reach. The
-      # stacktrace stays: it is module/function/arity, not values, and it is the
-      # part that says where.
+      # safe_reason/1 + format_location/1. This path projects the CRDT doc into
+      # notes.content, so note plaintext is in scope.
+      #
+      # NOT Exception.format_stacktrace/1. An earlier version of this comment
+      # claimed a stacktrace is "module/function/arity, not values" — it is not.
+      # BEAM puts the failing call's ARGUMENT LIST in the top frame for
+      # FunctionClauseError, UndefinedFunctionError and any BIF/NIF badarg, and
+      # the formatter inspects each at :printable_limit (4096). A
+      # FunctionClauseError in Crypto.hmac_content_hash(key, text) printed ~4 KB
+      # of the note body — right next to the safe_reason/1 call that had just
+      # suppressed it.
       Logger.error(
         "crdt checkpoint raised resolving user note_id=#{note_id} " <>
           "error=#{Metadata.safe_reason(err)} " <>
-          "at=#{Exception.format_stacktrace(__STACKTRACE__)}",
+          "at=#{Metadata.format_location(__STACKTRACE__)}",
         Metadata.with_category(:error, :sync, note_id: note_id)
       )
 
@@ -253,7 +258,7 @@ defmodule Engram.Notes.CrdtCheckpoint do
       Logger.error(
         "crdt checkpoint raised note_id=#{note_id} " <>
           "error=#{Metadata.safe_reason(err)} " <>
-          "at=#{Exception.format_stacktrace(__STACKTRACE__)}",
+          "at=#{Metadata.format_location(__STACKTRACE__)}",
         Metadata.with_category(:error, :sync, note_id: note_id)
       )
 

--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -101,8 +101,16 @@ defmodule Engram.Notes.CrdtCheckpoint do
     # raise here so unbind/checkpoint always degrades to :ok — the tail-WAL is
     # untouched (nothing pruned), so the flush replays on the next room bind.
     err ->
+      # safe_reason/1 + a bare stacktrace, not Exception.format/3. This path
+      # projects the CRDT doc into notes.content, so note plaintext is in scope,
+      # and CaseClauseError/MatchError/KeyError all render `inspect(term)` into
+      # a message BODY — the one place RedactFilter does not reach. The
+      # stacktrace stays: it is module/function/arity, not values, and it is the
+      # part that says where.
       Logger.error(
-        "crdt checkpoint raised resolving user note_id=#{note_id} error=#{Exception.format(:error, err, __STACKTRACE__)}",
+        "crdt checkpoint raised resolving user note_id=#{note_id} " <>
+          "error=#{Metadata.safe_reason(err)} " <>
+          "at=#{Exception.format_stacktrace(__STACKTRACE__)}",
         Metadata.with_category(:error, :sync, note_id: note_id)
       )
 
@@ -243,7 +251,9 @@ defmodule Engram.Notes.CrdtCheckpoint do
   rescue
     err ->
       Logger.error(
-        "crdt checkpoint raised note_id=#{note_id} error=#{Exception.format(:error, err, __STACKTRACE__)}",
+        "crdt checkpoint raised note_id=#{note_id} " <>
+          "error=#{Metadata.safe_reason(err)} " <>
+          "at=#{Exception.format_stacktrace(__STACKTRACE__)}",
         Metadata.with_category(:error, :sync, note_id: note_id)
       )
 

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -251,7 +251,10 @@ defmodule Engram.Notes.CrdtDeliver do
     :exit, reason ->
       Logger.error(
         "crdt deliver room push exited",
-        Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
+        Metadata.with_category(:error, :sync,
+          note_id: note_id,
+          reason: Metadata.safe_exit_reason(reason)
+        )
       )
 
       :ok

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -329,18 +329,39 @@ defmodule Engram.Notes.CrdtDeliver do
     end
   rescue
     err ->
-      log_state_load_failure(note_id, Exception.format(:error, err, __STACKTRACE__))
+      # `:reason` is NOT scrubbed by RedactFilter — its own moduledoc calls that
+      # out and tells call sites that might log an error struct there to use a
+      # different key. This loads CRDT state, so the term that blew up can be a
+      # Yjs doc or note content.
+      log_state_load_failure(note_id, Metadata.safe_reason(err))
       {:error, :raised}
   catch
     kind, reason ->
-      log_state_load_failure(note_id, {kind, reason})
+      log_state_load_failure(note_id, "#{kind}: #{Metadata.safe_reason(reason)}")
       {:error, :caught}
   end
 
+  # Two shapes reach here: a pre-filtered binary from the rescue/catch arms,
+  # and a plain `{:error, reason}` / `{:tenant_txn, reason}` from the case above,
+  # where `reason` is a Repo/transaction term. Both are narrowed the same way —
+  # `:reason` is a metadata key RedactFilter documents as deliberately NOT
+  # scrubbed, so nothing downstream will do it for us.
+  defp log_state_load_failure(note_id, reason) when is_binary(reason) do
+    emit_state_load_failure(note_id, reason)
+  end
+
+  defp log_state_load_failure(note_id, {tag, reason}) when is_atom(tag) do
+    emit_state_load_failure(note_id, "#{tag}: #{Metadata.safe_reason(reason)}")
+  end
+
   defp log_state_load_failure(note_id, reason) do
+    emit_state_load_failure(note_id, Metadata.safe_reason(reason))
+  end
+
+  defp emit_state_load_failure(note_id, reason) do
     Logger.error(
       "crdt deliver state load failed — skipping room push (announce still fires)",
-      Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
+      Metadata.with_category(:error, :sync, note_id: note_id, reason: reason)
     )
   end
 

--- a/lib/engram/notes/crdt_index_persistence.ex
+++ b/lib/engram/notes/crdt_index_persistence.ex
@@ -136,7 +136,7 @@ defmodule Engram.Notes.CrdtIndexPersistence do
       emit_checkpoint(:failed)
 
       Logger.error(
-        "crdt index checkpoint exited: #{inspect(reason)}",
+        "crdt index checkpoint exited: #{Metadata.safe_exit_reason(reason)}",
         Metadata.with_category(:error, :sync, user_id: user_id, vault_id: vault_id)
       )
 

--- a/lib/engram/notes/crdt_index_persistence.ex
+++ b/lib/engram/notes/crdt_index_persistence.ex
@@ -118,8 +118,10 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     e ->
       emit_checkpoint(:failed)
 
+      # The index doc holds every path and title in the vault, so this rescue
+      # has more user data in scope than most, not less.
       Logger.error(
-        "crdt index checkpoint raised: #{Exception.message(e)}",
+        "crdt index checkpoint raised: #{Metadata.safe_reason(e)}",
         Metadata.with_category(:error, :sync, user_id: user_id, vault_id: vault_id)
       )
 

--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -219,7 +219,10 @@ defmodule Engram.Notes.CrdtTransport do
     :exit, reason ->
       Logger.error(
         "crdt transport room apply exited",
-        Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
+        Metadata.with_category(:error, :sync,
+          note_id: note_id,
+          reason: Metadata.safe_exit_reason(reason)
+        )
       )
 
       {:error, :room_unavailable}

--- a/lib/engram/notes/utf8_backfill.ex
+++ b/lib/engram/notes/utf8_backfill.ex
@@ -194,6 +194,11 @@ defmodule Engram.Notes.Utf8Backfill do
   # (An earlier version of this comment claimed dialyzer had proved changesets
   # unreachable. It had not — it only rejected a clause ORDER. Wrong, and
   # recorded here so it is not re-derived.)
-  defp format_reason({:error, :version_conflict, _note}), do: "version_conflict"
-  defp format_reason(other), do: inspect(other)
+  # Public only so a test can exercise it. Round 5 reverted this function
+  # entirely and the whole "note content cannot reach the backfill's failure
+  # log" block stayed green — every assertion in it measured Ecto's Inspect
+  # impl and the cast list, and nothing called this.
+  @doc false
+  def format_reason({:error, :version_conflict, _note}), do: "version_conflict"
+  def format_reason(other), do: inspect(other)
 end

--- a/lib/engram/notes/utf8_backfill.ex
+++ b/lib/engram/notes/utf8_backfill.ex
@@ -180,14 +180,20 @@ defmodule Engram.Notes.Utf8Backfill do
 
   defp bump(acc, key), do: Map.update!(acc, key, &(&1 + 1))
 
-  # Only ONE of the shapes this `with` can reject carries note data: the
-  # version_conflict tuple, which hands back the whole `%Note{}`. Drop it to
-  # the bare label. Everything else is `{:error, atom()}` or the
-  # notes_cap_reached counts tuple — safe to render, and useful to read.
+  # The version_conflict tuple hands back the whole `%Note{}`, whose :content
+  # field is the note body. Drop it to the bare label.
   #
-  # Deliberately two clauses, not five: dialyzer showed the earlier
-  # Ecto.Changeset clauses could never match here, and clauses covering the
-  # whole type would have made a defensive catch-all unreachable.
+  # The catch-all renders everything else, and `upsert_note/4` CAN return
+  # `{:error, %Ecto.Changeset{}}` (notes.ex:570, :746, validate_path/1). That
+  # is not a plaintext leak today, but only because of two things this module
+  # does not own: Ecto's Inspect impl prints `data` as `#Engram.Notes.Note<>`
+  # rather than expanding it, and `Note.changeset/2`'s cast list excludes the
+  # virtual :content/:title/:path. Add :content to that cast list and plaintext
+  # comes back through here. The test below is what would catch that.
+  #
+  # (An earlier version of this comment claimed dialyzer had proved changesets
+  # unreachable. It had not — it only rejected a clause ORDER. Wrong, and
+  # recorded here so it is not re-derived.)
   defp format_reason({:error, :version_conflict, _note}), do: "version_conflict"
   defp format_reason(other), do: inspect(other)
 end

--- a/lib/engram/notes/utf8_backfill.ex
+++ b/lib/engram/notes/utf8_backfill.ex
@@ -165,8 +165,12 @@ defmodule Engram.Notes.Utf8Backfill do
       bump(acc, :fixed)
     else
       other ->
+        # `inspect(other)` here rendered whatever the `with` rejected, and one
+        # of those shapes is `{:error, :version_conflict, %Note{}}` — a struct
+        # whose `:content` field is the note body. One conflicting backfill row
+        # put a user's note into CloudWatch.
         Logger.warning(
-          "utf8_backfill: failed to rewrite note #{decrypted.id}: #{inspect(other)}",
+          "utf8_backfill: failed to rewrite note #{decrypted.id}: #{format_reason(other)}",
           Metadata.with_category(:warning, :data, reason: "rewrite_failed")
         )
 
@@ -175,4 +179,15 @@ defmodule Engram.Notes.Utf8Backfill do
   end
 
   defp bump(acc, key), do: Map.update!(acc, key, &(&1 + 1))
+
+  # Only ONE of the shapes this `with` can reject carries note data: the
+  # version_conflict tuple, which hands back the whole `%Note{}`. Drop it to
+  # the bare label. Everything else is `{:error, atom()}` or the
+  # notes_cap_reached counts tuple — safe to render, and useful to read.
+  #
+  # Deliberately two clauses, not five: dialyzer showed the earlier
+  # Ecto.Changeset clauses could never match here, and clauses covering the
+  # whole type would have made a defensive catch-all unreachable.
+  defp format_reason({:error, :version_conflict, _note}), do: "version_conflict"
+  defp format_reason(other), do: inspect(other)
 end

--- a/lib/engram/rerankers/jina.ex
+++ b/lib/engram/rerankers/jina.ex
@@ -66,7 +66,9 @@ defmodule Engram.Rerankers.Jina do
         "Jina reranker exception, falling back to vector scores",
         Metadata.with_category(:warning, :search,
           exception: inspect(e.__struct__),
-          message: Exception.message(e)
+          # The request body carries the search QUERY and the candidate note
+          # excerpts, so a Jason.EncodeError or Req error here can render them.
+          message: Metadata.safe_reason(e)
         )
       )
 

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -632,10 +632,23 @@ defmodule EngramWeb.CrdtChannel do
     fun.()
   rescue
     e ->
-      log_entry_failure(entry, Exception.message(e))
+      # safe_reason/1, not Exception.message/1. This guard wraps
+      # prepare_create/2 (whose entry holds the client's `b64` genesis frame)
+      # and seed_and_checkpoint/5 (which materializes that frame into
+      # notes.content), so note plaintext is in scope on both — and
+      # CaseClauseError, MatchError and KeyError all render `inspect(term)`.
+      #
+      # The `else` arm of this same function was already narrowed for exactly
+      # this reason (see the error_kind/1 comment below: "inspecting the
+      # changeset whole dumps its changes ... into Loki. Only metadata keys are
+      # redacted, never the message body"). The rescue never got the same
+      # treatment.
+      log_entry_failure(entry, Metadata.safe_reason(e))
   catch
     :exit, reason ->
-      log_entry_failure(entry, "exited: #{inspect(reason)}")
+      # An exit reason carries the crashed call's arguments, which on this path
+      # are Yjs frames. Kind only.
+      log_entry_failure(entry, "exited: #{Metadata.safe_reason(reason)}")
   end
 
   defp log_entry_failure(entry, reason) do

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -872,7 +872,10 @@ defmodule EngramWeb.CrdtChannel do
     :exit, reason ->
       Logger.warning(
         "crdt genesis seed room apply exited",
-        Metadata.with_category(:warning, :sync, note_id: note_id, reason: inspect(reason))
+        Metadata.with_category(:warning, :sync,
+          note_id: note_id,
+          reason: Metadata.safe_exit_reason(reason)
+        )
       )
 
       :error

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -62,6 +62,19 @@ defmodule EngramWeb.Router do
   pipeline :oauth_api do
     plug :accepts, ["json"]
     plug EngramWeb.Plugs.RateLimit, limit: 10, period: 60_000
+
+    # Not all of this pipeline answers JSON. `GET /oauth/authorize` renders
+    # HTML on the error paths (OAuthAuthorizeController.render_client_error/2
+    # and render_server_error/2 both send `text/html`), so the OAuth entry
+    # point was serving framable, sniffable documents with no headers at all.
+    #
+    # Same set as :spa minus CSP, which is built for the SPA's integrations and
+    # would not describe these self-contained error pages.
+    plug :put_secure_browser_headers, %{
+      "x-content-type-options" => "nosniff",
+      "x-frame-options" => "DENY",
+      "referrer-policy" => "origin"
+    }
   end
 
   # OpenAPI spec serving — PutApiSpec needs its `module:` option, which a

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -68,12 +68,23 @@ defmodule EngramWeb.Router do
     # and render_server_error/2 both send `text/html`), so the OAuth entry
     # point was serving framable, sniffable documents with no headers at all.
     #
-    # Same set as :spa minus CSP, which is built for the SPA's integrations and
-    # would not describe these self-contained error pages.
+    # The CSP is set EXPLICITLY, not left to the default. `put_secure_browser_headers/2`
+    # runs `put_secure_defaults/1` first and merges your map over it, so it
+    # always emits a CSP — Phoenix's default is `frame-ancestors 'self'`, and
+    # per CSP Level 2 §7.4.1 `frame-ancestors` SUPERSEDES `x-frame-options` in
+    # every browser that supports both. Sending DENY next to a default CSP
+    # produces an effective policy of `'self'`: the header says one thing and
+    # the browser does another.
+    #
+    # `default-src 'none'` is exact here rather than merely strict — these
+    # pages are a heading and two paragraphs, with no script, style, image or
+    # fetch of any kind. It also applies to this pipeline's JSON routes, where
+    # a CSP is inert.
     plug :put_secure_browser_headers, %{
       "x-content-type-options" => "nosniff",
       "x-frame-options" => "DENY",
-      "referrer-policy" => "origin"
+      "referrer-policy" => "origin",
+      "content-security-policy" => "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
     }
   end
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -6,7 +6,14 @@ defmodule EngramWeb.Router do
 
     plug :put_secure_browser_headers, %{
       "x-content-type-options" => "nosniff",
-      "x-frame-options" => "DENY"
+      "x-frame-options" => "DENY",
+      # Phoenix's put_secure_defaults/1 always emits a CSP, and its default is
+      # `frame-ancestors 'self'` — which per CSP Level 2 section 7.4.1
+      # SUPERSEDES the x-frame-options DENY set right above it. Left implicit,
+      # this pipeline claimed DENY and got 'self'. These routes answer JSON, so
+      # nothing here is framable anyway; the point is that the header and the
+      # effective policy now agree.
+      "content-security-policy" => "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
     }
   end
 
@@ -19,7 +26,14 @@ defmodule EngramWeb.Router do
   pipeline :api_any_accept do
     plug :put_secure_browser_headers, %{
       "x-content-type-options" => "nosniff",
-      "x-frame-options" => "DENY"
+      "x-frame-options" => "DENY",
+      # Phoenix's put_secure_defaults/1 always emits a CSP, and its default is
+      # `frame-ancestors 'self'` — which per CSP Level 2 section 7.4.1
+      # SUPERSEDES the x-frame-options DENY set right above it. Left implicit,
+      # this pipeline claimed DENY and got 'self'. These routes answer JSON, so
+      # nothing here is framable anyway; the point is that the header and the
+      # effective policy now agree.
+      "content-security-policy" => "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
     }
   end
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -89,7 +89,21 @@ defmodule EngramWeb.Router do
 
     plug :put_secure_browser_headers, %{
       "x-content-type-options" => "nosniff",
-      "x-frame-options" => "DENY"
+      "x-frame-options" => "DENY",
+      # Mirrors frontend/public/_headers, which covers ONLY the Cloudflare
+      # bundle. This pipeline serves the self-hosted SPA, and without the
+      # override Phoenix emits its default
+      # `strict-origin-when-cross-origin` — which sends the full path
+      # same-origin, i.e. `/link?code=` and `/reset-password?token=` ride the
+      # Referer of every same-origin subresource, including the lazy route
+      # chunk that loads before the page can scrub the URL.
+      #
+      # Self-host is where this matters MOST: password reset sits behind
+      # RequireLocalAuth, so the token flow only exists on this deployment.
+      #
+      # Only set here. The :api pipelines answer JSON, not documents, and a
+      # referrer policy governs requests a document makes.
+      "referrer-policy" => "origin"
     }
 
     plug :put_csp_header

--- a/test/engram/logger/metadata_safe_reason_test.exs
+++ b/test/engram/logger/metadata_safe_reason_test.exs
@@ -11,6 +11,8 @@ defmodule Engram.Logger.MetadataSafeReasonTest do
   """
   use ExUnit.Case, async: true
 
+  import Ecto.Query, only: [from: 2]
+
   alias Engram.Logger.Metadata
 
   @secret "Dear diary, the biopsy came back positive."
@@ -41,25 +43,91 @@ defmodule Engram.Logger.MetadataSafeReasonTest do
     end
   end
 
+  # Round 5 traced every allowlisted type's message/1 into deps/ and executed
+  # them. Three of the original five rendered user data. These are the ones
+  # that were WRONG, and they are pinned so the allowlist cannot regrow.
+  describe "types whose message/1 renders a value are NOT allowlisted" do
+    # The whole %Note{} — `inspect(changeset.data)`. This is the round-3 defect
+    # (Exception.message/1 renders inspect(term)) reintroduced by name in the
+    # fix for it.
+    test "Ecto.StaleEntryError does not render the struct it holds" do
+      note = %Engram.Notes.Note{content: @secret, title: "Biopsy", path: "Medical/biopsy.md"}
+      # Built via exception/1, which is what computes the leaky message.
+      e = Ecto.StaleEntryError.exception(action: :update, changeset: %Ecto.Changeset{data: note})
+
+      # The message really does carry it — otherwise this tests nothing.
+      assert Exception.message(e) =~ "biopsy"
+
+      # The struct really does inspect its plaintext — so this measures the
+      # filter, not an empty base.
+      assert inspect(note) =~ "biopsy"
+      refute Metadata.safe_reason(e) =~ "biopsy"
+      refute Metadata.safe_reason(e) =~ "Medical"
+    end
+
+    # Renders the query with pinned params verbatim.
+    test "Ecto.QueryError does not render a pinned parameter" do
+      # A real query with a pinned param — Inspect.Ecto.Query renders it
+      # verbatim into the message, which is the leak.
+      query = from(n in Engram.Notes.Note, where: n.kind == ^@secret)
+      e = Ecto.QueryError.exception(message: "boom", query: query)
+
+      assert Exception.message(e) =~ "biopsy"
+      refute Metadata.safe_reason(e) =~ "biopsy"
+    end
+
+    # message + the SQL + Postgres DETAIL ("Failing row contains (...)").
+    test "Postgrex.Error renders codes, never the failing row or the query" do
+      e = %Postgrex.Error{
+        postgres: %{
+          code: :check_violation,
+          message: ~s(new row violates check constraint, value "#{@secret}"),
+          detail: "Failing row contains (1, #{@secret}, Medical/biopsy.md).",
+          severity: "ERROR",
+          pg_code: "23514"
+        },
+        query: "INSERT INTO notes (content) VALUES ('#{@secret}')"
+      }
+
+      rendered = Metadata.safe_reason(e)
+
+      refute rendered =~ "biopsy"
+      refute rendered =~ "Medical"
+      refute rendered =~ "INSERT"
+      # ...while keeping what a responder greps for.
+      assert rendered =~ "23514"
+      assert rendered =~ "check_violation"
+      assert rendered =~ "ERROR"
+    end
+  end
+
   # The counterweight: a type filter that dropped every message would make the
   # log useless, and on-call would route around it.
   describe "allowlisted types keep their message" do
-    test "Postgrex.Error keeps the SQLSTATE, which is the useful part" do
-      e = %Postgrex.Error{
-        postgres: %{
-          code: :numeric_value_out_of_range,
-          message: "bigint out of range",
-          severity: "ERROR",
-          pg_code: "22003"
-        }
+    test "Ecto.ConstraintError keeps its constraint name" do
+      e = %Ecto.ConstraintError{
+        type: :unique,
+        constraint: "notes_path_hmac_index",
+        message: "constraint error: notes_path_hmac_index (unique_constraint)"
       }
 
-      assert Metadata.safe_reason(e) =~ "bigint out of range"
+      assert Metadata.safe_reason(e) =~ "notes_path_hmac_index"
     end
 
     test "DBConnection.ConnectionError keeps its message" do
       assert Metadata.safe_reason(%DBConnection.ConnectionError{message: "tcp recv: closed"}) =~
                "tcp recv"
+    end
+  end
+
+  # A rescue always binds a struct, but this is a public helper on a shared
+  # logging module and its @spec invites `catch :exit, reason`. Raising from
+  # inside an isolation helper defeats the isolation.
+  describe "never raises, whatever it is handed" do
+    test "a non-struct does not raise" do
+      for value <- [:some_atom, {:error, "boom"}, "raw string", 42, nil, %{a: 1}] do
+        assert is_binary(Metadata.safe_reason(value))
+      end
     end
   end
 

--- a/test/engram/logger/metadata_safe_reason_test.exs
+++ b/test/engram/logger/metadata_safe_reason_test.exs
@@ -17,6 +17,14 @@ defmodule Engram.Logger.MetadataSafeReasonTest do
 
   @secret "Dear diary, the biopsy came back positive."
 
+  # `String.to_integer(@secret)` on a literal makes the compiler prove the call
+  # fails and emit "the call to binary_to_integer/1 will fail with a 'badarg'
+  # exception" — which --warnings-as-errors turns into a CI failure. It compiled
+  # clean locally only because _build was warm and these files were already
+  # built; CI compiles fresh. Routing through Enum.random/1 hides the value's
+  # type from the compiler while returning exactly it.
+  defp opaque_secret, do: Enum.random([@secret])
+
   # Every one of these renders inspect(term) in its message/1, and every one is
   # reachable from a rescue that has note content in scope.
   describe "exceptions that inspect a term contribute their class only" do
@@ -144,7 +152,7 @@ defmodule Engram.Logger.MetadataSafeReasonTest do
       # Raised for real so the stacktrace is BEAM's, not a fixture.
       {:error, stacktrace} =
         try do
-          String.to_integer(@secret)
+          String.to_integer(opaque_secret())
         rescue
           _ -> {:error, __STACKTRACE__}
         end
@@ -176,7 +184,7 @@ defmodule Engram.Logger.MetadataSafeReasonTest do
     test "an exception+stacktrace exit does not carry the arguments" do
       {:error, stacktrace} =
         try do
-          String.to_integer(@secret)
+          String.to_integer(opaque_secret())
         rescue
           _ -> {:error, __STACKTRACE__}
         end

--- a/test/engram/logger/metadata_safe_reason_test.exs
+++ b/test/engram/logger/metadata_safe_reason_test.exs
@@ -123,6 +123,16 @@ defmodule Engram.Logger.MetadataSafeReasonTest do
   # A rescue always binds a struct, but this is a public helper on a shared
   # logging module and its @spec invites `catch :exit, reason`. Raising from
   # inside an isolation helper defeats the isolation.
+  # A filter that renders everything "unknown" gets routed around. Atoms are the
+  # most common reason shape here and cannot carry note content.
+  describe "atoms survive, because they are the useful case" do
+    test "a bare reason atom renders" do
+      assert Metadata.safe_reason(:not_found) == ":not_found"
+      assert Metadata.safe_reason(:version_conflict) == ":version_conflict"
+      assert Metadata.safe_reason(nil) == "nil"
+    end
+  end
+
   describe "never raises, whatever it is handed" do
     test "a non-struct does not raise" do
       for value <- [:some_atom, {:error, "boom"}, "raw string", 42, nil, %{a: 1}] do

--- a/test/engram/logger/metadata_safe_reason_test.exs
+++ b/test/engram/logger/metadata_safe_reason_test.exs
@@ -1,0 +1,71 @@
+defmodule Engram.Logger.MetadataSafeReasonTest do
+  @moduledoc """
+  `safe_reason/1` is the one seam that decides whether a rescued exception's
+  message may be logged.
+
+  It exists because moving a message from the log body into metadata does not
+  redact it: `RedactFilter` scrubs by KEY, and `:error` / `:reason` / `:message`
+  are not in its set — so Loki and CloudWatch print metadata verbatim. The only
+  thing standing between a `CaseClauseError` over a note body and CloudWatch is
+  this function.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.Logger.Metadata
+
+  @secret "Dear diary, the biopsy came back positive."
+
+  # Every one of these renders inspect(term) in its message/1, and every one is
+  # reachable from a rescue that has note content in scope.
+  describe "exceptions that inspect a term contribute their class only" do
+    test "CaseClauseError" do
+      e = %CaseClauseError{term: {:parsed, @secret}}
+      assert Metadata.safe_reason(e) == "CaseClauseError"
+    end
+
+    test "MatchError" do
+      e = %MatchError{term: @secret}
+      assert Metadata.safe_reason(e) == "MatchError"
+    end
+
+    test "KeyError" do
+      e = %KeyError{key: :missing, term: %{"content" => @secret}}
+      assert Metadata.safe_reason(e) == "KeyError"
+    end
+
+    test "the raw message really would have leaked" do
+      e = %CaseClauseError{term: {:parsed, @secret}}
+
+      assert Exception.message(e) =~ "biopsy"
+      refute Metadata.safe_reason(e) =~ "biopsy"
+    end
+  end
+
+  # The counterweight: a type filter that dropped every message would make the
+  # log useless, and on-call would route around it.
+  describe "allowlisted types keep their message" do
+    test "Postgrex.Error keeps the SQLSTATE, which is the useful part" do
+      e = %Postgrex.Error{
+        postgres: %{
+          code: :numeric_value_out_of_range,
+          message: "bigint out of range",
+          severity: "ERROR",
+          pg_code: "22003"
+        }
+      }
+
+      assert Metadata.safe_reason(e) =~ "bigint out of range"
+    end
+
+    test "DBConnection.ConnectionError keeps its message" do
+      assert Metadata.safe_reason(%DBConnection.ConnectionError{message: "tcp recv: closed"}) =~
+               "tcp recv"
+    end
+  end
+
+  # A new exception type — from Elixir, or a dependency bump — must default to
+  # safe. This is the whole reason it is an allowlist.
+  test "an unknown exception type defaults to class-only" do
+    assert Metadata.safe_reason(%RuntimeError{message: @secret}) == "RuntimeError"
+  end
+end

--- a/test/engram/logger/metadata_safe_reason_test.exs
+++ b/test/engram/logger/metadata_safe_reason_test.exs
@@ -133,6 +133,83 @@ defmodule Engram.Logger.MetadataSafeReasonTest do
     end
   end
 
+  # A stacktrace is NOT "module/function/arity". BEAM puts the failing call's
+  # actual ARGUMENT LIST in the top frame for FunctionClauseError,
+  # UndefinedFunctionError and any BIF/NIF badarg, and
+  # Exception.format_stacktrace/1 inspects each at :printable_limit (4096) —
+  # so ~4 KB of a note body printed right next to the safe_reason/1 call that
+  # had just suppressed it.
+  describe "format_location/1 renders where, never what" do
+    test "a real FunctionClauseError's arguments do not survive" do
+      # Raised for real so the stacktrace is BEAM's, not a fixture.
+      {:error, stacktrace} =
+        try do
+          String.to_integer(@secret)
+        rescue
+          _ -> {:error, __STACKTRACE__}
+        end
+
+      # The unsafe formatter really does carry it — otherwise this proves nothing.
+      assert Exception.format_stacktrace(stacktrace) =~ "biopsy"
+
+      located = Metadata.format_location(stacktrace)
+      refute located =~ "biopsy"
+      refute located =~ @secret
+      # ...while still saying where. (String.to_integer/1 inlines to the BIF,
+      # so the top frame is :erlang.binary_to_integer/1 — which is the point:
+      # a real BEAM stacktrace, not a fixture.)
+      assert located =~ "binary_to_integer/1"
+    end
+
+    test "handles a malformed or empty stacktrace without raising" do
+      assert Metadata.format_location([]) == ""
+      assert is_binary(Metadata.format_location(:not_a_stacktrace))
+      assert is_binary(Metadata.format_location([:garbage]))
+    end
+  end
+
+  # An exit reason is the other way a stacktrace — and its arguments — reach a
+  # log. A crashed GenServer exits with `{exception, stacktrace}`, and a call
+  # timeout exits with `{:timeout, {GenServer, :call, [pid, request, _]}}` where
+  # `request` on these paths is a Yjs frame or note content.
+  describe "safe_exit_reason/1 keeps the shape, drops the values" do
+    test "an exception+stacktrace exit does not carry the arguments" do
+      {:error, stacktrace} =
+        try do
+          String.to_integer(@secret)
+        rescue
+          _ -> {:error, __STACKTRACE__}
+        end
+
+      reason = {%ArgumentError{message: @secret}, stacktrace}
+
+      # Both halves really would have leaked.
+      assert inspect(reason) =~ "biopsy"
+
+      rendered = Metadata.safe_exit_reason(reason)
+      refute rendered =~ "biopsy"
+      assert rendered =~ "ArgumentError"
+      assert rendered =~ "binary_to_integer/1"
+    end
+
+    test "a GenServer call timeout drops the request payload" do
+      reason = {:timeout, {GenServer, :call, [self(), {:apply, @secret}, 5000]}}
+
+      assert inspect(reason) =~ "biopsy"
+
+      rendered = Metadata.safe_exit_reason(reason)
+      refute rendered =~ "biopsy"
+      assert rendered =~ "GenServer.call/3"
+    end
+
+    test "ordinary exit shapes stay readable" do
+      assert Metadata.safe_exit_reason(:normal) == ":normal"
+      assert Metadata.safe_exit_reason(:noproc) == ":noproc"
+      assert Metadata.safe_exit_reason({:shutdown, @secret}) == ":shutdown"
+      assert is_binary(Metadata.safe_exit_reason("weird"))
+    end
+  end
+
   describe "never raises, whatever it is handed" do
     test "a non-struct does not raise" do
       for value <- [:some_atom, {:error, "boom"}, "raw string", 42, nil, %{a: 1}] do

--- a/test/engram/logger/rescue_reason_sink_test.exs
+++ b/test/engram/logger/rescue_reason_sink_test.exs
@@ -1,0 +1,67 @@
+defmodule Engram.Logger.RescueReasonSinkTest do
+  @moduledoc """
+  End-to-end proof, at the SINK, that a rescued exception's reason cannot carry
+  note content into Loki or CloudWatch.
+
+  Why this exists rather than another `capture_log` assertion: `capture_log`
+  renders the DEV text formatter, whose `metadata:` allowlist in
+  config/config.exs does not contain `:error`. A leak in `error:` metadata is
+  therefore INVISIBLE to capture_log and fully visible in prod — a test that
+  passes for a reason that does not hold in production.
+
+  Prod uses `{LoggerJSON.Formatters.Basic, metadata: {:all_except, [...]}}`
+  (config/prod.exs) — an emit-everything-but-a-few-keys list. So this builds the
+  real event, runs the real `RedactFilter`, and formats with the real prod
+  formatter config.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.Logger.Metadata
+  alias Engram.Logger.RedactFilter
+
+  @secret "Dear diary, the biopsy came back positive."
+
+  defp prod_line(meta, message) do
+    event = %{level: :error, msg: {:string, message}, meta: meta}
+    filtered = RedactFilter.filter(event, [])
+
+    {mod, cfg} = LoggerJSON.Formatters.Basic.new(metadata: {:all_except, [:__sentry__]})
+
+    mod.format(filtered, cfg) |> IO.iodata_to_binary() |> String.trim() |> Jason.decode!()
+  end
+
+  test "the reason a rescue logs never reaches the prod sink with note content" do
+    e = %CaseClauseError{term: {:parsed, @secret}}
+    reason = Metadata.safe_reason(e)
+
+    meta =
+      Metadata.with_category(:error, :sync, path: "Medical/biopsy.md", error: reason)
+      |> Map.new()
+
+    decoded = prod_line(meta, "batch entry raised, degrading note path_hmac=abc (#{reason})")
+    line = Jason.encode!(decoded)
+
+    refute line =~ "biopsy"
+    refute line =~ @secret
+    # The class survives, so the line still says what broke.
+    assert decoded["metadata"]["error"] == "CaseClauseError"
+    # And the path is redacted by key, as it already was.
+    assert decoded["metadata"]["path"] == "[REDACTED]"
+  end
+
+  # The failing half, stated as a test so the reason for safe_reason/1 is not
+  # re-derived: RedactFilter has no `:error` key, so putting a raw message there
+  # is NOT gated. This asserts the property that made the earlier fix wrong.
+  test "RedactFilter does not gate the :error key, which is why the type filter exists" do
+    meta =
+      Metadata.with_category(:error, :sync,
+        error: Exception.message(%CaseClauseError{term: @secret})
+      )
+      |> Map.new()
+
+    line = prod_line(meta, "batch entry raised") |> Jason.encode!()
+
+    assert line =~ "biopsy",
+           "RedactFilter now scrubs :error — safe_reason/1 may be redundant, re-check it"
+  end
+end

--- a/test/engram/notes/utf8_backfill_test.exs
+++ b/test/engram/notes/utf8_backfill_test.exs
@@ -169,6 +169,26 @@ defmodule Engram.Notes.Utf8BackfillTest do
   # version), which is why this pins the invariants rather than driving the
   # branch end to end.
   describe "note content cannot reach the backfill's failure log" do
+    # The one test that exercises the FIX. Reverting format_reason/1 used to
+    # leave every other test in this block green, because they all measured
+    # Ecto's Inspect impl and the cast list rather than the function that
+    # actually drops the content-bearing shape.
+    test "format_reason/1 drops the %Note{} the version_conflict tuple carries" do
+      secret = "Dear diary, the biopsy came back positive."
+      note = %Note{content: secret, title: "Biopsy results", path: "Medical/biopsy.md"}
+
+      # The struct really does inspect its plaintext, so this measures the
+      # filter rather than an empty base.
+      assert inspect(note) =~ "biopsy"
+
+      assert Utf8Backfill.format_reason({:error, :version_conflict, note}) == "version_conflict"
+    end
+
+    # ...and the catch-all still renders the shapes that are safe and useful.
+    test "format_reason/1 still renders a plain error reason" do
+      assert Utf8Backfill.format_reason({:error, :not_found}) =~ "not_found"
+    end
+
     test "a changeset built from note attrs carries no plaintext", %{user: user, vault: vault} do
       secret = "Dear diary, the biopsy came back positive."
 

--- a/test/engram/notes/utf8_backfill_test.exs
+++ b/test/engram/notes/utf8_backfill_test.exs
@@ -144,4 +144,66 @@ defmodule Engram.Notes.Utf8BackfillTest do
     assert result.corrupt == 0
     assert result.fixed == 0
   end
+
+  # ---------------------------------------------------------------------------
+  # Log-leak tripwire for fix_note/3's error branch
+  # ---------------------------------------------------------------------------
+  #
+  # That branch renders whatever the `with` rejected into a Logger message
+  # BODY, which RedactFilter cannot scrub — it gates metadata by key and says so
+  # in its own moduledoc. `format_reason/1` drops the one content-bearing shape
+  # (`{:error, :version_conflict, %Note{}}`) to a bare label and inspects the
+  # rest.
+  #
+  # The rest includes `{:error, %Ecto.Changeset{}}`, which upsert_note/4 really
+  # can return. That is safe ONLY because of two things this module does not
+  # own, so both are pinned here rather than trusted:
+  #
+  #   1. Ecto's Inspect impl prints `data` as `#Engram.Notes.Note<>` instead of
+  #      expanding the struct.
+  #   2. Note.changeset/2's cast list excludes the virtual :content/:title/
+  #      :path, so they never reach `changes`.
+  #
+  # Break either and note plaintext reappears in CloudWatch, Loki and Sentry.
+  # Version conflict is not reachable from the backfill (it never declares a
+  # version), which is why this pins the invariants rather than driving the
+  # branch end to end.
+  describe "note content cannot reach the backfill's failure log" do
+    test "a changeset built from note attrs carries no plaintext", %{user: user, vault: vault} do
+      secret = "Dear diary, the biopsy came back positive."
+
+      changeset =
+        Note.changeset(%Note{}, %{
+          "content" => secret,
+          "title" => "Biopsy results",
+          "path" => "Medical/biopsy.md",
+          "user_id" => user.id,
+          "vault_id" => vault.id
+        })
+
+      rendered = inspect(changeset)
+
+      refute rendered =~ secret
+      refute rendered =~ "Biopsy results"
+      refute rendered =~ "Medical/biopsy.md"
+    end
+
+    test "the changeset cast list never takes the virtual plaintext fields",
+         %{user: user, vault: vault} do
+      changeset =
+        Note.changeset(%Note{}, %{
+          "content" => "secret body",
+          "title" => "secret title",
+          "path" => "secret/path.md",
+          "user_id" => user.id,
+          "vault_id" => vault.id
+        })
+
+      for field <- [:content, :title, :path] do
+        refute Map.has_key?(changeset.changes, field),
+               "#{field} is now cast into the changeset — it will render in any " <>
+                 "log line that inspects an {:error, changeset} from upsert_note"
+      end
+    end
+  end
 end

--- a/test/engram/notes/utf8_backfill_test.exs
+++ b/test/engram/notes/utf8_backfill_test.exs
@@ -172,14 +172,25 @@ defmodule Engram.Notes.Utf8BackfillTest do
     test "a changeset built from note attrs carries no plaintext", %{user: user, vault: vault} do
       secret = "Dear diary, the biopsy came back positive."
 
+      # `data` is a LOADED note, not `%Note{}`. That is the shape the real path
+      # produces — notes.ex:1626 and :1872 both build `prior |> Note.changeset(...)`
+      # — and it is the only shape under which invariant (1) is load-bearing:
+      # with an empty struct as data, no expansion of `data` could reveal the
+      # secret, so an empty base tested nothing about Ecto's Inspect impl.
+      loaded = %Note{content: secret, title: "Biopsy results", path: "Medical/biopsy.md"}
+
       changeset =
-        Note.changeset(%Note{}, %{
+        Note.changeset(loaded, %{
           "content" => secret,
           "title" => "Biopsy results",
           "path" => "Medical/biopsy.md",
           "user_id" => user.id,
           "vault_id" => vault.id
         })
+
+      # Self-proving: the struct really does hold the secret, so this test is
+      # measuring Ecto's Inspect impl rather than an empty base.
+      assert inspect(loaded) =~ "biopsy"
 
       rendered = inspect(changeset)
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -166,6 +166,40 @@ defmodule Engram.NotesTest do
                "path_hmac=" <> String.slice(Base.encode64(<<1, 2, 3, 4, 5, 6, 7, 8, 9>>), 0, 12)
     end
 
+    # The exception MESSAGE is not our own text. CaseClauseError, MatchError,
+    # Jason.EncodeError and Postgrex.Error all render `inspect(term)` of the
+    # value that blew up, and this rescue wraps frontmatter parsing, CRDT merge
+    # and encryption — all of which hold note content. Interpolating it put a
+    # note body straight into CloudWatch, Loki and Sentry.
+    test "process_batch_entry_rescued/3 keeps note content out of the log body" do
+      entry = %{
+        path: "poison.md",
+        input_path: "poison.md",
+        path_hmac: <<1, 2, 3, 4, 5, 6, 7, 8, 9>>,
+        result: nil
+      }
+
+      secret = "Dear diary, the biopsy came back positive."
+
+      log =
+        capture_log(fn ->
+          assert {_degraded, []} =
+                   Notes.process_batch_entry_rescued(entry, [], fn ->
+                     # Raised directly rather than via a literal `case`: the
+                     # compiler statically proves that clause unreachable and
+                     # warns, which --warnings-as-errors turns into a failure.
+                     # Same struct, same Exception.message/1 rendering.
+                     raise CaseClauseError, term: {:parsed, secret}
+                   end)
+        end)
+
+      assert log =~ "batch entry raised"
+      refute log =~ secret
+      refute log =~ "biopsy"
+      # The class still identifies what went wrong.
+      assert log =~ "CaseClauseError"
+    end
+
     test "process_batch_entry_rescued/3 passes through a non-raising fn untouched" do
       entry = %{path: "good.md", input_path: "good.md", result: nil}
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -200,6 +200,60 @@ defmodule Engram.NotesTest do
       assert log =~ "CaseClauseError"
     end
 
+    # `capture_log` renders METADATA as well as the body, which is the point:
+    # moving the exception message out of the body and into `error:` metadata
+    # does not redact it. `:error` is absent from RedactFilter's key set, so
+    # Loki and CloudWatch would print it verbatim. Only the type filter helps.
+    test "process_batch_entry_rescued/3 keeps content out of the metadata too" do
+      entry = %{
+        path: "poison.md",
+        input_path: "poison.md",
+        path_hmac: <<1, 2, 3, 4, 5, 6, 7, 8, 9>>,
+        result: nil
+      }
+
+      secret = "Dear diary, the biopsy came back positive."
+
+      log =
+        capture_log([metadata: :all], fn ->
+          Notes.process_batch_entry_rescued(entry, [], fn ->
+            raise KeyError, key: :missing, term: %{"content" => secret}
+          end)
+        end)
+
+      refute log =~ secret
+      refute log =~ "biopsy"
+      assert log =~ "KeyError"
+    end
+
+    # The counterpart: a DB error's message is the database's own text, and the
+    # SQLSTATE is the single most useful thing in this line. Allowlisted types
+    # keep their message so the type filter does not cost us the diagnosis.
+    test "process_batch_entry_rescued/3 keeps a database error's message" do
+      entry = %{
+        path: "poison.md",
+        input_path: "poison.md",
+        path_hmac: <<1, 2, 3, 4, 5, 6, 7, 8, 9>>,
+        result: nil
+      }
+
+      log =
+        capture_log(fn ->
+          Notes.process_batch_entry_rescued(entry, [], fn ->
+            raise %Postgrex.Error{
+              postgres: %{
+                code: :numeric_value_out_of_range,
+                message: "bigint out of range",
+                severity: "ERROR",
+                pg_code: "22003"
+              }
+            }
+          end)
+        end)
+
+      assert log =~ "bigint out of range"
+    end
+
     test "process_batch_entry_rescued/3 passes through a non-raising fn untouched" do
       entry = %{path: "good.md", input_path: "good.md", result: nil}
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -132,7 +132,15 @@ defmodule Engram.NotesTest do
     end
 
     test "process_batch_entry_rescued/3 catches a raise and degrades to a per-note error" do
-      entry = %{path: "poison.md", input_path: "poison.md", result: nil}
+      # `path_hmac` mirrors the real batch entry — process_batch_entry/6 reads
+      # it on the line above the rescue. Without it here the log falls back to
+      # "unknown" and this test would pass while proving nothing.
+      entry = %{
+        path: "poison.md",
+        input_path: "poison.md",
+        path_hmac: <<1, 2, 3, 4, 5, 6, 7, 8, 9>>,
+        result: nil
+      }
 
       log =
         capture_log(fn ->
@@ -147,7 +155,15 @@ defmodule Engram.NotesTest do
         end)
 
       assert log =~ "batch entry raised"
-      assert log =~ "poison.md"
+
+      # This assertion used to read `assert log =~ "poison.md"` — it pinned the
+      # leak in place. RedactFilter scrubs metadata, never the message body, so
+      # an interpolated path here reaches CloudWatch and Loki verbatim. On-call
+      # correlates on the HMAC instead: same row, non-reversible.
+      refute log =~ "poison.md"
+
+      assert log =~
+               "path_hmac=" <> String.slice(Base.encode64(<<1, 2, 3, 4, 5, 6, 7, 8, 9>>), 0, 12)
     end
 
     test "process_batch_entry_rescued/3 passes through a non-raising fn untouched" do
@@ -237,7 +253,11 @@ defmodule Engram.NotesTest do
         end)
 
       assert log =~ "batch entry raised"
-      assert log =~ "poison.md"
+
+      # Same flip as the unit test above, but through the real batch path, so
+      # the HMAC is the one production computes rather than a fixture.
+      refute log =~ "poison.md"
+      assert log =~ ~r"path_hmac=[A-Za-z0-9+/]{12}"
     end
   end
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -226,10 +226,12 @@ defmodule Engram.NotesTest do
       assert log =~ "KeyError"
     end
 
-    # The counterpart: a DB error's message is the database's own text, and the
-    # SQLSTATE is the single most useful thing in this line. Allowlisted types
-    # keep their message so the type filter does not cost us the diagnosis.
-    test "process_batch_entry_rescued/3 keeps a database error's message" do
+    # The counterpart. Postgrex.Error is NOT allowlisted — its message quotes
+    # the offending value, and it also renders the SQL and the Postgres DETAIL
+    # ("Failing row contains (…)"), which is the whole row. It is rendered
+    # structurally instead, from fields that are codes rather than values, so
+    # the SQLSTATE a responder greps for survives without the row.
+    test "process_batch_entry_rescued/3 keeps a database error's codes, not its text" do
       entry = %{
         path: "poison.md",
         input_path: "poison.md",
@@ -251,7 +253,9 @@ defmodule Engram.NotesTest do
           end)
         end)
 
-      assert log =~ "bigint out of range"
+      assert log =~ "22003"
+      assert log =~ "numeric_value_out_of_range"
+      refute log =~ "bigint out of range"
     end
 
     test "process_batch_entry_rescued/3 passes through a non-raising fn untouched" do

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -387,7 +387,14 @@ defmodule EngramWeb.CrdtChannelTest do
       # Contained, but never silent — a swallowed pool timeout is how this class
       # of failure stays invisible until e2e goes red.
       assert log =~ "crdt_create_batch entry failed"
-      assert log =~ "connection not available"
+
+      # The CLASS, not the message. This guard wraps prepare_create/2 and
+      # seed_and_checkpoint/5, so note plaintext is in scope, and a
+      # RuntimeError's message is whatever string was raised — `raise "failed
+      # for #{path}"` is one edit away. The `else` arm of this same function was
+      # already narrowed for that reason; the rescue now matches it.
+      assert log =~ "RuntimeError"
+      refute log =~ "connection not available"
     end
 
     test "an exiting entry (dead room / pool timeout) is contained the same way" do

--- a/test/engram_web/channels/user_socket_test.exs
+++ b/test/engram_web/channels/user_socket_test.exs
@@ -45,6 +45,25 @@ defmodule EngramWeb.UserSocketTest do
     refute log =~ token
   end
 
+  # Phoenix matches filter_parameters by SUBSTRING on the key, so the entries
+  # are prefixes/fragments, not names. "token" does NOT cover device_code —
+  # which redeems into both an access and a refresh token, and so is a bearer
+  # credential in its own right for its 300s life.
+  test "filters credential-bearing param names, not just exact matches", %{token: token} do
+    log =
+      capture_log(fn ->
+        assert {:ok, _socket} =
+                 connect(UserSocket, %{
+                   "token" => token,
+                   "device_code" => "dev-code-secret",
+                   "code_verifier" => "pkce-secret"
+                 })
+      end)
+
+    refute log =~ "dev-code-secret"
+    refute log =~ "pkce-secret"
+  end
+
   test "connect still works with no conn params (backward compatible)", %{token: token} do
     assert {:ok, socket} = connect(UserSocket, %{"token" => token})
     assert socket.assigns.conn_id == nil

--- a/test/engram_web/channels/user_socket_test.exs
+++ b/test/engram_web/channels/user_socket_test.exs
@@ -36,6 +36,13 @@ defmodule EngramWeb.UserSocketTest do
 
     assert log =~ "ws connect"
     assert log =~ "conn-abc"
+
+    # Phoenix's own "CONNECTED TO ... Parameters:" line renders the connect
+    # params. RedactFilter cannot help here — it scrubs metadata, never the
+    # message body — so the only control is :filter_parameters. This asserts
+    # the credential itself, not the presence of "[FILTERED]", because a
+    # future refactor could drop the line entirely and should still pass.
+    refute log =~ token
   end
 
   test "connect still works with no conn params (backward compatible)", %{token: token} do

--- a/test/engram_web/controllers/oauth_authorize_controller_test.exs
+++ b/test/engram_web/controllers/oauth_authorize_controller_test.exs
@@ -113,6 +113,21 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
       assert conn.resp_body =~ "invalid_client"
     end
 
+    # This route answers text/html, not JSON, so it needs the browser headers
+    # the :api pipelines legitimately skip. It had NONE — the OAuth entry point
+    # served framable, sniffable, full-Referer documents. `state` is in the
+    # query string of that page, which is why referrer-policy belongs here too.
+    test "the HTML error page carries browser security headers", %{conn: conn} do
+      params = valid_params("00000000-0000-0000-0000-000000000000", "https://x/cb")
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      assert ["text/html" <> _] = get_resp_header(conn, "content-type")
+      assert get_resp_header(conn, "x-frame-options") == ["DENY"]
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "referrer-policy") == ["origin"]
+    end
+
     test "returns 400 HTML when redirect_uri does not match registration", %{conn: conn} do
       client = register_client("https://claude.ai/api/mcp/auth_callback")
 

--- a/test/engram_web/controllers/oauth_authorize_controller_test.exs
+++ b/test/engram_web/controllers/oauth_authorize_controller_test.exs
@@ -123,9 +123,21 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
       conn = get(conn, "/oauth/authorize", params)
 
       assert ["text/html" <> _] = get_resp_header(conn, "content-type")
-      assert get_resp_header(conn, "x-frame-options") == ["DENY"]
       assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
       assert get_resp_header(conn, "referrer-policy") == ["origin"]
+
+      # x-frame-options is asserted, but it is NOT what stops framing here.
+      # put_secure_browser_headers always emits a CSP (put_secure_defaults runs
+      # first and the map merges over it), and CSP Level 2 §7.4.1 makes
+      # `frame-ancestors` supersede `x-frame-options` wherever both are
+      # understood. Phoenix's default is `frame-ancestors 'self'` — so asserting
+      # DENY alone passed while every modern browser allowed same-origin
+      # framing of the OAuth entry point.
+      assert get_resp_header(conn, "x-frame-options") == ["DENY"]
+
+      [csp] = get_resp_header(conn, "content-security-policy")
+      assert csp =~ "frame-ancestors 'none'"
+      assert csp =~ "default-src 'none'"
     end
 
     test "returns 400 HTML when redirect_uri does not match registration", %{conn: conn} do

--- a/test/engram_web/controllers/users_controller_test.exs
+++ b/test/engram_web/controllers/users_controller_test.exs
@@ -70,7 +70,22 @@ defmodule EngramWeb.UsersControllerTest do
       :ok
     end
 
-    test "200 with correct password, hard-deletes the user row", %{user: user} do
+    # The password rides the BODY. In a query string it is written to Phoenix's
+    # and the load balancer's access logs and to the browser's Sentry fetch
+    # breadcrumb — a credential the user typed into a confirm dialog, spread
+    # across three log stores. This test is the contract that keeps the body
+    # path working, so the frontend can never be pushed back to the query.
+    test "200 with correct password in the request BODY, hard-deletes the user row", %{user: user} do
+      conn = auth_conn(user) |> delete("/api/me", %{password: "password123"})
+      assert %{"ok" => true} = json_response(conn, 200)
+
+      refute Engram.Repo.get(Engram.Accounts.User, user.id, skip_tenant_check: true)
+    end
+
+    # Kept working on purpose: an older cached SPA bundle is still out there
+    # sending the query form, and breaking its delete would be worse than the
+    # leak it causes. Remove once the bundle floor has moved.
+    test "200 with correct password in the query string (legacy bundles)", %{user: user} do
       conn = auth_conn(user) |> delete("/api/me?password=password123")
       assert %{"ok" => true} = json_response(conn, 200)
 

--- a/test/engram_web/csp_pipeline_test.exs
+++ b/test/engram_web/csp_pipeline_test.exs
@@ -31,4 +31,20 @@ defmodule EngramWeb.CSPPipelineTest do
     assert get_resp_header(conn, "x-frame-options") == ["DENY"]
     assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
   end
+
+  # frontend/public/_headers sets this too, but that file is Cloudflare Pages
+  # metadata — it covers ONLY the uploaded bundle. This pipeline serves the
+  # self-hosted SPA, which is also the ONLY deployment where password reset
+  # exists (RequireLocalAuth), so `/reset-password?token=` riding the Referer
+  # of every same-origin subresource is a self-host-specific leak.
+  #
+  # Asserting the exact value, not just presence: Phoenix's default here is
+  # `strict-origin-when-cross-origin`, which passes a presence check while
+  # sending the full path same-origin — the thing being fixed.
+  test "GET / sets referrer-policy to origin, matching the Cloudflare bundle",
+       %{conn: conn} do
+    conn = get(conn, "/")
+
+    assert get_resp_header(conn, "referrer-policy") == ["origin"]
+  end
 end

--- a/test/engram_web/csp_pipeline_test.exs
+++ b/test/engram_web/csp_pipeline_test.exs
@@ -41,6 +41,19 @@ defmodule EngramWeb.CSPPipelineTest do
   # Asserting the exact value, not just presence: Phoenix's default here is
   # `strict-origin-when-cross-origin`, which passes a presence check while
   # sending the full path same-origin — the thing being fixed.
+  # The :api pipelines carried `x-frame-options: DENY` next to Phoenix's DEFAULT
+  # CSP, whose `frame-ancestors 'self'` supersedes it — so the whole REST
+  # surface advertised DENY and applied 'self'. Same defect as the OAuth
+  # pipeline, found in the same review, fixed in the same pass.
+  test "the api pipeline's CSP agrees with its x-frame-options", %{conn: conn} do
+    conn = get(conn, "/api/health")
+
+    assert get_resp_header(conn, "x-frame-options") == ["DENY"]
+    [csp] = get_resp_header(conn, "content-security-policy")
+    assert csp =~ "frame-ancestors 'none'"
+    refute csp =~ "frame-ancestors 'self'"
+  end
+
   test "GET / sets referrer-policy to origin, matching the Cloudflare bundle",
        %{conn: conn} do
     conn = get(conn, "/")


### PR DESCRIPTION
Remediation from a security/privacy audit of the SPA, run after the plugin-side finding that a sync recorder was buffering note content for export. Findings in severity order.

## Critical

**The account-delete flow put the user's password in a query string.**
```
DELETE /me?password=hunter2
```
That URL is written to Phoenix's access log, the load balancer's, every proxy between, browser history, and Sentry's fetch breadcrumb. It moves to the request body. The controller already reads merged params so the server needed no change; a test pins the body path, and the query form keeps working for cached bundles still in the wild.

**Self-host browsers reported to the SaaS Sentry.** The image bakes `VITE_SENTRY_DSN` into `build:selfhost` — the bundle a self-hoster serves — so the one deployment whose promise is that data stays on the operator's own infrastructure was the only one phoning home. Nobody opted in. Meanwhile `app.engram.page` reported *nowhere*. Both halves corrected; the SaaS half was checked against the privacy policy's sub-processor table first, which already discloses Sentry.

## High

**`Sentry.init({ integrations: [] })` does not disable the defaults — it MERGES.** Only `defaultIntegrations: false` opts out. So `breadcrumbsIntegration` (console, DOM, fetch, history) and `httpContextIntegration` (`request.url`) have been live all along, and URLs in this app carry note paths, attachment filenames, unresolved wikilink titles, and single-use credentials. Added `beforeBreadcrumb` + `beforeSend`: console and DOM breadcrumbs dropped outright, every URL keeps its shape and loses its contents.

**The `?code=` scrub shipped earlier tonight was incomplete.** A signed-out arrival is redirected first, and `signInRedirectTarget` copied the whole query into `return_to`, which is handed to Clerk as `forceRedirectUrl` — so the device code made the entire login round trip in the address bar and into history. Password-reset tokens took the same route and additionally sat in the URL for the life of the page. Both stripped; the reset page now scrubs its token after reading it.

**Sign-out did not clear everything.** The durable CRDT op-queue database is named `engram-crdt-queue` — one character outside the `engram-crdt/` prefix the wipe matches — so queued ops, which carry note paths, survived sign-out on a shared machine. Search history lived in localStorage under a key with no owner and no expiry.

## Medium

Attachment paths no longer go to `console.error` (console args become breadcrumbs, and an attachment path is folder structure plus a filename).

## Tests

`scrubUrl` has its own suite including both credential shapes. The `return_to` stripping, the op-queue wipe, and the password body path all have tests; each new test was checked against the unfixed source first. Frontend: 1591 passing, build + biome clean. Backend: `users_controller_test` passing.

## Deliberately not in this PR

Staging-fastraid runs the self-host image, so it loses *browser* crash reporting (backend Sentry unaffected). Giving it back means serving the DSN at runtime so the operator chooses, rather than baking it at build time — real work, and not urgent.