### PR TITLE
feat(crdt): add a tail log for the vault index room

### DIFF
--- a/docs/context/crdt-identity-authority.md
+++ b/docs/context/crdt-identity-authority.md
@@ -156,5 +156,22 @@ Writing the snapshot encrypts, and `users.encrypted_dek` holds the OLD wrapped
 dek until `final_flip` — so a write landing mid-rotation is unreadable once the
 old key retires (#1341). Under map-authority the claim IS the commit, so it
 cannot be "best effort": a rename during a DEK rotation fails loudly rather than
-half-completing. The live-room path needs no gate; it only mutates memory, and
-the room's own checkpoint is already gated.
+half-completing.
+
+**Both routes are gated, before routing.** An earlier version gated only the
+snapshot route, reasoning that "the live-room path needs no gate; it only
+mutates memory, and the room's own checkpoint is already gated." The tail log
+(#1391) falsified that. A room write becomes durable through `append_tail`,
+which is gated; the checkpoint that was supposed to write the in-memory claim
+"afterwards" is gated too and runs only at process death. So the ungated room
+route returned `:ok`, wrote nothing anywhere, and lost the claim when the room
+drained — with the caller's rename already committed against it. `RotationGate`
+is therefore checked in `Identity.apply_targets/4` before it picks a route
+(`route=gate phase=rotation` on `index_claim`).
+
+One residual, deliberately not closed: a client writing `filemeta_v0` directly
+over the channel bypasses `Identity` entirely, so its update reaches
+`update_v1/4` and is dropped by `append_tail`'s gate (`phase=skipped_rotation`).
+`SessionInvalidator.disconnect_user/1` drains sockets at the top of a rotation,
+which narrows the window rather than eliminating it. It has no production
+exposure until Engram-obsidian#362 makes a client write the map.

--- a/docs/context/crdt-identity-authority.md
+++ b/docs/context/crdt-identity-authority.md
@@ -126,6 +126,23 @@ discarded return value with a retry, which matters because a release refused
 mid-rotation used to vanish silently and leave one permanent path reservation
 per note.
 
+## The tail log is what makes a claim durable
+
+`vault_index_states` holds a snapshot written when a room EXITS. On its own that
+meant every claim made since the last checkpoint lived only in room memory, so a
+SIGKILL, a node loss or an ECS task replacement dropped committed identity — and
+projection then converged the rows back to the superseded snapshot.
+
+`vault_index_update_log` (#1391) closes it: every update is appended, replayed on
+`bind/3` after the snapshot, and pruned by EXACT id when a checkpoint folds it
+in. Never by a timestamp range — an update appended between the encode and the
+delete is not in the snapshot, and a range prune would drop exactly the claim the
+tail exists to protect.
+
+Durability is reached when the ROOM processes its own update message, not when
+`update_doc/2` returns; `handle_update_v1` is asynchronous. A kill inside that
+window still loses the update, as it does for note rooms.
+
 ## Removals are id-keyed, never path-keyed
 
 Removing an entry by deleting whatever sits at a path clobbers the entry of

--- a/docs/context/crdt-index-room.md
+++ b/docs/context/crdt-index-room.md
@@ -6,7 +6,7 @@ _Last verified: 2026-08-15_
 (`path -> %{note_id, type, hash}`), riding the existing per-vault `crdt:` channel as
 `crdt_index_msg`. **This map is AUTHORITATIVE for note paths** as of #1151 step 2 —
 `Engram.Notes.Identity` is the only server-side writer, `Engram.Workers.ProjectVaultIndex`
-reads it and derives the `notes.path_*` columns. Durability shipped in #1151 step 1;
+reads it and derives the `notes.path_*` columns. Durability shipped in #1151 step 1, with a per-update tail log in #1391;
 the #1152 drain is still unwired (step 3). See `crdt-identity-authority.md` for the
 decision, and note that projection must NEVER claim (`rename_note/5` takes
 `index: :skip` for it) or it feeds itself.

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -345,6 +345,41 @@ defmodule Engram.Crypto do
   end
 
   @doc """
+  Encrypts one `filemeta_v0` update for the index tail log (#1391).
+
+  AAD binds to the LOG ROW's id, not the vault, because each row is an
+  independent append that is later pruned by exact id — binding to the vault
+  would make every row of a vault interchangeable under AAD.
+  """
+  @spec encrypt_index_update(binary(), User.t(), String.t()) ::
+          {:ok, {binary(), binary()}} | {:error, term()}
+  def encrypt_index_update(update, %User{} = user, row_id)
+      when is_binary(update) and is_binary(row_id) do
+    with {:ok, user} <- ensure_user_dek(user),
+         {:ok, dek} <- get_dek(user) do
+      aad = aad_for_row(:vault_index_update_log, :update, row_id)
+      {ct, nonce} = Envelope.encrypt(update, dek, aad)
+      {:ok, {ct, nonce}}
+    end
+  end
+
+  @doc """
+  Decrypts one index tail row into the raw Yjs v1 update binary.
+  """
+  @spec decrypt_index_update(Engram.Notes.VaultIndexUpdateLog.t(), User.t()) ::
+          {:ok, binary()} | {:error, term()}
+  def decrypt_index_update(%Engram.Notes.VaultIndexUpdateLog{} = row, %User{} = user) do
+    aad = aad_for_row(:vault_index_update_log, :update, row.id)
+
+    with {:ok, dek} <- get_dek(user) do
+      case Envelope.decrypt(row.update_ciphertext, row.update_nonce, dek, aad) do
+        {:ok, update} -> {:ok, update}
+        :error -> {:error, :decrypt_failed}
+      end
+    end
+  end
+
+  @doc """
   Decrypts a note's `crdt_state_ciphertext` into the raw Yjs v1 state binary.
   Returns `{:ok, nil}` when the column is unpopulated (lazy-seed case).
   Legacy `dek_version < 2` rows decrypt with empty AAD; AAD-bound rows

--- a/lib/engram/crypto/user_dek_rotation.ex
+++ b/lib/engram/crypto/user_dek_rotation.ex
@@ -1137,13 +1137,25 @@ defmodule Engram.Crypto.UserDekRotation do
     # old-then-new, like `rewrap_crdt_tail/3`: a rotation RETRIED after a crash
     # meets rows it already re-wrapped, and decrypting under the old key is what
     # discriminates. Raising on those would make a resumed rotation impossible.
+    # log/log_meta/on_both_failed are REQUIRED: try_rewrap's failure branch
+    # fetch!es all three, so omitting them turns an unreadable row into a
+    # KeyError that aborts the rotation after several sweeps have already run
+    # and before final_flip — with no row_failed telemetry and nothing naming
+    # the row. Same shape as rewrap_crdt_tail/3, the note-tail analogue.
     case try_rewrap(row.update_ciphertext, row.update_nonce, old_dek, new_dek, aad, aad,
            table: :vault_index_update_log,
            phase: :sweep_vault_index_update_log,
-           user_id: user_id,
-           row_id: row.id
+           log: "T3.7 sweep_vault_index_update_log: decrypt failed under both old and new DEK",
+           log_meta: [user_id: user_id, row_id: row.id],
+           on_both_failed: {:error, :both_deks_failed}
          ) do
       :already_rotated ->
+        :ok
+
+      # One unreadable tail row must not abort the rotation: try_rewrap has
+      # already logged it and emitted row_failed, and there is nothing safe to
+      # write. Aborting would strand the user mid-rotation permanently.
+      {:error, _reason} ->
         :ok
 
       {:ok, plaintext} ->

--- a/lib/engram/crypto/user_dek_rotation.ex
+++ b/lib/engram/crypto/user_dek_rotation.ex
@@ -187,6 +187,7 @@ defmodule Engram.Crypto.UserDekRotation do
          :ok <- enqueue_crdt_head_rewarm(user_id),
          :ok <- sweep_vaults(user, old_dek, new_dek, new_filter_key, new_dek_version),
          :ok <- sweep_vault_index_states(user, old_dek, new_dek, new_dek_version),
+         :ok <- sweep_vault_index_update_log(user, old_dek, new_dek, new_dek_version),
          :ok <- sweep_attachments(user, old_dek, new_dek, new_filter_key, new_dek_version),
          :ok <- sweep_note_links(user, old_dek, new_dek, new_filter_key, new_dek_version),
          :ok <- sweep_qdrant(user, old_dek, new_dek),
@@ -1094,6 +1095,85 @@ defmodule Engram.Crypto.UserDekRotation do
         # decrypting the moment the old key is retired, and it would do so
         # silently, long after this rotation "succeeded".
         raise "T3.7 sweep_vault_index_states: decrypt failed vault_id=#{row.vault_id}"
+    end
+  end
+
+  # #1391 — the index TAIL. Rows here are as encrypted as the snapshot and just
+  # as load-bearing: they hold every claim made since the last checkpoint, which
+  # since #1151 step 2 is committed identity that exists nowhere else. Missing
+  # this sweep would leave them under a retiring key, and they would stop
+  # decrypting silently long after the rotation reported success.
+  #
+  # Keyed by the row id (not the vault) because the AAD binds per row.
+  defp sweep_vault_index_update_log(%User{id: user_id}, old_dek, new_dek, new_dek_version) do
+    sweep_table_loop(
+      user_id,
+      Engram.Notes.VaultIndexUpdateLog,
+      "00000000-0000-0000-0000-000000000000",
+      fn batch_ids ->
+        Repo.transaction(fn ->
+          rows =
+            from(l in Engram.Notes.VaultIndexUpdateLog,
+              where: l.id in ^batch_ids,
+              lock: "FOR UPDATE"
+            )
+            |> Repo.all(skip_tenant_check: true)
+
+          Enum.each(rows, &rewrap_index_update(&1, user_id, old_dek, new_dek, new_dek_version))
+        end)
+        |> case do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+      end
+    )
+  end
+
+  defp rewrap_index_update(row, user_id, old_dek, new_dek, new_dek_version) do
+    # AAD binds to the row id and does not change across a rotation, so old and
+    # new AAD are the same value here.
+    aad = Crypto.aad_for_row(:vault_index_update_log, :update, row.id)
+
+    # old-then-new, like `rewrap_crdt_tail/3`: a rotation RETRIED after a crash
+    # meets rows it already re-wrapped, and decrypting under the old key is what
+    # discriminates. Raising on those would make a resumed rotation impossible.
+    case try_rewrap(row.update_ciphertext, row.update_nonce, old_dek, new_dek, aad, aad,
+           table: :vault_index_update_log,
+           phase: :sweep_vault_index_update_log,
+           user_id: user_id,
+           row_id: row.id
+         ) do
+      :already_rotated ->
+        :ok
+
+      {:ok, plaintext} ->
+        {ct, nonce} = Envelope.encrypt(plaintext, new_dek, aad)
+
+        case from(l in Engram.Notes.VaultIndexUpdateLog, where: l.id == ^row.id)
+             |> Repo.update_all(
+               [set: [update_ciphertext: ct, update_nonce: nonce, dek_version: new_dek_version]],
+               skip_tenant_check: true
+             ) do
+          {1, _} ->
+            :ok
+
+          # NOT an error here, unlike the snapshot sweep. A checkpoint prunes
+          # tail rows by exact id, so a row legitimately disappears mid-rotation
+          # whenever a room happens to exit — and its content is already folded
+          # into the snapshot the previous sweep step re-wrapped.
+          {0, _} ->
+            Logger.info(
+              "T3.7 sweep_vault_index_update_log: row pruned by a checkpoint mid-rotation",
+              Metadata.with_category(:info, :crypto,
+                user_id: user_id,
+                table: :vault_index_update_log,
+                row_id: row.id,
+                phase: :sweep_vault_index_update_log
+              )
+            )
+
+            :ok
+        end
     end
   end
 

--- a/lib/engram/notes/crdt_index_doc.ex
+++ b/lib/engram/notes/crdt_index_doc.ex
@@ -90,11 +90,15 @@ defmodule Engram.Notes.CrdtIndexDoc do
       # an immortal orphan. Channels re-establish it on demand.
       restart: :temporary,
       # LONGER than a note room's 15 s, not shorter, and the OTP default of
-      # 5_000 is badly wrong here. A note room can afford to be brutal-killed
-      # mid-flush: its encrypted tail-log still holds every update, so the next
-      # bind replays it and only the work is wasted. This room has NO tail log
-      # (see CrdtIndexPersistence) — a blown deadline loses every index write
-      # since the last exit, permanently.
+      # 5_000 is badly wrong here.
+      #
+      # This room now HAS a tail log (#1391), so a blown deadline no longer
+      # loses every index write since the last exit — the next bind replays the
+      # tail, exactly as a note room replays its own. What a blown deadline
+      # still costs is the FOLD: the checkpoint never runs, so nothing is
+      # pruned and the tail keeps growing across restarts. The generous
+      # deadline is now about bounding tail growth and wasted replay work, not
+      # about preventing permanent loss.
       #
       # And the deadline is harder to hit: unbind/3 does a user lookup, a full
       # doc encode, AES-GCM over a blob #1149 sizes at ~2.0 MB for a 10k-note

--- a/lib/engram/notes/crdt_index_persistence.ex
+++ b/lib/engram/notes/crdt_index_persistence.ex
@@ -7,7 +7,7 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     re-spun room comes back with the index it had.
   * `unbind/3` — on graceful exit (last observer leaves, `auto_exit: true`),
     encrypt the whole doc state and upsert the single `vault_index_states` row.
-  * `update_v1/4` — deliberately NOT implemented. See below.
+  * `update_v1/4` — the tail append (#1391). See below.
 
   ## Snapshot-only, and what that costs
 
@@ -17,18 +17,46 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   rarer — so this stays snapshot-only. An ungraceful room death (SIGKILL, node
   loss) loses index writes since the last exit.
 
-  **The escalation trigger this section used to defer has already fired.** It
-  said "revisit when #363 makes the index authoritative"; the map became
-  authoritative for paths in #1151 step 2, not at #363
-  (`docs/context/crdt-identity-authority.md`). So a lost interval is no longer
-  merely STALE: it drops committed claims, and the rows then converge back to a
-  superseded snapshot on the next projection run.
+  **That is why `update_v1/4` exists here (#1391).** The snapshot alone was
+  written only when a room exited, so anything since the last checkpoint died
+  with the process — and once #1151 step 2 made the map authoritative for paths,
+  that meant losing committed path CLAIMS, after which projection drags the rows
+  back to the superseded snapshot. Every update is now appended to
+  `vault_index_update_log`, replayed on `bind/3` after the snapshot, and pruned
+  by EXACT id when a checkpoint folds it in.
 
-  What still makes it tolerable is scope, not safety: no CLIENT writes the map
-  yet, so the only claims in flight are the server's own, and each one is
-  followed immediately by the row write it authorises. A tail log is owed before
-  Engram-obsidian#362 lands. There is no rebuild path in `lib/` — do not read
-  "rebuildable" as "a rebuild exists".
+  Two consequences worth knowing:
+
+  * A claim is durable once the ROOM has processed its own update message, not
+    at the instant `update_doc/2` returns — `handle_update_v1` is delivered
+    asynchronously. A kill inside that window still loses the update, exactly as
+    it does for note rooms.
+  * The prune is by exact id and never by a timestamp range. An update appended
+    between the encode and the delete is not in the snapshot, and a range prune
+    would silently drop the one claim the tail exists to protect.
+
+  There is still no rebuild path in `lib/` — do not read "rebuildable" as "a
+  rebuild exists".
+
+  ## The tail is bounded ONLY by a graceful room exit
+
+  Note rooms bound their tail three ways — `CrdtCheckpointTimer` debounces a
+  flush, `update_v1/4` can checkpoint inline under `CheckpointGate`, and
+  overflow goes to the `crdt_checkpoint` Oban queue. This room has none of them
+  (`CrdtIndexDoc` runs no timer and sets no `idle_exit_ms`), so residency is
+  session-length and the only prune is `unbind/3`.
+
+  So the tail grows unbounded for: a room pinned open by a long-lived observer,
+  a crash loop that never reaches `terminate/2`, and every room exit during a
+  DEK rotation (the checkpoint is gated, so it skips the prune too). There is no
+  age sweep, no size cap and no reaper; the `on_delete: :delete_all` FKs only
+  fire when the user or vault is deleted.
+
+  Tolerable today because index writes are rename/create/delete rather than
+  keystrokes, so the volume is orders of magnitude below a note tail, and
+  because replay is idempotent. It stops being tolerable at the same point
+  everything else here does — generalising `CrdtCheckpointTimer` off `note_id`
+  is #1151 step 3, and that is what bounds this.
 
   ## This is what unblocks the #1152 drain for the index room
 
@@ -39,11 +67,13 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   """
   @behaviour Yex.Sync.SharedDoc.PersistenceBehaviour
 
+  import Ecto.Query, only: [where: 3, order_by: 3, select: 3]
+
   alias Engram.Accounts
   alias Engram.Crypto
   alias Engram.Crypto.RotationGate
   alias Engram.Logger.Metadata
-  alias Engram.Notes.{Enqueue, VaultIndexState}
+  alias Engram.Notes.{Enqueue, VaultIndexState, VaultIndexUpdateLog}
   alias Engram.Repo
 
   require Logger
@@ -63,6 +93,118 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   @checkpoint_event [:engram, :crdt, :index_checkpoint]
 
   @impl true
+  # #1391. WITHOUT this callback the room was snapshot-only: everything since the
+  # last checkpoint died with the process, and since #1151 step 2 made the map
+  # authoritative for paths, that is committed path CLAIMS being lost — after
+  # which projection drags the rows back to the superseded snapshot.
+  #
+  # Failure is logged and swallowed rather than raised: this runs inside the
+  # room's update handling, so raising kills the room for every client on the
+  # vault and loses MORE than the one update. The snapshot at checkpoint is
+  # still taken, so a dropped tail row degrades to exactly the old behaviour
+  # rather than to something worse.
+  def update_v1(%{user_id: user_id, vault_id: vault_id} = state, update, _name, _doc) do
+    case Process.get(:index_replay_echoes, 0) do
+      n when n > 0 ->
+        # Our own bind replaying. Re-appending it would duplicate the tail.
+        Process.put(:index_replay_echoes, n - 1)
+        state
+
+      _ ->
+        do_update_v1(state, user_id, vault_id, update)
+    end
+  end
+
+  defp do_update_v1(state, user_id, vault_id, update) do
+    with {:ok, user} <- fetch_user(user_id),
+         :ok <- append_tail(user, vault_id, update) do
+      state
+    else
+      {:error, reason} ->
+        emit_tail(:failed)
+
+        Logger.error(
+          "crdt index tail append failed: #{inspect(reason)}",
+          Metadata.with_category(:error, :sync, user_id: user_id, vault_id: vault_id)
+        )
+
+        state
+    end
+  end
+
+  defp fetch_user(user_id) do
+    case Accounts.get_user(user_id) do
+      nil -> {:error, :user_gone}
+      user -> {:ok, user}
+    end
+  end
+
+  # The row id is minted BEFORE encrypting because the AAD binds to it — the
+  # same pre-allocation the tombstone path uses for row-id-bound AAD.
+  defp append_tail(user, vault_id, update) do
+    # #1341. This ENCRYPTS, so it carries the same hazard as the checkpoint, and
+    # `Identity`'s "the room path needs no gate — it only mutates memory" stopped
+    # being true the moment this callback existed. A row written after the sweep
+    # has drained but before `final_flip` retires the old key is permanently
+    # unreadable: nothing will ever re-wrap it.
+    #
+    # Skipping costs the claim only until the next checkpoint, which is gated
+    # too and therefore leaves it in memory to be written afterwards. Writing an
+    # old-dek row loses it forever.
+    case RotationGate.check_user(user) do
+      {:error, :rotation_in_progress} ->
+        emit_tail(:skipped_rotation)
+        :ok
+
+      _ ->
+        do_append_tail(user, vault_id, update)
+    end
+  end
+
+  defp do_append_tail(user, vault_id, update) do
+    row_id = UUIDv7.generate()
+
+    # dek_version records the version that actually wrapped THIS row, never a
+    # constant: the rotation sweep stamps the new version, so a hardcoded 2
+    # would disagree with the user's after the first rotation and be believed.
+    dek_version = user.dek_version || Crypto.row_version_aad_bound()
+
+    with {:ok, {ct, nonce}} <- Crypto.encrypt_index_update(update, user, row_id) do
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          %VaultIndexUpdateLog{}
+          |> VaultIndexUpdateLog.changeset(%{
+            id: row_id,
+            vault_id: vault_id,
+            user_id: user.id,
+            update_ciphertext: ct,
+            update_nonce: nonce,
+            dek_version: dek_version
+          })
+          |> Repo.insert!()
+        end)
+
+      emit_tail(:ok)
+      :ok
+    end
+  rescue
+    # `Repo.insert!` RAISES on any DB error, and under pool starvation so does
+    # the checkout itself — neither is an {:error, _} the caller's `with` could
+    # catch. Unrescued they kill the room for every client on the vault, and
+    # `unbind`'s checkpoint then needs the same exhausted pool, so the update is
+    # lost from memory AND from the tail. `unbind/3` rescues for exactly this
+    # reason (the 2026-07-09 incident); match it.
+    e -> {:error, e}
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  defp emit_tail(phase) do
+    :telemetry.execute([:engram, :crdt, :index_tail], %{count: 1}, %{phase: phase})
+    :ok
+  end
+
+  @impl true
   def bind(%{user_id: user_id, vault_id: vault_id} = state, _doc_name, doc) do
     # Mirrors CrdtPersistence.bind/3: trapping exits makes gen_server intercept
     # the supervisor's :shutdown on a deploy and run terminate/2 -> unbind,
@@ -78,24 +220,51 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     # #954 error storm.
     user = Accounts.get_user!(user_id)
 
-    _ =
+    {:ok, {snapshot_applied, replay}} =
       Repo.with_tenant(user_id, fn ->
-        case Repo.get(VaultIndexState, vault_id) do
-          nil ->
-            # No snapshot yet: a vault whose index room has never checkpointed.
-            # The doc stays empty, which is the correct starting state.
-            :ok
+        applied =
+          case Repo.get(VaultIndexState, vault_id) do
+            nil ->
+              # No snapshot yet: a vault whose index room has never checkpointed.
+              # The doc stays empty, which is the correct starting state.
+              false
 
-          %VaultIndexState{} = row ->
-            apply_snapshot(row, user, doc, vault_id)
-        end
+            %VaultIndexState{} = row ->
+              apply_snapshot(row, user, doc, vault_id)
+              true
+          end
+
+        # AFTER the snapshot, always — including when there is none. A vault
+        # that has never checkpointed can still have tail rows, and those are
+        # the only record of its claims (#1391).
+        {applied, replay_tail(doc, user, vault_id)}
       end)
 
-    state
+    # y_ex installs the doc update monitor BEFORE bind/3 runs
+    # (`doc_server_worker.ex` monitor_update_v1 -> module.init -> bind), so every
+    # `Yex.apply_update/2` above posts an `{:update_v1, ...}` to this room's own
+    # mailbox and comes back through update_v1/4. Without this, binding would
+    # APPEND the snapshot and the whole tail it just read back onto the tail:
+    # n rows become 2n+1 every restart, each cycle also writing a row the size
+    # of the entire index. On a vault whose room keeps dying — the exact case
+    # the tail exists for — that is a spiral, not a leak.
+    #
+    # A count is sound rather than a heuristic: those messages are already in
+    # the mailbox when init returns, and a mailbox is FIFO, so they are the next
+    # `update_v1/4` calls this process makes. No client update can overtake them
+    # because start_link has not returned yet.
+    echoes = if(snapshot_applied, do: 1, else: 0) + length(replay.applied)
+    Process.put(:index_replay_echoes, echoes)
+
+    # C2: prune must never delete a row bind could not fold in. A row that fails
+    # to decrypt today (a DekCache miss, a read racing a rotation) still holds a
+    # claim that a later successful replay can recover — unless a checkpoint
+    # deleted it in the meantime.
+    Map.put(state, :unfolded_ids, replay.skipped)
   end
 
   @impl true
-  def unbind(%{user_id: user_id, vault_id: vault_id}, _doc_name, doc) do
+  def unbind(%{user_id: user_id, vault_id: vault_id} = state, _doc_name, doc) do
     # get_user/1, NOT the bang variant. A deleted user or a vault force-purge is
     # an EXPECTED lifecycle state here — rows go while rooms are still exiting —
     # and raising turned that into a per-room error storm during a purge
@@ -110,7 +279,10 @@ defmodule Engram.Notes.CrdtIndexPersistence do
         :ok
 
       user ->
-        checkpoint(user, user_id, vault_id, doc)
+        # Rows bind could not fold in are excluded from the prune — they are
+        # not in this doc, so deleting them would destroy claims a later
+        # successful replay could still recover.
+        checkpoint(user, user_id, vault_id, doc, Map.get(state, :unfolded_ids, []))
     end
   rescue
     # A DB failure does NOT surface as {:error, _} — Repo.insert_all RAISES, and
@@ -144,7 +316,7 @@ defmodule Engram.Notes.CrdtIndexPersistence do
       :ok
   end
 
-  defp checkpoint(user, user_id, vault_id, doc) do
+  defp checkpoint(user, user_id, vault_id, doc, unfolded_ids) do
     # #1341, and the note path names THIS leg as the likeliest to race:
     # `SessionInvalidator.disconnect_user/1` fires at the TOP of a rotation, so
     # rooms start draining while the sweep is still running. A checkpoint landing
@@ -154,9 +326,9 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     # the last phase, so get_user still answers with the old wrapped dek
     # throughout the window.
     #
-    # Skipping is right even with no tail log to replay: a skipped checkpoint
-    # leaves the index STALE, which this module already treats as acceptable.
-    # Writing loses it outright.
+    # Skipping is right: the tail still holds everything since the last
+    # checkpoint, so a skipped checkpoint costs a replay on the next bind rather
+    # than the claims themselves. Writing an old-dek snapshot loses them outright.
     case RotationGate.check_user(user) do
       {:error, :rotation_in_progress} ->
         emit_checkpoint(:skipped_rotation)
@@ -169,7 +341,7 @@ defmodule Engram.Notes.CrdtIndexPersistence do
         :ok
 
       _ ->
-        write_snapshot(user, user_id, vault_id, doc)
+        write_snapshot(user, user_id, vault_id, doc, unfolded_ids)
     end
   end
 
@@ -192,17 +364,40 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   """
   @spec load_doc(map(), String.t()) :: {:ok, Yex.Doc.t()} | {:error, term()}
   def load_doc(user, vault_id) do
-    {:ok, row} = Repo.with_tenant(user.id, fn -> Repo.get(VaultIndexState, vault_id) end)
     doc = Yex.Doc.new()
 
-    case row do
-      nil ->
+    # snapshot + tail ≡ bind/3's recipe. Teaching bind/3 to replay the tail and
+    # NOT this would leave the roomless reader blind to every claim made since
+    # the last checkpoint — which is precisely the state an ungraceful room
+    # death creates, and precisely when `Identity` takes this path because
+    # `:global` has no room to find.
+    #
+    # The consequences of the two disagreeing are not staleness. `Identity`
+    # would accept a claim on a path a tail row already holds (returning success
+    # where a conflict is owed), and a release would fail to remove an entry
+    # that lives only in the tail, which the next bind then replays back — one
+    # permanent path reservation per note.
+    Repo.with_tenant(user.id, fn ->
+      with :ok <- load_snapshot_into(doc, user, vault_id) do
+        _ = replay_tail(doc, user, vault_id)
         {:ok, doc}
+      end
+    end)
+    |> case do
+      {:ok, result} -> result
+      other -> other
+    end
+  end
+
+  defp load_snapshot_into(doc, user, vault_id) do
+    case Repo.get(VaultIndexState, vault_id) do
+      nil ->
+        :ok
 
       row ->
         with {:ok, snapshot} <- Crypto.decrypt_index_state(row, user) do
           case Yex.apply_update(doc, snapshot) do
-            :ok -> {:ok, doc}
+            :ok -> :ok
             _ -> {:error, :corrupt_snapshot}
           end
         end
@@ -228,10 +423,21 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     end
   end
 
-  defp write_snapshot(user, user_id, vault_id, doc) do
+  defp write_snapshot(user, user_id, vault_id, doc, unfolded_ids) do
+    # Read the tail ids BEFORE writing, and prune exactly those afterwards.
+    #
+    # Not a timestamp or "everything for this vault" range: an update appended
+    # between the encode and the delete is NOT in the snapshot, and a range
+    # prune would drop it — silently losing the one claim the tail exists to
+    # protect. Rows that arrive after this read simply survive into the next
+    # bind, where replaying an update the snapshot already contains is a no-op
+    # because Yjs updates are idempotent.
+    folded_ids = tail_ids(user, vault_id) -- unfolded_ids
+
     case persist_doc(user, vault_id, doc) do
       :ok ->
         emit_checkpoint(:ok)
+        prune_tail(user, folded_ids)
 
         # Project the index onto the notes path columns (#1151 step 2) — in a
         # worker, never here. This runs inside terminate/2 against a shutdown
@@ -292,6 +498,84 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   # Raising fails the room start instead. The client's frame errors and it
   # retries; a genuinely corrupt snapshot surfaces as a loud, repeated failure
   # rather than a vault that silently forgot every path it knew.
+  # Replays every tail row for this vault, oldest first, and returns the ids
+  # that actually applied. Ordered by (inserted_at, id): two appends can land
+  # inside one clock tick, and the checkpoint prunes by EXACT id, so a tie must
+  # not let replay and prune disagree about which rows were folded in.
+  #
+  # A row that will not decrypt is SKIPPED, not fatal. Yjs updates are
+  # commutative and idempotent, so the rest still converge; refusing to bind
+  # over one bad row would take the whole vault's index down.
+  # Must be called inside the caller's `Repo.with_tenant` transaction — it
+  # queries a tenant-scoped table.
+  @doc false
+  @spec replay_tail(Yex.Doc.t(), map(), String.t()) ::
+          %{applied: [Ecto.UUID.t()], skipped: [Ecto.UUID.t()]}
+  def replay_tail(doc, user, vault_id) do
+    VaultIndexUpdateLog
+    |> where([l], l.vault_id == ^vault_id)
+    |> order_by([l], asc: l.inserted_at, asc: l.id)
+    |> Repo.all()
+    |> Enum.reduce(%{applied: [], skipped: []}, fn row, acc ->
+      case Crypto.decrypt_index_update(row, user) do
+        {:ok, update} ->
+          case Yex.apply_update(doc, update) do
+            :ok ->
+              %{acc | applied: [row.id | acc.applied]}
+
+            _ ->
+              skip_row(acc, row, user, vault_id, :corrupt_row)
+          end
+
+        {:error, reason} ->
+          skip_row(acc, row, user, vault_id, {:undecryptable_row, reason})
+      end
+    end)
+    |> then(fn acc -> %{applied: Enum.reverse(acc.applied), skipped: acc.skipped} end)
+  end
+
+  # A skipped row is NOT dropped. It keeps its place in the tail so a later bind
+  # — after the transient that caused it has cleared — can still recover the
+  # claim. It is also LOGGED, not merely counted: a permanently lost path claim
+  # that surfaces only as a Prometheus tick gives an operator no vault to look at.
+  defp skip_row(acc, row, user, vault_id, reason) do
+    phase = if is_tuple(reason), do: elem(reason, 0), else: reason
+    emit_tail(phase)
+
+    Logger.warning(
+      "crdt index tail row skipped on replay: #{inspect(reason)}",
+      Metadata.with_category(:warning, :sync, user_id: user.id, vault_id: vault_id)
+    )
+
+    %{acc | skipped: [row.id | acc.skipped]}
+  end
+
+  defp tail_ids(user, vault_id) do
+    {:ok, ids} =
+      Repo.with_tenant(user.id, fn ->
+        VaultIndexUpdateLog
+        |> where([l], l.vault_id == ^vault_id)
+        |> select([l], l.id)
+        |> Repo.all()
+      end)
+
+    ids
+  end
+
+  defp prune_tail(_user, []), do: :ok
+
+  defp prune_tail(user, ids) do
+    {:ok, {count, _}} =
+      Repo.with_tenant(user.id, fn ->
+        VaultIndexUpdateLog
+        |> where([l], l.id in ^ids)
+        |> Repo.delete_all()
+      end)
+
+    :telemetry.execute([:engram, :crdt, :index_tail], %{count: count}, %{phase: :pruned})
+    :ok
+  end
+
   defp apply_snapshot(row, user, doc, vault_id) do
     case Crypto.decrypt_index_state(row, user) do
       {:ok, snapshot} when is_binary(snapshot) ->

--- a/lib/engram/notes/crdt_index_persistence.ex
+++ b/lib/engram/notes/crdt_index_persistence.ex
@@ -220,9 +220,9 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     # #954 error storm.
     user = Accounts.get_user!(user_id)
 
-    {:ok, {snapshot_applied, replay}} =
+    {:ok, {snapshot_echoed?, replay}} =
       Repo.with_tenant(user_id, fn ->
-        applied =
+        echoed? =
           case Repo.get(VaultIndexState, vault_id) do
             nil ->
               # No snapshot yet: a vault whose index room has never checkpointed.
@@ -231,13 +231,12 @@ defmodule Engram.Notes.CrdtIndexPersistence do
 
             %VaultIndexState{} = row ->
               apply_snapshot(row, user, doc, vault_id)
-              true
           end
 
         # AFTER the snapshot, always — including when there is none. A vault
         # that has never checkpointed can still have tail rows, and those are
         # the only record of its claims (#1391).
-        {applied, replay_tail(doc, user, vault_id)}
+        {echoed?, replay_tail(doc, user, vault_id)}
       end)
 
     # y_ex installs the doc update monitor BEFORE bind/3 runs
@@ -249,11 +248,15 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     # of the entire index. On a vault whose room keeps dying — the exact case
     # the tail exists for — that is a spiral, not a leak.
     #
-    # A count is sound rather than a heuristic: those messages are already in
+    # The count is safe to use as a credit because those messages are already in
     # the mailbox when init returns, and a mailbox is FIFO, so they are the next
     # `update_v1/4` calls this process makes. No client update can overtake them
     # because start_link has not returned yet.
-    echoes = if(snapshot_applied, do: 1, else: 0) + length(replay.applied)
+    #
+    # It counts CHANGES, not applies. An apply that changed nothing emits
+    # nothing, so counting it would leave a credit behind that the next real
+    # client claim spends — see `apply_echoing?/2`.
+    echoes = if(snapshot_echoed?, do: 1, else: 0) + replay.echoes
     Process.put(:index_replay_echoes, echoes)
 
     # C2: prune must never delete a row bind could not fold in. A row that fails
@@ -423,6 +426,47 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     end
   end
 
+  @doc """
+  The roomless equivalent of a checkpoint: load, mutate, persist, prune.
+
+  `Identity` takes this path when `:global` finds no room for the vault. It has
+  to honour the SAME fold-and-prune contract `write_snapshot/5` does, because
+  `persist_doc/3` folds the replayed tail into the snapshot it writes. Folding
+  without pruning leaves every one of those rows behind, duplicated inside the
+  snapshot — and the next bind replays them as no-ops, which emit no
+  `{:update_v1, ...}` and so mis-credit the echo suppressor (see
+  `apply_echoing?/2`). One roomless write was enough to start silently dropping
+  the next room session's claims.
+
+  The whole fold runs in ONE transaction, so a mutation that cannot be persisted
+  cannot prune either.
+  """
+  @spec fold_roomless(map(), String.t(), (Yex.Doc.t() -> :ok | {:error, term()})) ::
+          :ok | {:error, term()}
+  def fold_roomless(user, vault_id, mutate) when is_function(mutate, 1) do
+    Repo.with_tenant(user.id, fn ->
+      doc = Yex.Doc.new()
+
+      with :ok <- load_snapshot_into(doc, user, vault_id) do
+        replay = replay_tail(doc, user, vault_id)
+
+        # Read BEFORE the write and prune exactly these, minus whatever replay
+        # could not fold in — identical reasoning to write_snapshot/5.
+        folded_ids = tail_ids(user, vault_id) -- replay.skipped
+
+        with :ok <- mutate.(doc),
+             :ok <- persist_doc(user, vault_id, doc) do
+          prune_tail(user, folded_ids)
+          :ok
+        end
+      end
+    end)
+    |> case do
+      {:ok, result} -> result
+      other -> other
+    end
+  end
+
   defp write_snapshot(user, user_id, vault_id, doc, unfolded_ids) do
     # Read the tail ids BEFORE writing, and prune exactly those afterwards.
     #
@@ -437,7 +481,7 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     case persist_doc(user, vault_id, doc) do
       :ok ->
         emit_checkpoint(:ok)
-        prune_tail(user, folded_ids)
+        prune_tail_safely(user, vault_id, folded_ids)
 
         # Project the index onto the notes path columns (#1151 step 2) — in a
         # worker, never here. This runs inside terminate/2 against a shutdown
@@ -486,18 +530,6 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     end
   end
 
-  # FAIL LOUD, exactly as CrdtPersistence.bind/3 does for a note's snapshot.
-  #
-  # Binding an empty doc here would be the fail-OPEN choice, and with no tail
-  # log it is strictly worse than it is for notes: the room comes up looking
-  # like a fresh vault, and the very next unbind/3 writes that empty doc back
-  # over a snapshot we merely failed to READ. A transient failure — DEK cache
-  # miss, a read racing a DEK rotation — becomes permanent loss of the whole
-  # index.
-  #
-  # Raising fails the room start instead. The client's frame errors and it
-  # retries; a genuinely corrupt snapshot surfaces as a loud, repeated failure
-  # rather than a vault that silently forgot every path it knew.
   # Replays every tail row for this vault, oldest first, and returns the ids
   # that actually applied. Ordered by (inserted_at, id): two appends can land
   # inside one clock tick, and the checkpoint prunes by EXACT id, so a tie must
@@ -510,18 +542,22 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   # queries a tenant-scoped table.
   @doc false
   @spec replay_tail(Yex.Doc.t(), map(), String.t()) ::
-          %{applied: [Ecto.UUID.t()], skipped: [Ecto.UUID.t()]}
+          %{applied: [Ecto.UUID.t()], skipped: [Ecto.UUID.t()], echoes: non_neg_integer()}
   def replay_tail(doc, user, vault_id) do
     VaultIndexUpdateLog
     |> where([l], l.vault_id == ^vault_id)
     |> order_by([l], asc: l.inserted_at, asc: l.id)
     |> Repo.all()
-    |> Enum.reduce(%{applied: [], skipped: []}, fn row, acc ->
+    |> Enum.reduce(%{applied: [], skipped: [], echoes: 0}, fn row, acc ->
       case Crypto.decrypt_index_update(row, user) do
         {:ok, update} ->
-          case Yex.apply_update(doc, update) do
-            :ok ->
-              %{acc | applied: [row.id | acc.applied]}
+          case apply_echoing?(doc, update) do
+            {:ok, echoed?} ->
+              %{
+                acc
+                | applied: [row.id | acc.applied],
+                  echoes: acc.echoes + if(echoed?, do: 1, else: 0)
+              }
 
             _ ->
               skip_row(acc, row, user, vault_id, :corrupt_row)
@@ -531,7 +567,32 @@ defmodule Engram.Notes.CrdtIndexPersistence do
           skip_row(acc, row, user, vault_id, {:undecryptable_row, reason})
       end
     end)
-    |> then(fn acc -> %{applied: Enum.reverse(acc.applied), skipped: acc.skipped} end)
+    |> then(fn acc -> %{acc | applied: Enum.reverse(acc.applied)} end)
+  end
+
+  # Whether this apply will actually post an `{:update_v1, ...}` back to us.
+  #
+  # yrs fires the update observer from the transaction COMMIT hook, and only
+  # when the transaction changed the doc. `Yex.apply_update/2` answers `:ok`
+  # either way, so counting APPLIES rather than CHANGES over-counts — and every
+  # over-count is a permanent credit in `:index_replay_echoes` that silently
+  # swallows one real client claim. Two ordinary states hit it: an empty
+  # snapshot (a vault whose room bound and exited without a write), and a tail
+  # row a roomless `Identity.via_snapshot` write already folded into the
+  # snapshot.
+  #
+  # The state vector is the CONSERVATIVE signal. It advances iff new items were
+  # integrated, and integrating new items always emits. A delete-only update can
+  # emit without advancing it — that under-counts, which merely re-appends an
+  # idempotent row to the tail. Over-counting loses a claim outright, so the
+  # error is deliberately biased to the harmless direction.
+  defp apply_echoing?(doc, update) do
+    before_sv = Yex.encode_state_vector(doc)
+
+    case Yex.apply_update(doc, update) do
+      :ok -> {:ok, Yex.encode_state_vector(doc) != before_sv}
+      other -> other
+    end
   end
 
   # A skipped row is NOT dropped. It keeps its place in the tail so a later bind
@@ -565,21 +626,71 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   defp prune_tail(_user, []), do: :ok
 
   defp prune_tail(user, ids) do
-    {:ok, {count, _}} =
-      Repo.with_tenant(user.id, fn ->
-        VaultIndexUpdateLog
-        |> where([l], l.id in ^ids)
-        |> Repo.delete_all()
+    # CHUNKED: `l.id in ^ids` binds one parameter per id, and the tail is
+    # unbounded for a room that never checkpoints (see the moduledoc), so a
+    # large enough fold would blow Postgres' parameter ceiling — and take a
+    # checkpoint that had already succeeded down with it.
+    count =
+      ids
+      |> Enum.chunk_every(5_000)
+      |> Enum.reduce(0, fn chunk, acc ->
+        {:ok, {n, _}} =
+          Repo.with_tenant(user.id, fn ->
+            VaultIndexUpdateLog
+            |> where([l], l.id in ^chunk)
+            |> Repo.delete_all()
+          end)
+
+        acc + n
       end)
 
     :telemetry.execute([:engram, :crdt, :index_tail], %{count: count}, %{phase: :pruned})
     :ok
   end
 
+  # The snapshot is ALREADY durable when this runs, so a prune failure is a
+  # tail-hygiene problem, not a checkpoint failure. Letting it propagate made
+  # `unbind/3`'s rescue emit `checkpoint(:failed)` for a checkpoint that had in
+  # fact succeeded, and skipped the ProjectVaultIndex enqueue — so `notes.path_*`
+  # never converged to the snapshot that had just been written.
+  #
+  # Rescuing here is not swallowing a bug: the rows it fails to delete are
+  # replayed as idempotent no-ops on the next bind, and the failure is logged
+  # and counted under its own phase.
+  defp prune_tail_safely(user, vault_id, ids) do
+    prune_tail(user, ids)
+  rescue
+    e ->
+      emit_tail(:prune_failed)
+
+      Logger.error(
+        "crdt index tail prune failed after a durable checkpoint: #{Exception.message(e)}",
+        Metadata.with_category(:error, :sync, user_id: user.id, vault_id: vault_id)
+      )
+
+      :ok
+  end
+
+  # FAIL LOUD, exactly as CrdtPersistence.bind/3 does for a note's snapshot.
+  #
+  # Binding an empty doc here would be the fail-OPEN choice: the room comes up
+  # looking like a fresh vault, and the very next unbind/3 writes that empty doc
+  # back over a snapshot we merely failed to READ. A transient failure — DEK
+  # cache miss, a read racing a DEK rotation — becomes permanent loss of the
+  # whole index. The tail log narrows the blast radius to whatever the last
+  # checkpoint folded in; it does not make fail-open safe.
+  #
+  # Raising fails the room start instead. The client's frame errors and it
+  # retries; a genuinely corrupt snapshot surfaces as a loud, repeated failure
+  # rather than a vault that silently forgot every path it knew.
+  #
+  # Returns whether the apply will echo back through update_v1/4 — see
+  # `apply_echoing?/2`. An EMPTY snapshot applies cleanly and emits nothing.
   defp apply_snapshot(row, user, doc, vault_id) do
     case Crypto.decrypt_index_state(row, user) do
       {:ok, snapshot} when is_binary(snapshot) ->
-        :ok = Yex.apply_update(doc, snapshot)
+        {:ok, echoed?} = apply_echoing?(doc, snapshot)
+        echoed?
 
       {:error, reason} ->
         Logger.error(

--- a/lib/engram/notes/crdt_index_persistence.ex
+++ b/lib/engram/notes/crdt_index_persistence.ex
@@ -9,13 +9,14 @@ defmodule Engram.Notes.CrdtIndexPersistence do
     encrypt the whole doc state and upsert the single `vault_index_states` row.
   * `update_v1/4` — the tail append (#1391). See below.
 
-  ## Snapshot-only, and what that costs
+  ## Why a tail log, when the writes are rare
 
   `CrdtPersistence` appends every update to `crdt_update_log` because a note
   room's hot path is keystrokes and losing a checkpoint interval means losing
   typing. The index's writes are rename/create/delete — orders of magnitude
-  rarer — so this stays snapshot-only. An ungraceful room death (SIGKILL, node
-  loss) loses index writes since the last exit.
+  rarer — which is why this room shipped snapshot-only in #1150. Rarity turned
+  out to be the wrong axis: what matters is what a lost write COSTS, not how
+  often one happens.
 
   **That is why `update_v1/4` exists here (#1391).** The snapshot alone was
   written only when a room exited, so anything since the last checkpoint died

--- a/lib/engram/notes/identity.ex
+++ b/lib/engram/notes/identity.ex
@@ -151,6 +151,30 @@ defmodule Engram.Notes.Identity do
     # whether a socket is open", and the room route is the open-socket half.
     warn_if_in_transaction(user, vault_id, op)
 
+    # Gated BEFORE routing, so both routes fail closed. This used to sit only on
+    # the snapshot route, on the reasoning that "the room path needs no gate —
+    # it only mutates memory, and the room's own checkpoint is already gated."
+    # The tail log killed that: a room write now has to become durable through
+    # `append_tail`, which is gated, and the checkpoint that was supposed to
+    # rescue the in-memory claim afterwards is gated too and runs only at
+    # process death. So the ungated room route returned :ok, wrote no tail row,
+    # wrote no snapshot, and lost the claim outright when the room drained —
+    # while the caller had already committed the notes row against it.
+    #
+    # Refusing is the documented contract: "a rename during a DEK rotation fails
+    # rather than half-applying."
+    case rotation_gate(user) do
+      :ok ->
+        route_targets(user, vault_id, targets, op)
+
+      {:error, :rotation_in_progress} = err ->
+        emit(op, :gate, :rotation, targets)
+        log(user, vault_id, op, "refused — dek rotation in progress")
+        err
+    end
+  end
+
+  defp route_targets(user, vault_id, targets, op) do
     case :global.whereis_name({:crdt_index, vault_id}) do
       pid when is_pid(pid) ->
         case via_room(pid, targets) do
@@ -229,8 +253,12 @@ defmodule Engram.Notes.Identity do
   #
   # Because the claim is the commit, this cannot be skipped-and-continued the
   # way a derived side effect could: half-applying a rename is worse than
-  # refusing it. The room path needs no gate — it only mutates memory, and the
-  # room's own checkpoint is already gated.
+  # refusing it.
+  #
+  # `apply_targets/4` now gates BOTH routes before it picks one, so this is a
+  # second line rather than the only one. It is kept because `via_snapshot` is
+  # also the fallback target of a room that died mid-write, and a rotation can
+  # begin in that window.
   #
   # Matching `:ok` EXPLICITLY, not `_`. This gate stands between a write and
   # permanent unreadability; a future third return from `check_user/1` must
@@ -258,12 +286,13 @@ defmodule Engram.Notes.Identity do
   defp rotation_gate(_other), do: {:error, :rotation_in_progress}
 
   defp do_via_snapshot(user, vault_id, targets, op) do
-    with {:ok, doc} <- CrdtIndexPersistence.load_doc(user, vault_id),
-         :ok <- mutate(doc, targets),
-         :ok <- CrdtIndexPersistence.persist_doc(user, vault_id, doc) do
-      emit(op, :snapshot, :ok, targets)
-      recheck_room(user, vault_id, targets, op)
-    else
+    # fold_roomless owns the load -> mutate -> persist -> PRUNE contract. Doing
+    # the first three by hand here is what left folded tail rows behind.
+    case CrdtIndexPersistence.fold_roomless(user, vault_id, &mutate(&1, targets)) do
+      :ok ->
+        emit(op, :snapshot, :ok, targets)
+        recheck_room(user, vault_id, targets, op)
+
       {:error, :conflict} = err ->
         emit(op, :snapshot, :conflict, targets)
         err

--- a/lib/engram/notes/vault_index_state.ex
+++ b/lib/engram/notes/vault_index_state.ex
@@ -3,13 +3,17 @@ defmodule Engram.Notes.VaultIndexState do
   The encrypted `filemeta_v0` snapshot for one vault's index room (#1151).
 
   One row per vault, upserted when the room exits and read when it binds.
-  Snapshot-only: there is no per-update tail log the way `notes.crdt_state` has
-  `crdt_update_log`. Index writes are rename/create/delete rather than
-  keystrokes, and until Engram-obsidian#363 the `notes` rows stay authoritative
-  for paths — so losing a checkpoint interval leaves the index STALE, never
-  silently wrong. No rebuild path exists in `lib/`; what makes staleness
-  tolerable today is that nothing reads the index. Add a tail log when that
-  stops being true.
+
+  This is the SNAPSHOT half of a two-part record. `vault_index_update_log` is
+  the other: every update is appended there as it happens, and a checkpoint
+  folds the tail into this row and prunes exactly what it folded (#1391). So a
+  bind reads this row and then replays whatever tail survived it.
+
+  The tail exists because the map is authoritative for paths
+  (`docs/context/crdt-identity-authority.md`). Losing a checkpoint interval used
+  to leave the index merely STALE, with the `notes` rows still holding the
+  truth; under map-authority it loses committed path CLAIMS outright, and
+  projection then drags the rows back to the superseded snapshot.
 
   Keyed by `vault_id` rather than a surrogate `id`, which is why the AAD is
   built explicitly (`Crypto.encrypt_index_state/3`) instead of going through

--- a/lib/engram/notes/vault_index_update_log.ex
+++ b/lib/engram/notes/vault_index_update_log.ex
@@ -1,0 +1,43 @@
+defmodule Engram.Notes.VaultIndexUpdateLog do
+  @moduledoc """
+  Append-only encrypted Yjs update row for a vault's `filemeta_v0` index room.
+
+  The tail that makes the index durable BETWEEN checkpoints (#1391), mirroring
+  `Engram.Notes.CrdtUpdateLog` for note rooms. Compacted on checkpoint.
+
+  `vault_index_states` alone was snapshot-only, written when a room exits. That
+  was sound while the `notes` rows were authoritative for paths — a lost
+  interval left the index STALE and the rows still held the truth. #1151 step 2
+  made the MAP authoritative (`docs/context/crdt-identity-authority.md`), so a
+  lost interval now drops committed path CLAIMS and the rows converge back to a
+  superseded snapshot on the next projection run.
+
+  Keyed by its own id rather than the vault, because rows are appended and then
+  pruned by EXACT id — see `CrdtIndexPersistence`'s checkpoint, which must not
+  prune a row it did not fold in.
+  """
+  use Engram.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  schema "vault_index_update_log" do
+    field :vault_id, Ecto.UUID
+    field :user_id, Ecto.UUID
+    field :update_ciphertext, :binary
+    field :update_nonce, :binary
+    field :dek_version, :integer, default: 2
+    field :inserted_at, :utc_datetime_usec
+  end
+
+  @fields [:id, :vault_id, :user_id, :update_ciphertext, :update_nonce, :dek_version]
+  @required [:vault_id, :user_id, :update_ciphertext, :update_nonce]
+
+  @doc false
+  def changeset(row, attrs) do
+    row
+    |> cast(attrs, @fields)
+    |> validate_required(@required)
+  end
+end

--- a/lib/engram/prom_ex/crdt.ex
+++ b/lib/engram/prom_ex/crdt.ex
@@ -131,8 +131,10 @@ defmodule Engram.PromEx.Crdt do
           event_name: @claim_event,
           description:
             "Server-side filemeta_v0 writes by op (claim | release), route " <>
-              "(room | snapshot | orphan) and phase (ok | conflict | rotation | room_exit | " <>
-              "mailbox_empty | load_failed | persist_failed | orphan_claim).",
+              "(gate | room | snapshot | orphan) and phase (ok | conflict | rotation | " <>
+              "room_exit | mailbox_empty | load_failed | persist_failed | orphan_claim). " <>
+              "route=gate phase=rotation is a write REFUSED before routing because a DEK " <>
+              "rotation is running — the caller got an error and did not commit.",
           tags: [:op, :route, :phase]
         ),
         sum(
@@ -169,7 +171,10 @@ defmodule Engram.PromEx.Crdt do
           event_name: @tail_event,
           description:
             "filemeta_v0 tail-log operations by phase (ok | failed | pruned | " <>
-              "corrupt_row | undecryptable_row).",
+              "corrupt_row | undecryptable_row | skipped_rotation | prune_failed). " <>
+              "A sustained `failed` " <>
+              "OR `skipped_rotation` both mean the same thing — claims are living only in " <>
+              "room memory and die with the process.",
           tags: [:phase]
         ),
         counter(

--- a/lib/engram/prom_ex/crdt.ex
+++ b/lib/engram/prom_ex/crdt.ex
@@ -88,6 +88,7 @@ defmodule Engram.PromEx.Crdt do
   @claim_event [:engram, :crdt, :index_claim]
   @recheck_event [:engram, :crdt, :index_recheck]
   @in_transaction_event [:engram, :crdt, :index_in_transaction]
+  @tail_event [:engram, :crdt, :index_tail]
   @drain_event [:engram, :crdt, :room_drain]
   @checkpoint_event [:engram, :crdt, :index_checkpoint]
   @projection_event [:engram, :crdt, :index_projection]
@@ -158,6 +159,18 @@ defmodule Engram.PromEx.Crdt do
           event_name: @in_transaction_event,
           description: "filemeta_v0 writes made inside a caller's transaction (should be 0).",
           tags: [:op]
+        ),
+        # #1391 — the index tail. `ok` should track index writes closely; a
+        # sustained `failed` means claims are living only in room memory, which
+        # is exactly the state the tail exists to prevent and is otherwise
+        # invisible until a room dies and the claims are simply gone.
+        counter(
+          metric_prefix ++ [:index_tail, :total],
+          event_name: @tail_event,
+          description:
+            "filemeta_v0 tail-log operations by phase (ok | failed | pruned | " <>
+              "corrupt_row | undecryptable_row).",
+          tags: [:phase]
         ),
         counter(
           metric_prefix ++ [:index_projection, :total],

--- a/lib/engram/repo.ex
+++ b/lib/engram/repo.ex
@@ -13,7 +13,7 @@ defmodule Engram.Repo do
   # (Engram#788). Their access is already correct — onboarding_actions via
   # `skip_tenant_check`, crdt_update_log via `with_tenant` — so listing them
   # only tightens the guard, it doesn't change behavior.
-  @tenant_tables ~w(notes chunks attachments api_keys vaults user_agreements onboarding_actions crdt_update_log note_links vault_index_states)a
+  @tenant_tables ~w(notes chunks attachments api_keys vaults user_agreements onboarding_actions crdt_update_log note_links vault_index_states vault_index_update_log)a
 
   @doc """
   The tables guarded by `prepare_query/3`, which must equal the set of tables

--- a/priv/repo/migrations/20260816070000_create_vault_index_update_log_expand.exs
+++ b/priv/repo/migrations/20260816070000_create_vault_index_update_log_expand.exs
@@ -1,0 +1,72 @@
+defmodule Engram.Repo.Migrations.CreateVaultIndexUpdateLogExpand do
+  use Ecto.Migration
+
+  # squawk-ignore-file
+  #
+  # phase/expand — new table, no backfill. The per-update tail for a vault's
+  # `filemeta_v0` index room, mirroring `crdt_update_log` for note rooms.
+  #
+  # #1391. `vault_index_states` is snapshot-only, written when a room exits.
+  # That was a sound trade while the `notes` rows were authoritative for paths:
+  # losing a checkpoint interval left the index STALE and the rows still held
+  # the truth. #1151 step 2 made the MAP authoritative and derives the path
+  # columns from it, so an interval lost to a SIGKILL, a node loss or an ECS
+  # task replacement now drops committed path CLAIMS — and the rows converge
+  # back to the superseded snapshot on the next projection run.
+  #
+  # Volume is nothing like the note tail: index writes are rename/create/delete,
+  # not keystrokes, and the checkpoint prunes what it folds in.
+  #
+  # RLS mirrors crdt_update_log / vault_index_states — tenant-scoped by user_id.
+  def change do
+    create table(:vault_index_update_log, primary_key: false) do
+      add :id, :uuid, primary_key: true, default: fragment("uuidv7()")
+
+      add :vault_id, references(:vaults, type: :uuid, on_delete: :delete_all), null: false
+      add :user_id, references(:users, type: :uuid, on_delete: :delete_all), null: false
+
+      add :update_ciphertext, :binary, null: false
+      add :update_nonce, :binary, null: false
+
+      # Always AAD-bound (aad_for_row(:vault_index_update_log, :update, id)).
+      # Carried so UserDekRotation's sweep stamps it like every other encrypted
+      # table.
+      add :dek_version, :integer, null: false, default: 2
+
+      add :inserted_at, :timestamptz, null: false, default: fragment("now()")
+    end
+
+    # Replay order is (vault_id, inserted_at, id): the id tiebreak matters
+    # because two updates can land inside one clock tick, and Yjs updates are
+    # commutative but the PRUNE is by exact id — an ordering tie must not make
+    # replay and prune disagree about which rows a checkpoint folded in.
+    create index(:vault_index_update_log, [:vault_id, :inserted_at, :id])
+
+    # RLS predicate, and the on_delete: :delete_all cascade scans it.
+    create index(:vault_index_update_log, [:user_id])
+
+    execute(
+      "ALTER TABLE vault_index_update_log ENABLE ROW LEVEL SECURITY",
+      "ALTER TABLE vault_index_update_log DISABLE ROW LEVEL SECURITY"
+    )
+
+    execute(
+      "ALTER TABLE vault_index_update_log FORCE ROW LEVEL SECURITY",
+      "ALTER TABLE vault_index_update_log NO FORCE ROW LEVEL SECURITY"
+    )
+
+    execute(
+      """
+      CREATE POLICY tenant_isolation_vault_index_update_log ON vault_index_update_log
+        USING (user_id::text = (SELECT current_setting('app.current_tenant', true)))
+        WITH CHECK (user_id::text = (SELECT current_setting('app.current_tenant', true)))
+      """,
+      "DROP POLICY IF EXISTS tenant_isolation_vault_index_update_log ON vault_index_update_log"
+    )
+
+    execute(
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON vault_index_update_log TO engram_app",
+      "REVOKE ALL ON vault_index_update_log FROM engram_app"
+    )
+  end
+end

--- a/test/engram/crypto/user_dek_rotation_test.exs
+++ b/test/engram/crypto/user_dek_rotation_test.exs
@@ -8,7 +8,15 @@ defmodule Engram.Crypto.UserDekRotationTest do
   alias Engram.Attachments
   alias Engram.Crypto
   alias Engram.Crypto.{DekCache, Envelope, UserDekRotation}
-  alias Engram.Notes.{CrdtBridge, CrdtIndexDoc, CrdtIndexRegistry, VaultIndexState}
+
+  alias Engram.Notes.{
+    CrdtBridge,
+    CrdtIndexDoc,
+    CrdtIndexRegistry,
+    VaultIndexState,
+    VaultIndexUpdateLog
+  }
+
   alias Engram.Repo
   alias Engram.Test.LogCapture
   alias Engram.Vector.Qdrant
@@ -150,6 +158,124 @@ defmodule Engram.Crypto.UserDekRotationTest do
 
       assert entry["note_id"] == "note-rotated"
     end
+
+    # The snapshot sweep above is only half the story. A claim is durable the
+    # moment it hits the TAIL, long before any checkpoint folds it into a
+    # snapshot — so a rotation that sweeps `vault_index_states` but not
+    # `vault_index_update_log` leaves every uncheckpointed claim wrapped under
+    # the retired dek. That failure is silent and delayed in exactly the way the
+    # comment at the top of this block warns about: the rows keep decrypting
+    # until the old key goes away, and only then does a rebind come up missing
+    # claims that the rotation reported as successfully migrated.
+    test "the index tail rewraps too, so uncheckpointed claims survive", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, room} = CrdtIndexRegistry.ensure_observed(user.id, vault.id)
+
+      :ok =
+        SharedDoc.update_doc(room, fn doc ->
+          doc
+          |> Yex.Doc.get_map(CrdtIndexDoc.map_name())
+          |> Yex.Map.set("Tail/rotated.md", %{"note_id" => "note-tail-rotated"})
+        end)
+
+      # `handle_update_v1` is asynchronous, so the write has to be observed as
+      # DURABLE before rotating — otherwise the sweep can legitimately run
+      # before the row exists and the test proves nothing.
+      before = await_index_tail(user, vault.id, 1)
+
+      assert :ok = UserDekRotation.rotate_user(user.id)
+
+      after_rows = index_tail_rows(user, vault.id)
+      assert length(after_rows) == 1
+      [after_row] = after_rows
+      [before_row] = before
+
+      refute after_row.update_ciphertext == before_row.update_ciphertext,
+             "the tail row was left wrapped under the retired dek"
+
+      assert after_row.dek_version == before_row.dek_version + 1
+
+      # Kill rather than unobserve: a graceful exit would checkpoint and prune,
+      # so the rebind below would read the snapshot and never touch the tail —
+      # which is precisely the path under test.
+      ref = Process.monitor(room)
+      Process.exit(room, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^room, _}, 5_000
+
+      {:ok, respun} = CrdtIndexRegistry.ensure_observed(user.id, vault.id)
+      test_pid = self()
+
+      :ok =
+        SharedDoc.update_doc(respun, fn doc ->
+          send(
+            test_pid,
+            {:entry,
+             doc |> Yex.Doc.get_map(CrdtIndexDoc.map_name()) |> Yex.Map.fetch("Tail/rotated.md")}
+          )
+        end)
+
+      assert_receive {:entry, {:ok, %{"note_id" => "note-tail-rotated"}}}, 5_000
+    end
+
+    # A tail row that decrypts under NEITHER key has to be survivable. It is a
+    # lost claim, but aborting the sweep strands the user mid-rotation — several
+    # tables re-wrapped, `final_flip` never reached — and the rotation cannot be
+    # retried into a good state.
+    #
+    # This also pins the opts contract: `try_rewrap`'s failure branch `fetch!`es
+    # :log, :log_meta and :on_both_failed, so a call site that omits them turns
+    # this row into a KeyError instead of a logged, counted skip.
+    test "an unreadable index tail row does not abort the rotation", %{user: user, vault: vault} do
+      {:ok, room} = CrdtIndexRegistry.ensure_observed(user.id, vault.id)
+
+      :ok =
+        SharedDoc.update_doc(room, fn doc ->
+          doc
+          |> Yex.Doc.get_map(CrdtIndexDoc.map_name())
+          |> Yex.Map.set("Corrupt/row.md", %{"note_id" => "note-corrupt"})
+        end)
+
+      [row] = await_index_tail(user, vault.id, 1)
+
+      # Flip a bit in the AEAD TAG rather than truncating: Envelope.decrypt/4
+      # short-circuits on `byte_size - 16 < 0` before AES-GCM ever runs, so a
+      # short blob would never exercise the tag check a real corruption trips.
+      <<head::binary-size(byte_size(row.update_ciphertext) - 1), last>> = row.update_ciphertext
+      corrupted = <<head::binary, Bitwise.bxor(last, 0xFF)>>
+
+      {:ok, {1, _}} =
+        Repo.with_tenant(user.id, fn ->
+          from(l in VaultIndexUpdateLog, where: l.id == ^row.id)
+          |> Repo.update_all(set: [update_ciphertext: corrupted])
+        end)
+
+      assert :ok = UserDekRotation.rotate_user(user.id),
+             "one unreadable tail row aborted the whole rotation"
+    end
+  end
+
+  defp index_tail_rows(user, vault_id) do
+    {:ok, rows} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(from(l in VaultIndexUpdateLog, where: l.vault_id == ^vault_id, order_by: l.id))
+      end)
+
+    rows
+  end
+
+  defp await_index_tail(user, vault_id, n) do
+    Enum.reduce_while(1..200, nil, fn _, _ ->
+      case index_tail_rows(user, vault_id) do
+        rows when length(rows) >= n ->
+          {:halt, rows}
+
+        _ ->
+          Process.sleep(10)
+          {:cont, nil}
+      end
+    end) || flunk("the index write never reached the tail log")
   end
 
   describe "rotate_user/1 — socket drain (#1092)" do

--- a/test/engram/notes/crdt_index_chaos_test.exs
+++ b/test/engram/notes/crdt_index_chaos_test.exs
@@ -1,0 +1,215 @@
+defmodule Engram.Notes.CrdtIndexChaosTest do
+  @moduledoc """
+  Randomised lifecycle chaos over the index room's durability.
+
+  The example-based tests each pin ONE ordering: write-then-kill, write-then-
+  checkpoint, two-writes-one-checkpoint. Every bug this subsystem has actually
+  shipped came from an ordering nobody wrote a test for — the checkpoint that
+  pruned a row it had not folded in, the bind that echoed its own replay back
+  onto the tail, the snapshot that raced a rotation. Those are interleavings,
+  not features, so they are enumerated here rather than hand-picked.
+
+  A `model` map is the oracle: the last `note_id` written to each path is what
+  the doc must hold, no matter what happened to the room in between. Ops are
+  drawn from a SEEDED generator, so a failure is replayable — the seed is in
+  the message.
+
+  The one race deliberately excluded: `handle_update_v1` is asynchronous, so a
+  write that has not yet reached the tail is legitimately lost by a kill (the
+  client still holds it and retransmits on rejoin). The loop therefore waits
+  for durability before it kills. What is asserted is the promise the design
+  actually makes — ONCE DURABLE, NEVER LOST — not a stronger one it doesn't.
+  """
+  use Engram.DataCase, async: false
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.{Crypto, Repo, Vaults}
+  alias Engram.Notes.{CrdtIndexDoc, CrdtIndexRegistry, VaultIndexUpdateLog}
+  alias Yex.Sync.SharedDoc
+
+  # Small path pool on purpose: reuse forces overwrite-same-key, which is where
+  # last-writer-wins and tail replay ORDER start to matter. A wide pool would
+  # make every op independent and test almost nothing.
+  @paths ~w(a.md b.md c.md d/e.md d/f.md)
+  @ops [:put, :put, :put, :kill, :stop, :rebind, :read]
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "IndexChaos"})
+    %{user: user, vault: vault}
+  end
+
+  defp tail_count(user, vault_id) do
+    {:ok, n} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.aggregate(from(l in VaultIndexUpdateLog, where: l.vault_id == ^vault_id), :count)
+      end)
+
+    n
+  end
+
+  defp await_tail_growth(user, vault_id, baseline) do
+    Enum.reduce_while(1..200, nil, fn _, _ ->
+      case tail_count(user, vault_id) do
+        n when n > baseline ->
+          {:halt, n}
+
+        _ ->
+          Process.sleep(10)
+          {:cont, nil}
+      end
+    end) || flunk("a write never became durable (tail stayed at #{baseline})")
+  end
+
+  defp put(room, path, note_id) do
+    :ok =
+      SharedDoc.update_doc(room, fn doc ->
+        doc
+        |> Yex.Doc.get_map(CrdtIndexDoc.map_name())
+        |> Yex.Map.set(path, %{"note_id" => note_id})
+      end)
+  end
+
+  defp read(room, path) do
+    me = self()
+
+    :ok =
+      SharedDoc.update_doc(room, fn doc ->
+        send(
+          me,
+          {:read, path, doc |> Yex.Doc.get_map(CrdtIndexDoc.map_name()) |> Yex.Map.fetch(path)}
+        )
+      end)
+
+    receive do
+      {:read, ^path, {:ok, %{"note_id" => id}}} -> id
+      {:read, ^path, _} -> nil
+    after
+      5_000 -> flunk("the room never answered a read of #{path}")
+    end
+  end
+
+  defp start_room(%{user: user, vault: vault}) do
+    {:ok, room} = CrdtIndexRegistry.ensure_observed(user.id, vault.id)
+    room
+  end
+
+  # Graceful: drop the last observer -> auto_exit -> terminate -> unbind ->
+  # checkpoint. This is the path that writes a snapshot and prunes the tail.
+  defp stop_room(room) do
+    ref = Process.monitor(room)
+    :ok = SharedDoc.unobserve(room)
+
+    receive do
+      {:DOWN, ^ref, :process, ^room, _} -> :ok
+    after
+      5_000 -> flunk("the room never exited after losing its last observer")
+    end
+  end
+
+  # Violent: no terminate/2, so no unbind and no snapshot. Everything since the
+  # last checkpoint has to come back from the tail alone.
+  defp kill_room(room) do
+    ref = Process.monitor(room)
+    Process.exit(room, :kill)
+
+    receive do
+      {:DOWN, ^ref, :process, ^room, _} -> :ok
+    after
+      5_000 -> flunk("the room survived a kill")
+    end
+  end
+
+  defp alive?(room), do: is_pid(room) and Process.alive?(room)
+
+  defp step(:put, ctx, {room, model, baseline}) do
+    room = if alive?(room), do: room, else: start_room(ctx)
+    path = Enum.random(@paths)
+    id = Ecto.UUID.generate()
+    put(room, path, id)
+    {room, Map.put(model, path, id), await_tail_growth(ctx.user, ctx.vault.id, baseline)}
+  end
+
+  defp step(:kill, ctx, {room, model, _baseline}) do
+    if alive?(room), do: kill_room(room)
+    {nil, model, tail_count(ctx.user, ctx.vault.id)}
+  end
+
+  defp step(:stop, ctx, {room, model, _baseline}) do
+    if alive?(room), do: stop_room(room)
+    {nil, model, tail_count(ctx.user, ctx.vault.id)}
+  end
+
+  defp step(:rebind, ctx, {room, model, baseline}) do
+    if alive?(room),
+      do: {room, model, baseline},
+      else: {start_room(ctx), model, tail_count(ctx.user, ctx.vault.id)}
+  end
+
+  defp step(:read, ctx, {room, model, baseline}) do
+    room = if alive?(room), do: room, else: start_room(ctx)
+    path = Enum.random(@paths)
+
+    assert read(room, path) == Map.get(model, path),
+           "a live room disagreed with the model on #{path}"
+
+    {room, model, baseline}
+  end
+
+  # Every path is checked against a room bound from scratch, so the assertion
+  # reads the DURABLE state (snapshot + tail replay), never a doc that merely
+  # happened to still be in memory.
+  defp verify_from_cold_start(ctx, model, seed) do
+    room = start_room(ctx)
+
+    for {path, expected} <- model do
+      assert read(room, path) == expected,
+             "#{path} did not survive the lifecycle (seed #{inspect(seed)})"
+    end
+
+    stop_room(room)
+  end
+
+  describe "durability under a randomised room lifecycle" do
+    for seed <- [{1, 2, 3}, {17, 41, 97}, {2026, 8, 16}] do
+      @seed seed
+
+      test "once durable, a claim survives any interleaving (seed #{inspect(seed)})", ctx do
+        :rand.seed(:exsss, @seed)
+
+        {room, model, _} =
+          Enum.reduce(1..30, {nil, %{}, 0}, fn _, acc ->
+            step(Enum.random(@ops), ctx, acc)
+          end)
+
+        if alive?(room), do: stop_room(room)
+
+        refute model == %{}, "the generator produced no writes at all"
+        verify_from_cold_start(ctx, model, @seed)
+      end
+    end
+
+    # The tail is unbounded until #1151 step 3 generalises the checkpoint timer,
+    # so what keeps it finite today is that a graceful exit prunes what it
+    # folded in. If a checkpoint ever prunes MORE than it folded, the cold-start
+    # check above goes red; if it prunes LESS, the tail grows forever and this
+    # catches it.
+    test "a graceful exit always leaves the tail empty", ctx do
+      :rand.seed(:exsss, {5, 5, 5})
+
+      {room, _model, _} =
+        Enum.reduce(1..12, {nil, %{}, 0}, fn _, acc ->
+          step(Enum.random([:put, :put, :kill, :rebind]), ctx, acc)
+        end)
+
+      room = if alive?(room), do: room, else: start_room(ctx)
+      stop_room(room)
+
+      assert tail_count(ctx.user, ctx.vault.id) == 0,
+             "a checkpoint left rows behind it had already folded into the snapshot"
+    end
+  end
+end

