### PR TITLE
feat(crdt): drain the per-vault index room on idle (closes #1152)

### DIFF
--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -117,7 +117,12 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     room_pid = Keyword.fetch!(opts, :room_pid)
     user_id = Keyword.fetch!(opts, :user_id)
     vault_id = Keyword.fetch!(opts, :vault_id)
-    note_id = Keyword.fetch!(opts, :note_id)
+
+    # `:note` (default) keys off note_id and checkpoints on every tick.
+    # `:index` keys off vault_id and NEVER ticks a checkpoint — see
+    # `do_checkpoint/1`. Defaulting keeps every existing note call site literal.
+    mode = Keyword.get(opts, :mode, :note)
+    room_key = if mode == :index, do: vault_id, else: Keyword.fetch!(opts, :note_id)
 
     cfg = Application.get_env(:engram, __MODULE__, [])
     settle_ms = Keyword.get(cfg, :settle_ms, @default_settle_ms)
@@ -136,7 +141,8 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
       room_pid: room_pid,
       user_id: user_id,
       vault_id: vault_id,
-      note_id: note_id,
+      mode: mode,
+      room_key: room_key,
       settle_ms: settle_ms,
       ceiling_ms: ceiling_ms,
       eager_ms: eager_ms,
@@ -169,9 +175,11 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     now = monotonic_ms()
     {delay, first_dirty_at} = compute_delay(state, now)
 
-    # Cancel any existing settle timer and re-arm it.
+    # Cancel any existing settle timer and re-arm it. Not armed at all in
+    # :index mode — `do_checkpoint/1` is a no-op there, so a settle tick would
+    # be a timer scheduled to do nothing.
     _ = if state.settle_timer, do: Process.cancel_timer(state.settle_timer)
-    timer = Process.send_after(self(), :tick, delay)
+    timer = if state.mode == :index, do: nil, else: Process.send_after(self(), :tick, delay)
 
     {:noreply,
      touch_lru(
@@ -219,7 +227,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
               # denominator an operator reads this metric through.
               Logger.warning(
                 "crdt drain broadcast failed: #{inspect(reason)}",
-                Engram.Logger.Metadata.with_category(:warning, :sync, note_id: state.note_id)
+                Engram.Logger.Metadata.with_category(:warning, :sync, room_key: state.room_key)
               )
 
               :request_failed
@@ -252,7 +260,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   # for both normal and abnormal room exits without leaving an orphaned timer.
   @impl true
   def handle_info({:EXIT, _room_pid, _reason}, state) do
-    if state.idle_exit_ms, do: CrdtRoomLru.forget(state.note_id)
+    if state.idle_exit_ms, do: CrdtRoomLru.forget(state.room_key)
     {:stop, :normal, state}
   end
 
@@ -266,7 +274,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   # room in the LRU and left it evictable: half-disabled, in the one direction
   # nothing would notice, since eviction bypasses `idle?/2` on purpose.
   defp touch_lru(%{idle_exit_ms: ms} = state) when is_integer(ms) and ms > 0 do
-    CrdtRoomLru.touch(state.note_id, state.room_pid, state.vault_id)
+    CrdtRoomLru.touch(state.room_key, state.room_pid, state.vault_id)
     state
   end
 
@@ -378,6 +386,14 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
 
   defp arm_idle(state), do: state
 
+  # An index room's checkpoint MUST come from `CrdtIndexPersistence.unbind/3`,
+  # never from a tick here. Only the room's own persistence state knows which
+  # tail rows failed to replay (`:unfolded_ids`), and a checkpoint that prunes
+  # without that list deletes exactly the claims the tail log exists to protect
+  # (#1391). So the drain is the whole mechanism for this room: observers let
+  # go, `auto_exit` fires, and `terminate/2` checkpoints with the right state.
+  defp do_checkpoint(%{mode: :index}), do: :ok
+
   defp do_checkpoint(%{room_pid: room_pid} = state) do
     # Capture the row version BEFORE snapshotting the doc so it never exceeds the
     # version the snapshot reflects (#902 fence). A REST/MCP write committing
@@ -387,10 +403,10 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     # nil on read failure is NOT an unfenced write (it was, before #1360). The
     # version CAS is layered ON TOP of `snapshot_fence/2`, which applies to every
     # checkpoint write path unconditionally. nil just drops the extra layer.
-    captured_version = CrdtCheckpoint.current_version(state.user_id, state.note_id)
+    captured_version = CrdtCheckpoint.current_version(state.user_id, state.room_key)
     doc = Yex.Sync.SharedDoc.get_doc(room_pid)
 
-    CrdtCheckpoint.checkpoint(state.user_id, state.vault_id, state.note_id, doc,
+    CrdtCheckpoint.checkpoint(state.user_id, state.vault_id, state.room_key, doc,
       captured_version: captured_version
     )
   rescue
@@ -410,8 +426,8 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
 
   defp log_read_failure(state, reason) do
     Logger.warning(
-      "crdt checkpoint timer could not fetch doc note_id=#{state.note_id} reason=#{inspect(reason)}",
-      Engram.Logger.Metadata.with_category(:warning, :sync, note_id: state.note_id)
+      "crdt checkpoint timer could not fetch doc room_key=#{state.room_key} reason=#{inspect(reason)}",
+      Engram.Logger.Metadata.with_category(:warning, :sync, room_key: state.room_key)
     )
   end
 

--- a/lib/engram/notes/crdt_index_doc.ex
+++ b/lib/engram/notes/crdt_index_doc.ex
@@ -31,23 +31,56 @@ defmodule Engram.Notes.CrdtIndexDoc do
   projection is a no-op — which is a statement about the client we ship, not
   about what the server accepts.
 
-  ## Why there is still no idle drain here
+  ## The idle drain (#1152)
 
-  Note rooms opt into the #1152 drain safely because `terminate/2` runs
-  `CrdtPersistence.unbind/3`, which checkpoints before the room goes away. As of
-  #1151 this room has that too — so the drain is now *safe* here, but it is not
-  *wired*, and those are different things.
+  Draining a room is lossless only if something checkpoints it on the way out.
+  #1151 gave this room that (`CrdtIndexPersistence.unbind/3`), and #1391 gave it
+  a tail log so an ungraceful death is survivable too. Both were prerequisites;
+  neither wired anything up.
 
-  **Still no `idle_exit_ms` and no `CrdtCheckpointTimer`.** The timer is
-  note-keyed: `note_id` threads through its state and its `CrdtRoomLru.touch/3`
-  call, so serving this room means generalising it rather than passing an
-  option. Until then residency here is bounded only by `auto_exit` on the last
-  observer, which is session-length — the open item named in
-  `docs/context/crdt-index-room.md`.
+  It is wired now. `start_link/1` starts a `CrdtCheckpointTimer` in `mode:
+  :index`, which is the timer generalised off `note_id` — it keys on `vault_id`
+  and, crucially, **never checkpoints on a tick**. Only the room's own
+  persistence state knows which tail rows failed to replay, so a checkpoint that
+  did not come from `unbind/3` would prune rows it never folded in. The drain is
+  the mechanism instead: observers let go, `auto_exit` fires on the last one,
+  and `terminate/2` checkpoints with the state that has the answer.
 
+  This matters more here than for a note room. `auto_exit` bounds a note room
+  well, because a note is observed only while it is open. This room is observed
+  for as long as ANY socket on the vault is connected, so without the drain its
+  residency is session-length and tracks concurrent connections rather than
+  mutation rate.
+
+  **On by default, and not behind a flag.** Note rooms take the drain as an
+  opt-in because `auto_exit` already bounds them; this room does not have that
+  luxury, so shipping it off would ship the measured 7.91 MB/vault residency and
+  call it done. `@default_idle_exit_ms` is the value, overridable per room for
+  tests. There is no "drain disabled" mode here to fall back to — the way back
+  is a different number, not a switch.
   """
 
+  alias Engram.Notes.CrdtCheckpointTimer
+
   @map_name "filemeta_v0"
+
+  # The drain is ON for this room, unconditionally — not a flag, not opt-in.
+  #
+  # Unlike a note room, which `auto_exit` bounds well because a note is observed
+  # only while it is open, this room is observed for as long as ANY socket on
+  # the vault is connected. Without a drain its residency is session-length,
+  # which #1149 measured at 7.91 MB per 10k-note vault. Shipping that OFF by
+  # default would mean shipping the measured problem and calling it done.
+  #
+  # Draining is lossless and cheap to undo: `terminate/2` checkpoints, the tail
+  # log covers an ungraceful death, and the next index frame re-spins the room
+  # through `ensure_index_room/1`. The cost of a wrong value is a re-bind
+  # (decrypt + replay), not a lost claim.
+  #
+  # 5 minutes of no index WRITES — renames, creates, deletes. A client that is
+  # merely connected and reading generates no activity here, which is the point:
+  # residency should track mutation, not connection count.
+  @default_idle_exit_ms 300_000
 
   @doc """
   The `Y.Map` name holding `path -> %{note_id, type, hash}`.
@@ -67,17 +100,53 @@ defmodule Engram.Notes.CrdtIndexDoc do
     vault_id = Keyword.fetch!(opts, :vault_id)
     user_id = Keyword.fetch!(opts, :user_id)
 
-    Yex.Sync.SharedDoc.start_link(
-      [
-        doc_name: vault_id,
-        # Must match CrdtBridge.new_doc/0 — UTF-16 offsets are wire-compatible
-        # with Yjs JS clients; the y_ex default (:bytes) is NOT.
-        doc_option: %Yex.Doc.Options{offset_kind: :utf16},
-        persistence: {Engram.Notes.CrdtIndexPersistence, %{user_id: user_id, vault_id: vault_id}},
-        auto_exit: true
-      ],
-      name: Engram.Notes.CrdtIndexRegistry.global_name(vault_id)
-    )
+    result =
+      Yex.Sync.SharedDoc.start_link(
+        [
+          doc_name: vault_id,
+          # Must match CrdtBridge.new_doc/0 — UTF-16 offsets are wire-compatible
+          # with Yjs JS clients; the y_ex default (:bytes) is NOT.
+          doc_option: %Yex.Doc.Options{offset_kind: :utf16},
+          persistence:
+            {Engram.Notes.CrdtIndexPersistence, %{user_id: user_id, vault_id: vault_id}},
+          auto_exit: true
+        ],
+        name: Engram.Notes.CrdtIndexRegistry.global_name(vault_id)
+      )
+
+    with {:ok, room_pid} <- result do
+      # #1152's remaining half. `auto_exit` alone bounds a NOTE room, which is
+      # observed only while the note is open — but this room is observed for as
+      # long as any socket on the vault is connected, so its lifetime is
+      # session-length and its residency tracks concurrent connections rather
+      # than mutation rate.
+      #
+      # `mode: :index` because the timer is otherwise note-keyed and would
+      # checkpoint on every tick. This room must NOT: only its own persistence
+      # state knows which tail rows failed to replay, so the checkpoint has to
+      # come from `unbind/3`. The drain is what gets it there — observers let
+      # go, auto_exit fires, terminate checkpoints.
+      {:ok, timer_pid} =
+        CrdtCheckpointTimer.start_link(
+          room_pid: room_pid,
+          user_id: user_id,
+          vault_id: vault_id,
+          mode: :index,
+          # Explicit and never nil. The timer treats nil as "drain disabled",
+          # so falling through to its config fallback would have made this
+          # room's residency depend on a note-room knob being set.
+          idle_exit_ms: Keyword.get(opts, :idle_exit_ms, @default_idle_exit_ms)
+        )
+
+      # Same channel as the note room: update_v1 runs INSIDE this process, so
+      # it reads the timer pid straight out of the process dictionary rather
+      # than doing a registry lookup on every update.
+      Yex.Sync.SharedDoc.update_doc(room_pid, fn _doc ->
+        Process.put(:crdt_timer_pid, timer_pid)
+      end)
+
+      result
+    end
   end
 
   @doc false

--- a/lib/engram/notes/crdt_index_doc.ex
+++ b/lib/engram/notes/crdt_index_doc.ex
@@ -55,9 +55,9 @@ defmodule Engram.Notes.CrdtIndexDoc do
   **On by default, and not behind a flag.** Note rooms take the drain as an
   opt-in because `auto_exit` already bounds them; this room does not have that
   luxury, so shipping it off would ship the measured 7.91 MB/vault residency and
-  call it done. `@default_idle_exit_ms` is the value, overridable per room for
-  tests. There is no "drain disabled" mode here to fall back to — the way back
-  is a different number, not a switch.
+  call it done. The interval resolves per-room opt -> `CRDT_IDLE_EXIT_MS` ->
+  `@default_idle_exit_ms`, and never to `nil`. There is no "drain disabled" mode
+  to fall back to — the way back is a different number, not a switch.
   """
 
   alias Engram.Notes.CrdtCheckpointTimer
@@ -132,10 +132,7 @@ defmodule Engram.Notes.CrdtIndexDoc do
           user_id: user_id,
           vault_id: vault_id,
           mode: :index,
-          # Explicit and never nil. The timer treats nil as "drain disabled",
-          # so falling through to its config fallback would have made this
-          # room's residency depend on a note-room knob being set.
-          idle_exit_ms: Keyword.get(opts, :idle_exit_ms, @default_idle_exit_ms)
+          idle_exit_ms: idle_exit_ms(opts)
         )
 
       # Same channel as the note room: update_v1 runs INSIDE this process, so
@@ -147,6 +144,20 @@ defmodule Engram.Notes.CrdtIndexDoc do
 
       result
     end
+  end
+
+  # Per-room opt, then the fleet-wide knob, then the default — and NEVER nil,
+  # which is how the timer spells "drain disabled".
+  #
+  # The middle rung matters: `CRDT_IDLE_EXIT_MS` (`ci/compose.yml`, 5 s) is what
+  # makes the Obsidian e2e suite exercise draining against the real client.
+  # Hard-coding past it would have left the index room's drain untested there —
+  # no e2e run lasts #{@default_idle_exit_ms} ms — which is precisely the
+  # coverage this room needs most, since nothing in prod writes the map yet.
+  defp idle_exit_ms(opts) do
+    Keyword.get(opts, :idle_exit_ms) ||
+      Application.get_env(:engram, CrdtCheckpointTimer, [])[:idle_exit_ms] ||
+      @default_idle_exit_ms
   end
 
   @doc false

--- a/lib/engram/notes/crdt_index_persistence.ex
+++ b/lib/engram/notes/crdt_index_persistence.ex
@@ -43,28 +43,23 @@ defmodule Engram.Notes.CrdtIndexPersistence do
 
   Note rooms bound their tail three ways — `CrdtCheckpointTimer` debounces a
   flush, `update_v1/4` can checkpoint inline under `CheckpointGate`, and
-  overflow goes to the `crdt_checkpoint` Oban queue. This room has none of them
-  (`CrdtIndexDoc` runs no timer and sets no `idle_exit_ms`), so residency is
-  session-length and the only prune is `unbind/3`.
+  overflow goes to the `crdt_checkpoint` Oban queue. This room has exactly one:
+  `unbind/3`. Nothing folds the tail while the room is alive, deliberately —
+  only the room's persistence state knows which rows failed to replay, so a
+  checkpoint from anywhere else would prune rows it never folded in.
 
-  So the tail grows unbounded for: a room pinned open by a long-lived observer,
-  a crash loop that never reaches `terminate/2`, and every room exit during a
-  DEK rotation (the checkpoint is gated, so it skips the prune too). There is no
-  age sweep, no size cap and no reaper; the `on_delete: :delete_all` FKs only
-  fire when the user or vault is deleted.
+  What bounds it is therefore the room EXITING, and #1152's idle drain is what
+  makes that happen on a timer rather than on the last socket disconnecting
+  (`CrdtIndexDoc` wires it; see there). With the drain off, the tail still grows
+  unbounded for: a room pinned open by a long-lived observer, a crash loop that
+  never reaches `terminate/2`, and every room exit during a DEK rotation (the
+  checkpoint is gated, so it skips the prune too). There is no age sweep, no
+  size cap and no reaper; the `on_delete: :delete_all` FKs only fire when the
+  user or vault is deleted.
 
-  Tolerable today because index writes are rename/create/delete rather than
+  Tolerable because index writes are rename/create/delete rather than
   keystrokes, so the volume is orders of magnitude below a note tail, and
-  because replay is idempotent. It stops being tolerable at the same point
-  everything else here does — generalising `CrdtCheckpointTimer` off `note_id`
-  is #1151 step 3, and that is what bounds this.
-
-  ## This is what unblocks the #1152 drain for the index room
-
-  `CrdtIndexDoc` runs no `CrdtCheckpointTimer` and sets no `idle_exit_ms`,
-  because draining a room is lossless only if something checkpoints it on the
-  way out. That is now this module. Opting the index room in is a follow-up,
-  not an automatic consequence — see `docs/context/crdt-index-room.md`.
+  because replay is idempotent.
   """
   @behaviour Yex.Sync.SharedDoc.PersistenceBehaviour
 
@@ -74,7 +69,7 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   alias Engram.Crypto
   alias Engram.Crypto.RotationGate
   alias Engram.Logger.Metadata
-  alias Engram.Notes.{Enqueue, VaultIndexState, VaultIndexUpdateLog}
+  alias Engram.Notes.{CrdtCheckpointTimer, Enqueue, VaultIndexState, VaultIndexUpdateLog}
   alias Engram.Repo
 
   require Logger
@@ -117,6 +112,18 @@ defmodule Engram.Notes.CrdtIndexPersistence do
   end
 
   defp do_update_v1(state, user_id, vault_id, update) do
+    # Postpone the idle drain (#1152). Signalled for EVERY update, including one
+    # whose tail append fails below: activity is about whether the room is in
+    # use, not whether the write succeeded, and draining a room a client is
+    # actively writing to is the churn the whole re-arm design avoids.
+    #
+    # Runs inside the room process, so the timer pid comes from the process
+    # dictionary — `CrdtIndexDoc.start_link/1` put it there.
+    case Process.get(:crdt_timer_pid) do
+      pid when is_pid(pid) -> CrdtCheckpointTimer.notify_activity(pid)
+      _ -> :ok
+    end
+
     with {:ok, user} <- fetch_user(user_id),
          :ok <- append_tail(user, vault_id, update) do
       state

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -953,33 +953,25 @@ defmodule EngramWeb.CrdtChannel do
   # re-ask a no-op ("not ours"), pinning the room for the life of the socket —
   # the unbounded residency this whole feature exists to prevent.
   @impl true
+  # The per-vault index room is tracked in its OWN assign, not in room_doc, so
+  # it has to be matched first — exactly like the {:yjs, frame, room} handler
+  # above. Consulting only room_doc sent every index drain to the "not ours"
+  # branch of handle_note_room_drain/2, where it was dropped: the timer's
+  # backed-off re-ask kept asking a channel that structurally could not answer,
+  # and the room stayed resident for the life of the socket (#1152).
   def handle_info({:crdt_room_drain, room}, socket) do
-    case Map.get(socket.assigns.room_doc, room) do
-      nil ->
-        # Not ours (a room we already released, or another channel's).
-        {:noreply, socket}
+    if room == socket.assigns[:index_room] do
+      case release_room(room) do
+        :retry ->
+          {:noreply, socket}
 
-      doc_id ->
-        case release_room(room) do
-          :retry ->
-            {:noreply, socket}
-
-          :gone ->
-            case Map.get(socket.assigns.rooms, doc_id) do
-              %{ref: ref} -> Process.demonitor(ref, [:flush])
-              _ -> :ok
-            end
-
-            socket =
-              socket
-              |> assign(:rooms, Map.delete(socket.assigns.rooms, doc_id))
-              |> assign(:room_doc, Map.delete(socket.assigns.room_doc, room))
-              # Remember we let this one go, so the re-spin stays quiet (see the
-              # announce in start_and_observe_room).
-              |> assign(:drained, remember_drained(socket.assigns.drained, doc_id))
-
-            {:noreply, socket}
-        end
+        :gone ->
+          # Forget it, or the next index frame casts at a corpse and gets :ok
+          # back — the silent-drop class the room monitor exists to prevent.
+          {:noreply, assign(socket, :index_room, nil)}
+      end
+    else
+      handle_note_room_drain(room, socket)
     end
   end
 
@@ -1111,6 +1103,36 @@ defmodule EngramWeb.CrdtChannel do
   @spec locally_dead?(pid(), node()) :: boolean()
   def locally_dead?(room, self_node \\ node()),
     do: node(room) == self_node and not Process.alive?(room)
+
+  defp handle_note_room_drain(room, socket) do
+    case Map.get(socket.assigns.room_doc, room) do
+      nil ->
+        # Not ours (a room we already released, or another channel's).
+        {:noreply, socket}
+
+      doc_id ->
+        case release_room(room) do
+          :retry ->
+            {:noreply, socket}
+
+          :gone ->
+            case Map.get(socket.assigns.rooms, doc_id) do
+              %{ref: ref} -> Process.demonitor(ref, [:flush])
+              _ -> :ok
+            end
+
+            socket =
+              socket
+              |> assign(:rooms, Map.delete(socket.assigns.rooms, doc_id))
+              |> assign(:room_doc, Map.delete(socket.assigns.room_doc, room))
+              # Remember we let this one go, so the re-spin stays quiet (see the
+              # announce in start_and_observe_room).
+              |> assign(:drained, remember_drained(socket.assigns.drained, doc_id))
+
+            {:noreply, socket}
+        end
+    end
+  end
 
   defp room_responsive?(room) do
     SharedDoc.update_doc(room, fn _doc -> :ok end, room_probe_ms())

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -905,7 +905,8 @@ defmodule Engram.Notes.CrdtCheckpointTest do
       room_pid: dead_room,
       user_id: user.id,
       vault_id: vault.id,
-      note_id: note.id,
+      mode: :note,
+      room_key: note.id,
       first_dirty_at: 123,
       settle_timer: nil
     }

--- a/test/engram/notes/crdt_checkpoint_timer_test.exs
+++ b/test/engram/notes/crdt_checkpoint_timer_test.exs
@@ -9,7 +9,7 @@ defmodule Engram.Notes.CrdtCheckpointTimerTest do
   """
   use ExUnit.Case, async: true
 
-  alias Engram.Notes.CrdtCheckpointTimer
+  alias Engram.Notes.{CrdtCheckpointTimer, CrdtRegistry}
 
   # Eager < settle so the eager path is observable; ceiling well above both.
   @cfg %{settle_ms: 1_000, ceiling_ms: 5_000, eager_ms: 100}
@@ -19,6 +19,62 @@ defmodule Engram.Notes.CrdtCheckpointTimerTest do
       Map.merge(@cfg, %{last_activity_at: nil, first_dirty_at: nil}),
       Map.new(overrides)
     )
+  end
+
+  # #1152's remaining half. The timer was note-keyed — `note_id` was a
+  # `Keyword.fetch!` and threaded through the LRU call and every log line — so
+  # the per-vault index room could not use it at all, and stayed bounded only by
+  # `auto_exit` on the last observer, i.e. session-length.
+  #
+  # These are behavioural rather than pure: what matters is that a timer with no
+  # note at all still arms, still drains, and does NOT try to checkpoint a note.
+  describe "index mode — a vault-keyed room (#1152)" do
+    setup do
+      # A stand-in for the room. The timer links to it, so it must outlive the
+      # timer rather than being a bare self().
+      room = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(room, :kill) end)
+      %{room: room, vault_id: Ecto.UUID.generate(), user_id: Ecto.UUID.generate()}
+    end
+
+    test "an index-mode timer drains its room without a note_id", ctx do
+      Phoenix.PubSub.subscribe(Engram.PubSub, CrdtRegistry.drain_topic(ctx.vault_id))
+
+      {:ok, _timer} =
+        CrdtCheckpointTimer.start_link(
+          room_pid: ctx.room,
+          user_id: ctx.user_id,
+          vault_id: ctx.vault_id,
+          mode: :index,
+          idle_exit_ms: 50
+        )
+
+      assert_receive {:crdt_room_drain, room}, 2_000
+      assert room == ctx.room
+    end
+
+    # The index checkpoint has to run from `unbind/3`, not from a tick. Only the
+    # room's own persistence state knows which tail rows failed to replay, and
+    # pruning without that list destroys exactly the claims the tail exists to
+    # protect. So the drain is the mechanism here: observers let go, auto_exit
+    # fires, terminate checkpoints with the right state.
+    test "an index-mode tick does not attempt a note checkpoint", ctx do
+      {:ok, timer} =
+        CrdtCheckpointTimer.start_link(
+          room_pid: ctx.room,
+          user_id: ctx.user_id,
+          vault_id: ctx.vault_id,
+          mode: :index,
+          idle_exit_ms: 60_000
+        )
+
+      # A note-mode tick would call CrdtCheckpoint against a nil note_id and
+      # crash. Drive one directly rather than waiting for the scheduler.
+      send(timer, :tick)
+      Process.sleep(100)
+
+      assert Process.alive?(timer), "the index timer died trying to checkpoint a note"
+    end
   end
 
   describe "compute_delay/2 — eager first flush" do

--- a/test/engram/notes/crdt_index_room_test.exs
+++ b/test/engram/notes/crdt_index_room_test.exs
@@ -124,12 +124,17 @@ defmodule Engram.Notes.CrdtIndexRoomTest do
     end
   end
 
-  describe "inertness" do
-    # The index room has NO persistence until #1151, so a drain would exit it
-    # and take the whole index with it. `terminate/2` -> unbind is exactly what
-    # makes draining a NOTE room lossless, and the index room has no such
-    # thing yet. Enabling #1152 here before #1151 lands is silent index loss.
-    test "the room runs NO checkpoint timer, so it cannot drain itself away", ctx do
+  describe "room lifetime" do
+    # INVERTED (#1152). This used to assert `timers == []` — that the room ran
+    # no timer at all — because a drain with no `terminate/2` checkpoint behind
+    # it would have exited the room and taken the whole index with it.
+    #
+    # Both prerequisites have since landed: #1151 gave the room a checkpoint on
+    # unbind, and #1391 gave it a tail log so even an ungraceful death is
+    # survivable. The room now runs a timer, and what has to be pinned is no
+    # longer its absence but its SHAPE — an index-mode timer that never ticks a
+    # checkpoint of its own.
+    test "the room runs an INDEX-mode timer, which never checkpoints on a tick", ctx do
       {:ok, room} = CrdtIndexRegistry.ensure_observed(ctx.user.id, ctx.vault.id)
 
       # Inspect what the room is actually LINKED to, not the opts this test
@@ -149,9 +154,31 @@ defmodule Engram.Notes.CrdtIndexRoomTest do
             )
         end)
 
-      assert timers == [],
-             "the index room must not drain until #1151 gives it a checkpoint — " <>
-               "draining it now would exit the room and take the whole index with it"
+      assert [timer] = timers,
+             "the index room runs no checkpoint timer, so nothing can ever drain it " <>
+               "and its residency stays session-length (#1152)"
+
+      state = :sys.get_state(timer)
+
+      # `:index`, not `:note`. A note-mode timer would tick `CrdtCheckpoint`
+      # against this room — and an index checkpoint that does not come from
+      # `unbind/3` cannot know which tail rows failed to replay, so it would
+      # prune claims it never folded in (#1391).
+      assert state.mode == :index
+      assert state.room_key == ctx.vault.id
+
+      # ON, not opt-in. `nil` is how the timer spells "drain disabled", so a
+      # room that fell through to the note-room config fallback would go back to
+      # session-length residency the moment that knob was unset — the measured
+      # 7.91 MB/vault (#1149), shipped silently.
+      assert is_integer(state.idle_exit_ms) and state.idle_exit_ms > 0,
+             "the index room's drain must not depend on a flag being set"
+
+      # A tick must be inert rather than merely unlikely. Drive one directly:
+      # the note path would crash on a nil note.
+      send(timer, :tick)
+      Process.sleep(50)
+      assert Process.alive?(timer)
     end
 
     test "a crashed room is not resurrected observer-less" do

--- a/test/engram_web/channels/crdt_channel_drain_test.exs
+++ b/test/engram_web/channels/crdt_channel_drain_test.exs
@@ -179,6 +179,60 @@ defmodule EngramWeb.CrdtChannelDrainTest do
     assert_receive {:DOWN, ^ref, :process, ^room, :normal}, 5_000
   end
 
+  # The per-vault INDEX room is tracked in its own assign (`:index_room`), not
+  # in `room_doc`, which maps note-room pids to doc ids. The drain handler only
+  # consulted `room_doc`, so an index-room drain fell through to its "not ours"
+  # branch and was dropped — silently, and forever: the timer's backed-off
+  # re-ask would keep asking a channel that structurally could not answer, and
+  # residency would stay session-length, which is the whole thing #1152 exists
+  # to bound.
+  test "a drain of the INDEX room releases it instead of being ignored as 'not ours'", ctx do
+    %{socket: socket, user: user, vault: vault} = ctx
+
+    # Open the index room the way a client does — through the channel.
+    push(socket, "crdt_index_msg", %{"b64" => index_claim_frame()})
+    room = await_index_room(vault.id)
+    ref = Process.monitor(room)
+
+    Phoenix.PubSub.broadcast(
+      Engram.PubSub,
+      CrdtRegistry.drain_topic(vault.id),
+      {:crdt_room_drain, room}
+    )
+
+    # The channel is the room's only observer, so letting go trips auto_exit —
+    # whose terminate/2 checkpoints. Nothing else can end this room.
+    assert_receive {:DOWN, ^ref, :process, ^room, _}, 5_000
+
+    # And the channel must forget it, or the next index frame casts at a corpse
+    # and returns :ok.
+    refute :sys.get_state(socket.channel_pid).assigns[:index_room] == room,
+           "the channel kept a released index room cached"
+
+    _ = user
+  end
+
+  defp index_claim_frame do
+    doc = CrdtBridge.new_doc()
+
+    doc
+    |> Yex.Doc.get_map(Engram.Notes.CrdtIndexDoc.map_name())
+    |> Yex.Map.set("drained.md", %{"note_id" => Ecto.UUID.generate()})
+
+    {:ok, update} = Yex.encode_state_as_update(doc)
+    {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_update, update}})
+    Base.encode64(frame)
+  end
+
+  defp await_index_room(vault_id) do
+    Enum.reduce_while(1..100, nil, fn _, _ ->
+      case :global.whereis_name({:crdt_index, vault_id}) do
+        pid when is_pid(pid) -> {:halt, pid}
+        :undefined -> Process.sleep(20) && {:cont, nil}
+      end
+    end) || flunk("the channel never started an index room")
+  end
+
   # The production shape: two devices on one note share ONE room, so the drain
   # has to be handled by every observer and the exit must happen exactly once,
   # on the last release. A drain that assumed a single observer would either


### PR DESCRIPTION
Closes the remaining half of #1152. The note-room side shipped in #1382; the index room was left out because the timer was note-keyed, and because draining a room is lossless only if something checkpoints it on the way out. Both blockers are gone — #1151 gave the room a checkpoint on unbind, #1391 gave it a tail log.

## Why it matters more here

`auto_exit` bounds a note room well: a note is observed only while it is open. This room is observed for as long as **any** socket on the vault is connected, so residency was session-length and tracked connection count rather than mutation rate. #1149 measured **7.91 MB per 10k-note vault**.

## Three parts

1. **`CrdtCheckpointTimer` generalised off `note_id`** — now carries `mode` + `room_key`. `:note` keys on note_id and ticks a checkpoint; `:index` keys on vault_id and **never** does. That is a correctness constraint, not an optimisation: only the room's own persistence state knows which tail rows failed to replay, so a checkpoint from anywhere but `unbind/3` would prune rows it never folded in — destroying exactly the claims the tail log protects.

2. **`CrdtIndexDoc` starts the timer**, and `CrdtIndexPersistence.update_v1/4` signals activity (for every update, including one whose tail append fails — activity is about whether the room is in use, not whether the write succeeded).

3. **`CrdtChannel` recognises an index-room drain.** It only consulted `room_doc`, which maps *note*-room pids to doc ids; the index room lives in its own `:index_room` assign. Every index drain hit the "not ours" branch and was dropped silently — the timer would have kept re-asking a channel that structurally could not answer, and the feature would have looked wired while doing nothing.

## On by default, no flag

Shipping it off would ship the measured residency and call it done. A drain is lossless (`terminate/2` checkpoints, tail log covers an ungraceful death, next frame re-spins the room), so a wrong interval costs a re-bind — decrypt + replay, tens of ms — not a claim. The way back is a different number, not a switch.

Default: 5 minutes of no index **writes**. A connected client that is only reading generates no activity here, which is the point — residency should track mutation.

## Tests

Two tests asserted the behaviour this replaces; both inverted rather than deleted. `CrdtIndexRoomTest`'s *"the room runs NO checkpoint timer"* now pins the timer's shape — index mode, vault-keyed, a tick proven inert, and a non-nil idle window so it cannot revert to depending on a flag. The channel drain suite gains the index-room case that would have caught part 3.

Local: credo clean, dialyzer clean, 4518 tests / 0 failures.

## Caveat worth stating

No client writes this index yet (Engram-obsidian#362), so CI green proves less here than usual. Unlike the tail log, though, this **does** change live behaviour — index rooms now exit on a timer. Post-merge the meaningful check is index-room residency + `engram_prom_ex_crdt_room_drain_total` on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)