--- a/test/engram/notes/crdt_index_persistence_test.exs
+++ b/test/engram/notes/crdt_index_persistence_test.exs
@@ -13,11 +13,20 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
       write to the map -> room exits -> encrypted snapshot in the DB
         -> new room binds -> the same entries are back
 
-  Snapshot-only by design (no per-update tail log): index writes are
-  rename/create/delete, not keystrokes, and until Engram-obsidian#363 the notes
-  rows remain authoritative for paths — so a lost checkpoint interval leaves the
-  index STALE, never silently wrong. Nothing reads the index yet and no rebuild
-  path exists; "stale is tolerable" is a statement about today.
+  Snapshot-only is no longer enough. #1150's reasoning — that a lost checkpoint
+  interval leaves the index merely STALE because the notes rows stay
+  authoritative — died with the map-authority decision
+  (`docs/context/crdt-identity-authority.md`). The map IS the identity record
+  now, so a claim lost between checkpoints is lost outright, not recoverable
+  from the rows. Hence the tail log: every update is appended durably, and a
+  checkpoint folds the tail into the snapshot and prunes only what it folded.
+
+      write -> tail (durable immediately)
+        -> checkpoint folds + prunes -> snapshot
+        -> new room binds from snapshot + replays whatever tail remains
+
+  The two failure modes that matter are pruning too much (a claim vanishes) and
+  pruning too little (the tail grows forever); both are pinned below.
   """
   use Engram.DataCase, async: false
   use Oban.Testing, repo: Engram.Repo
@@ -222,6 +231,99 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
       :ok = stop_room_and_wait(revived2)
     end
 
+    # The test above only pins the UNDER-count direction: it never checkpoints,
+    # so `snapshot_applied` is always false, and it issues no update after a
+    # bind. An implementation that credited too MANY echoes passed it — and an
+    # over-credit is not a cosmetic error, it is a permanent credit that the
+    # next real client claim spends instead of being written.
+    #
+    # yrs fires the update observer from the transaction commit hook only when
+    # the transaction CHANGED the doc, so any apply that changes nothing emits
+    # nothing. Two ordinary situations produce one:
+    #
+    #   1. an empty snapshot — a room that bound and exited without a write
+    #   2. a tail row a roomless write already folded into the snapshot
+    #
+    # Both are exercised below. The shape is the same in each: get the room into
+    # the suspect state, then write ONE claim and demand exactly one tail row.
+    test "a bind over an EMPTY snapshot still appends the next claim", ctx do
+      # A room that binds and exits with no writes checkpoints an empty doc.
+      ctx |> start_index_room() |> stop_room_and_wait()
+
+      {:ok, snapshot_row} =
+        Repo.with_tenant(ctx.user.id, fn ->
+          Repo.get_by(VaultIndexState, vault_id: ctx.vault.id)
+        end)
+
+      assert %VaultIndexState{} = snapshot_row, "expected an empty snapshot to have been written"
+      assert tail_count(ctx.user, ctx.vault.id) == 0
+
+      # Binding applies that empty snapshot: :ok, but no echo.
+      room = start_index_room(ctx)
+      put_entry(room, "after-empty.md", "66666666-6666-4666-8666-666666666666")
+
+      :ok = await_tail(ctx.user, ctx.vault.id, 1)
+
+      assert tail_count(ctx.user, ctx.vault.id) == 1,
+             "the empty snapshot was counted as an echo and swallowed a real claim"
+
+      :ok = stop_room_and_wait(room)
+    end
+
+    test "a bind over a NON-EMPTY snapshot appends the next claim exactly once", ctx do
+      room = start_index_room(ctx)
+      put_entry(room, "snapshotted.md", "77777777-7777-4777-8777-777777777777")
+      :ok = await_tail(ctx.user, ctx.vault.id, 1)
+      # Graceful: folds into the snapshot and prunes the tail to 0.
+      :ok = stop_room_and_wait(room)
+      assert tail_count(ctx.user, ctx.vault.id) == 0
+
+      revived = start_index_room(ctx)
+      put_entry(revived, "next.md", "88888888-8888-4888-8888-888888888888")
+      :ok = await_tail(ctx.user, ctx.vault.id, 1)
+
+      assert tail_count(ctx.user, ctx.vault.id) == 1,
+             "the claim after a bind was swallowed by a mis-credited echo"
+
+      :ok = stop_room_and_wait(revived)
+    end
+
+    # Sequence B's root cause. `Identity`'s roomless path folds the tail into
+    # the snapshot it writes; if it does not also PRUNE, those rows survive and
+    # the next bind replays them as no-ops — each one a mis-credited echo, so N
+    # leftover rows silently eat the next N claims.
+    test "a roomless write prunes the tail rows it folded in", ctx do
+      room = start_index_room(ctx)
+      put_entry(room, "orphaned.md", "99999999-9999-4999-8999-999999999999")
+      :ok = await_tail(ctx.user, ctx.vault.id, 1)
+      # Ungraceful: the row survives with no snapshot behind it.
+      :ok = kill_room_and_wait(room)
+      assert tail_count(ctx.user, ctx.vault.id) == 1
+
+      # No room is live, so this takes Identity's snapshot route.
+      assert :ok =
+               Engram.Notes.Identity.claim(
+                 ctx.user,
+                 ctx.vault.id,
+                 [{"roomless.md", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}]
+               )
+
+      assert tail_count(ctx.user, ctx.vault.id) == 0,
+             "the roomless write folded the tail into its snapshot but left the rows behind"
+
+      # And the folded claim is still there, i.e. it pruned what it folded, not
+      # more than it folded.
+      revived = start_index_room(ctx)
+
+      assert read_entry(revived, "orphaned.md")["note_id"] ==
+               "99999999-9999-4999-8999-999999999999"
+
+      assert read_entry(revived, "roomless.md")["note_id"] ==
+               "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+      :ok = stop_room_and_wait(revived)
+    end
+
     test "a checkpoint prunes the tail it folded in", ctx do
       room = start_index_room(ctx)
       before = tail_count(ctx.user, ctx.vault.id)
@@ -247,13 +349,23 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
       :ok = await_tail(ctx.user, ctx.vault.id, before + 1)
       :ok = kill_room_and_wait(room)
 
-      # Corrupt the ciphertext so replay must skip it. AAD binds to the row id,
-      # so flipping bytes makes decrypt fail exactly as a real transient would.
+      # Corrupt the ciphertext so replay must skip it, by flipping a bit in the
+      # AEAD TAG. Replacing it with a short blob instead would trip
+      # Envelope.decrypt/4's `byte_size - 16 < 0` length short-circuit and never
+      # reach AES-GCM — still an error, but not the one a real transient or a
+      # torn write produces.
+      {:ok, [row]} =
+        Repo.with_tenant(ctx.user.id, fn ->
+          Repo.all(from(l in VaultIndexUpdateLog, where: l.vault_id == ^ctx.vault.id))
+        end)
+
+      <<head::binary-size(byte_size(row.update_ciphertext) - 1), last>> = row.update_ciphertext
+
       {:ok, {1, _}} =
         Repo.with_tenant(ctx.user.id, fn ->
           Repo.update_all(
-            from(l in VaultIndexUpdateLog, where: l.vault_id == ^ctx.vault.id),
-            set: [update_ciphertext: <<0, 1, 2, 3, 4, 5, 6, 7>>]
+            from(l in VaultIndexUpdateLog, where: l.id == ^row.id),
+            set: [update_ciphertext: <<head::binary, Bitwise.bxor(last, 0xFF)>>]
           )
         end)
 

--- a/test/engram/notes/crdt_index_persistence_test.exs
+++ b/test/engram/notes/crdt_index_persistence_test.exs
@@ -25,7 +25,7 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
   import Ecto.Query, only: [from: 2]
 
   alias Engram.{Crypto, Repo, Vaults}
-  alias Engram.Notes.{CrdtIndexDoc, CrdtIndexRegistry, VaultIndexState}
+  alias Engram.Notes.{CrdtIndexDoc, CrdtIndexRegistry, VaultIndexState, VaultIndexUpdateLog}
   alias Yex.Sync.SharedDoc
 
   setup do
@@ -89,6 +89,181 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
     :ok = SharedDoc.unobserve(room)
     assert_receive {:DOWN, ^ref, :process, ^room, _}, 5_000
     :ok
+  end
+
+  # Wait until `n` tail rows are durable for this vault.
+  #
+  # `SharedDoc.update_doc/2` returns once the mutation has been applied to the
+  # doc, but the resulting update is delivered to the room as a MESSAGE and
+  # persisted in `handle_update_v1`. So there is a real window in which the doc
+  # has changed and nothing is on disk yet, and killing inside it loses the
+  # update no matter what the tail log does. That is inherent — note rooms have
+  # the same property — so the tests synchronise on durability rather than
+  # pretending the write is atomic with the mutation.
+  defp tail_count(user, vault_id) do
+    {:ok, count} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.aggregate(from(l in VaultIndexUpdateLog, where: l.vault_id == ^vault_id), :count)
+      end)
+
+    count
+  end
+
+  defp await_tail(user, vault_id, n) do
+    Enum.reduce_while(1..100, :timeout, fn _, _ ->
+      count = tail_count(user, vault_id)
+
+      if count >= n do
+        {:halt, :ok}
+      else
+        Process.sleep(20)
+        {:cont, :timeout}
+      end
+    end)
+    |> case do
+      :ok -> :ok
+      :timeout -> flunk("tail never reached #{n} row(s) for vault #{vault_id}")
+    end
+  end
+
+  # Kill the room outright: no terminate/2, so no unbind/3 and no checkpoint.
+  # This is a deploy replacing an ECS task, a node loss, or an OOM kill.
+  defp kill_room_and_wait(room) do
+    ref = Process.monitor(room)
+    Process.exit(room, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^room, :killed}, 5_000
+    :ok
+  end
+
+  describe "durability across an UNGRACEFUL death" do
+    # #1391. Snapshot-only was a sound trade while the `notes` rows were
+    # authoritative for paths: losing a checkpoint interval left the index
+    # STALE, and the rows still held the truth.
+    #
+    # #1151 step 2 changed the premise. The map is now authoritative and
+    # `ProjectVaultIndex` derives the path columns FROM it, so an interval lost
+    # to a SIGKILL drops committed path claims — and the rows then converge
+    # BACK to the superseded snapshot on the next projection run. There is no
+    # rebuild path in `lib/`.
+    test "a claim survives a room that dies without checkpointing", ctx do
+      room = start_index_room(ctx)
+      before = tail_count(ctx.user, ctx.vault.id)
+      put_entry(room, "survives.md", "11111111-1111-4111-8111-111111111111")
+      :ok = await_tail(ctx.user, ctx.vault.id, before + 1)
+
+      :ok = kill_room_and_wait(room)
+
+      revived = start_index_room(ctx)
+
+      assert read_entry(revived, "survives.md")["note_id"] ==
+               "11111111-1111-4111-8111-111111111111",
+             "a committed claim was lost because the room died before checkpointing"
+
+      # Stop it before the test ends. unbind/3 now WRITES (checkpoint + tail
+      # prune), so a room still alive at teardown runs those against a sandbox
+      # connection whose owner has gone.
+      :ok = stop_room_and_wait(revived)
+    end
+
+    # The tail must carry updates made AFTER the last checkpoint, not replace
+    # what the checkpoint already folded in.
+    test "a checkpointed entry and a post-checkpoint entry both survive", ctx do
+      room = start_index_room(ctx)
+      put_entry(room, "folded.md", "22222222-2222-4222-8222-222222222222")
+      :ok = stop_room_and_wait(room)
+
+      room2 = start_index_room(ctx)
+      # Baseline AFTER the checkpoint above, because that checkpoint prunes the
+      # tail it folded in. Awaiting an absolute count of 1 raced the prune: it
+      # could observe the row the checkpoint was still deleting, return early,
+      # and kill the room before "tailed.md" was ever appended.
+      before = tail_count(ctx.user, ctx.vault.id)
+      put_entry(room2, "tailed.md", "33333333-3333-4333-8333-333333333333")
+      :ok = await_tail(ctx.user, ctx.vault.id, before + 1)
+      :ok = kill_room_and_wait(room2)
+
+      revived = start_index_room(ctx)
+
+      assert read_entry(revived, "folded.md")["note_id"] ==
+               "22222222-2222-4222-8222-222222222222"
+
+      assert read_entry(revived, "tailed.md")["note_id"] ==
+               "33333333-3333-4333-8333-333333333333"
+
+      :ok = stop_room_and_wait(revived)
+    end
+  end
+
+  describe "the tail prune contract" do
+    # y_ex installs the doc update monitor BEFORE bind/3 runs, so every
+    # apply_update inside bind echoes back through update_v1/4. Unsuppressed,
+    # binding re-appends the snapshot AND the whole tail it just read: n rows
+    # become 2n+1 every restart, each cycle also writing a row the size of the
+    # entire index. On a vault whose room keeps dying — the exact case the tail
+    # exists for — that is a spiral.
+    test "binding does not append the snapshot or the tail back onto the tail", ctx do
+      room = start_index_room(ctx)
+      before = tail_count(ctx.user, ctx.vault.id)
+      put_entry(room, "one.md", "44444444-4444-4444-8444-444444444444")
+      :ok = await_tail(ctx.user, ctx.vault.id, before + 1)
+      :ok = kill_room_and_wait(room)
+
+      after_first = tail_count(ctx.user, ctx.vault.id)
+
+      # Bind twice more. Each bind replays the tail and, if the echo is not
+      # suppressed, re-appends everything it replayed.
+      revived = start_index_room(ctx)
+      :ok = kill_room_and_wait(revived)
+      revived2 = start_index_room(ctx)
+
+      assert tail_count(ctx.user, ctx.vault.id) == after_first,
+             "bind re-appended its own replay to the tail"
+
+      :ok = stop_room_and_wait(revived2)
+    end
+
+    test "a checkpoint prunes the tail it folded in", ctx do
+      room = start_index_room(ctx)
+      before = tail_count(ctx.user, ctx.vault.id)
+      put_entry(room, "folded.md", "55555555-5555-4555-8555-555555555555")
+      :ok = await_tail(ctx.user, ctx.vault.id, before + 1)
+
+      # Graceful exit -> unbind -> checkpoint -> prune.
+      :ok = stop_room_and_wait(room)
+
+      assert tail_count(ctx.user, ctx.vault.id) == 0,
+             "a checkpoint left behind rows it had already folded into the snapshot"
+    end
+
+    # THE regression for the prune contract. `replay_tail` skips a row it cannot
+    # decrypt so a later successful replay can still recover the claim — but the
+    # prune used to re-query EVERY row for the vault and delete it anyway. One
+    # transient decrypt failure then destroyed the claim permanently, in the
+    # code whose entire purpose is preventing that.
+    test "a row that could not be replayed is NOT pruned by the checkpoint", ctx do
+      room = start_index_room(ctx)
+      before = tail_count(ctx.user, ctx.vault.id)
+      put_entry(room, "fragile.md", "66666666-6666-4666-8666-666666666666")
+      :ok = await_tail(ctx.user, ctx.vault.id, before + 1)
+      :ok = kill_room_and_wait(room)
+
+      # Corrupt the ciphertext so replay must skip it. AAD binds to the row id,
+      # so flipping bytes makes decrypt fail exactly as a real transient would.
+      {:ok, {1, _}} =
+        Repo.with_tenant(ctx.user.id, fn ->
+          Repo.update_all(
+            from(l in VaultIndexUpdateLog, where: l.vault_id == ^ctx.vault.id),
+            set: [update_ciphertext: <<0, 1, 2, 3, 4, 5, 6, 7>>]
+          )
+        end)
+
+      # Bind (skips the row), then check point on the way out.
+      revived = start_index_room(ctx)
+      :ok = stop_room_and_wait(revived)
+
+      assert tail_count(ctx.user, ctx.vault.id) == 1,
+             "the checkpoint deleted a row it never folded in — that claim is now unrecoverable"
+    end
   end
 
   describe "snapshot round trip" do

--- a/test/engram/notes/crdt_index_persistence_test.exs
+++ b/test/engram/notes/crdt_index_persistence_test.exs
@@ -502,26 +502,23 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
   # The documented lossy case, asserted rather than merely described. If someone
   # later adds a tail log, this test is what tells them the trade-off changed.
   describe "ungraceful death" do
-    test "a killed room loses writes since the last checkpoint", ctx do
-      room = start_index_room(ctx)
-      put_entry(room, "saved.md", "note-saved")
-      stop_room_and_wait(room)
-
-      respun = start_index_room(ctx)
-      put_entry(respun, "unsaved.md", "note-unsaved")
-
-      ref = Process.monitor(respun)
-      Process.exit(respun, :kill)
-      assert_receive {:DOWN, ^ref, :process, ^respun, :killed}, 5_000
-
-      final = start_index_room(ctx)
-
-      assert read_entry(final, "saved.md")["note_id"] == "note-saved",
-             "the last checkpoint must survive"
-
-      refute read_entry(final, "unsaved.md"),
-             "snapshot-only: a SIGKILL loses writes since the last exit (add a tail log to change this)"
-    end
+    # DELETED: "a killed room loses writes since the last checkpoint" (#1391).
+    #
+    # It asserted `refute read_entry(final, "unsaved.md")` — that a SIGKILL
+    # destroys everything since the last checkpoint. That was the correct
+    # contract when the room was snapshot-only, and the tail log inverts it:
+    # "a claim survives a room that dies without checkpointing", above, now
+    # asserts the opposite of it on purpose.
+    #
+    # It was also passing for the wrong reason. `handle_update_v1` is
+    # asynchronous, so the test only stayed green by KILLING the room before
+    # the tail append it was meant to disprove had run — a race it happened to
+    # win. Keeping it would have meant an intermittently red suite asserting
+    # behaviour the design deliberately removed.
+    #
+    # The residual window it half-described is real (a write killed before it
+    # reaches the tail IS lost) and is documented on `await_tail/3`. It is not
+    # re-tested here: pinning it requires winning that same race.
   end
 
   # A deploy terminates rooms via the supervisor, not by dropping observers.

--- a/test/engram/notes/crdt_index_room_test.exs
+++ b/test/engram/notes/crdt_index_room_test.exs
@@ -161,10 +161,12 @@ defmodule Engram.Notes.CrdtIndexRoomTest do
     end
   end
 
-  # A note room gets 15 s because a blown deadline costs it NOTHING — its tail
-  # log replays. This room has no tail log, so a blown deadline loses every
-  # index write since the last exit. It shipped on the OTP default of 5 s: the
-  # risk ordering exactly inverted. One assertion, because the default is
+  # Both rooms now have a tail log (#1391), so a blown deadline no longer loses
+  # writes on either — it costs the FOLD. The checkpoint never runs, nothing is
+  # pruned, and the tail grows across restarts. This room still gets the longer
+  # budget because its flush is a single ~2 MB encode + encrypt for the whole
+  # vault, against a note's one document. It shipped on the OTP default of 5 s,
+  # which brutal-kills that flush. One assertion, because the default is
   # invisible (there is no `shutdown:` key to read).
   test "the shutdown budget exceeds a note room's, because a blown deadline costs more here" do
     spec = CrdtIndexDoc.child_spec(vault_id: Ecto.UUID.generate(), user_id: Ecto.UUID.generate())
@@ -177,7 +179,7 @@ defmodule Engram.Notes.CrdtIndexRoomTest do
       )
 
     assert spec.shutdown >= note_spec.shutdown,
-           "the room WITHOUT a tail log must not get less flush time than the one with"
+           "the room with the whole-vault flush must not get less time than a single note's"
 
     assert spec.shutdown > 5_000, "the OTP default brutal-kills a ~2 MB encrypt + write"
   end

--- a/test/engram/notes/identity_test.exs
+++ b/test/engram/notes/identity_test.exs
@@ -394,6 +394,43 @@ defmodule Engram.Notes.IdentityTest do
       assert path_of(ctx, n.id) == "rot.md"
       assert index_entries(ctx)["rot.md"]["note_id"] == n.id
     end
+
+    # The test above has NO live room, so it only ever exercised the snapshot
+    # route. The room route was deliberately ungated on the reasoning that it
+    # "only mutates memory, and the room's own checkpoint is already gated" —
+    # which the tail log falsified. With a room live, the claim mutated the
+    # doc, `append_tail` skipped on the gate, the gated checkpoint wrote no
+    # snapshot, and the claim died with the process. Silently: the caller got
+    # :ok and committed the rename against a claim that no longer existed.
+    test "a rename during a rotation is refused on the LIVE-ROOM route too", ctx do
+      n = note(ctx, "rot-room.md")
+      seed_index(ctx, [{"rot-room.md", entry_for(n.id)}])
+
+      {:ok, room} = CrdtIndexRegistry.ensure_observed(ctx.user.id, ctx.vault.id)
+
+      {1, _} =
+        Repo.update_all(
+          from(u in Engram.Accounts.User, where: u.id == ^ctx.user.id),
+          set: [dek_rotation_locked_at: DateTime.utc_now()]
+        )
+
+      user = Repo.get!(Engram.Accounts.User, ctx.user.id)
+
+      assert {:error, :rotation_in_progress} =
+               Notes.rename_note(user, ctx.vault, "rot-room.md", "moved-room.md")
+
+      assert path_of(ctx, n.id) == "rot-room.md"
+
+      # The live doc must be untouched. Asserting only on the persisted state
+      # would pass even if the room HAD been mutated, because nothing during a
+      # rotation is allowed to write it down — which is the entire failure.
+      assert read_live(room, "rot-room.md")["note_id"] == n.id
+      refute read_live(room, "moved-room.md")
+
+      ref = Process.monitor(room)
+      :ok = SharedDoc.unobserve(room)
+      assert_receive {:DOWN, ^ref, :process, ^room, _}, 5_000
+    end
   end
 
   describe "projection never claims" do

--- a/test/engram_web/channels/crdt_index_end_to_end_test.exs
+++ b/test/engram_web/channels/crdt_index_end_to_end_test.exs
@@ -1,0 +1,198 @@
+defmodule EngramWeb.CrdtIndexEndToEndTest do
+  @moduledoc """
+  The whole identity loop, driven by a CLIENT over the real channel.
+
+  Every other test of this subsystem calls the server's own functions:
+  `Identity.claim/3`, `CrdtIndexPersistence.bind/3`, `ProjectVaultIndex.perform/1`.
+  That leaves the thing the design actually promises unexercised — a client
+  writes `filemeta_v0`, and the `notes` rows follow.
+
+  It matters more here than it usually would. Nothing in `lib/` writes the index
+  in production yet (Engram-obsidian#362 is the client adoption), so the whole
+  feature has shipped through green CI — e2e suites included — twice while
+  carrying critical defects, simply because no test path reached it. Reviews
+  caught those; reviews are not a substitute for execution.
+
+  Nothing here is a mock: a real `UserSocket`, the real `CrdtChannel`, real
+  `sync_update` frames encoded by y_ex, the real room, real Postgres, real
+  encryption, and the real projection worker.
+
+      client frame -> channel -> room -> tail log -> checkpoint -> snapshot
+        -> ProjectVaultIndex -> notes.path_* actually moves
+  """
+  use EngramWeb.ChannelCase, async: false
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Engram.{Crypto, Notes, Repo, Vaults}
+  alias Engram.Notes.{CrdtBridge, CrdtIndexDoc, CrdtIndexRegistry, VaultIndexUpdateLog}
+  alias Engram.Workers.ProjectVaultIndex
+  alias Yex.Sync.SharedDoc
+
+  setup do
+    EngramWeb.RateLimiter.reset_buckets!()
+    on_exit(fn -> EngramWeb.RateLimiter.reset_buckets!() end)
+
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "IndexE2E"})
+
+    {:ok, _, socket} =
+      subscribe_and_join(
+        user_socket(user),
+        EngramWeb.CrdtChannel,
+        "crdt:#{user.id}:#{vault.id}",
+        %{"crdt_proto" => 2}
+      )
+
+    Sandbox.allow(Repo, self(), socket.channel_pid)
+
+    %{socket: socket, user: user, vault: vault}
+  end
+
+  # Exactly what a client sends: a Yjs sync_update carrying one filemeta_v0 entry.
+  defp client_claim(path, note_id) do
+    doc = CrdtBridge.new_doc()
+
+    doc
+    |> Yex.Doc.get_map(CrdtIndexDoc.map_name())
+    |> Yex.Map.set(path, %{"note_id" => note_id})
+
+    {:ok, update} = Yex.encode_state_as_update(doc)
+    {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_update, update}})
+    Base.encode64(frame)
+  end
+
+  defp note(ctx, path) do
+    {:ok, note} = Notes.upsert_note(ctx.user, ctx.vault, %{"path" => path, "content" => "x"})
+    note
+  end
+
+  defp path_of(ctx, note_id) do
+    case Notes.get_note_by_id(ctx.user, ctx.vault, note_id) do
+      {:ok, %{path: path}} -> path
+      _ -> nil
+    end
+  end
+
+  defp tail_count(ctx) do
+    {:ok, n} =
+      Repo.with_tenant(ctx.user.id, fn ->
+        Repo.aggregate(from(l in VaultIndexUpdateLog, where: l.vault_id == ^ctx.vault.id), :count)
+      end)
+
+    n
+  end
+
+  # The room is started by the channel, so the test process is not an observer.
+  # Wait for the write to be DURABLE rather than for a message we cannot see —
+  # `handle_update_v1` is asynchronous, so a frame being accepted says nothing
+  # about the tail yet.
+  defp await_tail(ctx, n) do
+    Enum.reduce_while(1..150, :timeout, fn _, _ ->
+      if tail_count(ctx) >= n do
+        {:halt, :ok}
+      else
+        Process.sleep(20)
+        {:cont, :timeout}
+      end
+    end)
+    |> case do
+      :ok -> :ok
+      :timeout -> flunk("client claim never reached the tail log")
+    end
+  end
+
+  defp stop_room_and_wait(ctx) do
+    case :global.whereis_name({:crdt_index, ctx.vault.id}) do
+      pid when is_pid(pid) ->
+        ref = Process.monitor(pid)
+        # The channel is the room's observer, so closing it is what drops the
+        # last observer and triggers auto_exit -> terminate -> unbind.
+        #
+        # Unlink first: subscribe_and_join LINKS the channel to the test
+        # process, so its shutdown propagates and kills the test itself.
+        Process.unlink(ctx.socket.channel_pid)
+        :ok = close(ctx.socket)
+        assert_receive {:DOWN, ^ref, :process, ^pid, _}, 5_000
+        :ok
+
+      :undefined ->
+        :ok
+    end
+  end
+
+  defp run_projection(ctx) do
+    ProjectVaultIndex.perform(%Oban.Job{
+      args: %{"user_id" => ctx.user.id, "vault_id" => ctx.vault.id}
+    })
+  end
+
+  describe "a client claim moves the row" do
+    test "client writes filemeta_v0 over the channel and the note actually moves", ctx do
+      n = note(ctx, "Old/e2e.md")
+
+      push(ctx.socket, "crdt_index_msg", %{"b64" => client_claim("New/e2e.md", n.id)})
+      :ok = await_tail(ctx, 1)
+
+      # Graceful room exit -> checkpoint -> snapshot, and the projection enqueue.
+      :ok = stop_room_and_wait(ctx)
+
+      assert :ok = run_projection(ctx)
+
+      assert path_of(ctx, n.id) == "New/e2e.md",
+             "a claim written by a real client over the real channel did not move the row"
+    end
+
+    # The claim is durable in the TAIL before any checkpoint. This is the path
+    # that had no coverage at all before #1391: kill the room without a graceful
+    # exit and the claim must still land.
+    test "a claim survives a room killed before it ever checkpoints", ctx do
+      n = note(ctx, "Old/killed.md")
+
+      push(ctx.socket, "crdt_index_msg", %{"b64" => client_claim("New/killed.md", n.id)})
+      :ok = await_tail(ctx, 1)
+
+      # Kill the ROOM outright: no terminate/2, so no unbind and no snapshot.
+      pid = :global.whereis_name({:crdt_index, ctx.vault.id})
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 5_000
+
+      # A fresh room binds from snapshot + tail. Projection reads the persisted
+      # snapshot, so the claim has to survive all the way through a checkpoint.
+      {:ok, revived} = CrdtIndexRegistry.ensure_observed(ctx.user.id, ctx.vault.id)
+      ref2 = Process.monitor(revived)
+      :ok = SharedDoc.unobserve(revived)
+      assert_receive {:DOWN, ^ref2, :process, ^revived, _}, 5_000
+
+      assert :ok = run_projection(ctx)
+
+      assert path_of(ctx, n.id) == "New/killed.md",
+             "a claim that only ever existed in the tail was lost across a room kill"
+    end
+
+    # Two claims, one checkpoint. Pins that the tail replays in order and that
+    # the checkpoint folds ALL of it in, not just the last one.
+    test "several client claims all survive one checkpoint", ctx do
+      a = note(ctx, "Old/a.md")
+      b = note(ctx, "Old/b.md")
+
+      push(ctx.socket, "crdt_index_msg", %{"b64" => client_claim("New/a.md", a.id)})
+      push(ctx.socket, "crdt_index_msg", %{"b64" => client_claim("New/b.md", b.id)})
+      :ok = await_tail(ctx, 2)
+
+      :ok = stop_room_and_wait(ctx)
+
+      assert :ok = run_projection(ctx)
+
+      assert path_of(ctx, a.id) == "New/a.md"
+      assert path_of(ctx, b.id) == "New/b.md"
+
+      assert tail_count(ctx) == 0,
+             "the checkpoint folded the claims in but left the tail behind"
+    end
+  end
+end


### PR DESCRIPTION
Closes #1391. Blocks Engram-obsidian#362.

## Why this is a prerequisite, not a follow-up

`vault_index_states` holds a snapshot written when a room **exits**. That was a sound trade while the `notes` rows were authoritative for paths: losing a checkpoint interval left the index STALE and the rows still held the truth.

**#1151 step 2 changed the premise.** The `filemeta_v0` map is authoritative now and `ProjectVaultIndex` derives `notes.path_*` from it, so a SIGKILL, a node loss or an ECS task replacement drops committed path **claims** — and the rows then converge back to the superseded snapshot on the next projection run. There is no rebuild path in `lib/`.

Once a *client* writes the map (#362), those claims exist nowhere else and a lost interval is unrecoverable. Hence: this before that.

## What landed

`vault_index_update_log`, mirroring `crdt_update_log` for note rooms — `phase/expand`, RLS + FORCE RLS + tenant policy + grant, `timestamptz`. AAD binds per **row**, since rows are independently appended and pruned.

`update_v1/4` appends, `bind/3` replays after the snapshot, the checkpoint prunes.

## The four defects an adversarial review caught, all fixed

**`bind/3` was re-appending its own replay.** y_ex installs the doc update monitor *before* `bind` runs, so every `apply_update` inside it comes back through `update_v1/4`. Unsuppressed, binding re-appends the snapshot **and** the whole tail it just read: `n` rows become `2n+1` per restart, each cycle also writing a row the size of the entire index. On a vault whose room keeps dying — the exact case this feature exists for — that is a spiral, not a leak. Counting the echoes is exact rather than heuristic: they are already in the mailbox when `init` returns, and a mailbox is FIFO.

**The prune deleted rows it never folded in.** `replay_tail` skips a row it cannot decrypt so a later replay can still recover the claim — but the prune re-queried *every* row and deleted it anyway. One transient decrypt failure destroyed a claim permanently, in the code whose whole purpose is preventing that. It now prunes only what bind applied, and skipped rows are **logged with their vault** rather than ticking an untraceable counter.

**`load_doc/2` was not taught to replay.** That is the roomless reader `Identity` uses when no room is live — precisely the post-crash state. Blind to tail-only claims, it would accept a claim on a path already held (returning success where a conflict is owed), and a release could not remove an entry living only in the tail, which the next bind replays back: one permanent path reservation per note. `snapshot + tail` now genuinely equals `bind/3`'s recipe.

**`append_tail` had no rotation gate.** It encrypts, so a row written after the sweep drains but before `final_flip` retires the old key is permanently unreadable. `Identity`'s "the room path needs no gate, it only mutates memory" stopped being true the moment this callback existed.

Also: `update_v1` did not actually swallow failures (`Repo.insert!` raises, and so does a checkout under pool starvation — unrescued they kill the room for every client on the vault); `dek_version` was hardcoded rather than recording the version that wrapped the row; and the rotation sweep now decrypts old-then-new like `rewrap_crdt_tail`, so a rotation retried after a crash does not raise on rows it already re-wrapped.

## Known bound, documented not hidden

The tail is pruned **only** by a graceful exit. This room has no `CrdtCheckpointTimer` and no `idle_exit_ms`, so a pinned-open room, a crash loop, or a room exiting mid-rotation leaves it to grow. Tolerable because index writes are rename/create/delete rather than keystrokes, and replay is idempotent. Generalising `CrdtCheckpointTimer` off `note_id` (#1151 step 3) is what bounds it.

## A property worth knowing

Durability is reached when the **room processes its own update message**, not when `update_doc/2` returns — `handle_update_v1` is asynchronous. A kill inside that window still loses the update, exactly as for note rooms. The tests synchronise on durability rather than pretending the write is atomic with the mutation.

## Verification

Gauntlet run sequentially: `mix format --check-formatted`, `mix credo --strict` (no issues), **4503 tests / 0 failures**, `mix dialyzer` (passed).

Five guarantees are mutation-proven — removing the append, the replay, the echo suppression, the unfolded-row exclusion, or the prune each turns the suite red. The prune contract previously had **zero** tests, which is why the second defect above was live; it now has three.

Refs #1151