### PR TITLE
test(e2e): contract the converge oracle to note_id only

### DIFF
--- a/e2e/helpers/log_oracle.py
+++ b/e2e/helpers/log_oracle.py
@@ -255,21 +255,9 @@ def wait_for_binary_delivery(
 
 
 def wait_for_client_log(
-    api_sync,
-    *needles: str,
-    timeout: float,
-    after: str | None = None,
-    any_of: tuple[str, ...] = (),
+    api_sync, *needles: str, timeout: float, after: str | None = None
 ) -> None:
     """Poll client logs until one line contains ALL ``needles``.
-
-    ``any_of``, when given, additionally requires AT LEAST ONE of its members
-    on the same line. It exists for backend/plugin migrations where the two
-    repos cannot land in one commit: a backend PR's e2e runs against plugin
-    ``main`` while the plugin PR's e2e runs against backend ``main``, so during
-    a log-format change neither side can assert on the new format alone
-    without deadlocking the other. Assert on both, merge, then contract to the
-    new one. Do NOT reach for it to paper over an oracle that is merely flaky.
 
     Shared by CRDT mechanism-oracle tests (previously duplicated as a local
     ``_wait_for_log``/``_wait_for_heal_log`` in each test file). Logs
@@ -287,16 +275,7 @@ def wait_for_client_log(
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         logs = api_sync.get_logs(since=after or "", limit=1000).get("logs", [])
-        for log in logs:
-            message = log.get("message", "")
-            if not all(n in message for n in needles):
-                continue
-            if any_of and not any(n in message for n in any_of):
-                continue
+        if any(all(n in log.get("message", "") for n in needles) for log in logs):
             return
         time.sleep(1)
-    raise TimeoutError(
-        f"no client log containing {needles!r}"
-        + (f" and one of {any_of!r}" if any_of else "")
-        + f" within {timeout}s"
-    )
+    raise TimeoutError(f"no client log containing {needles!r} within {timeout}s")

--- a/e2e/tests/crdt/test_live_bound_both_ends.py
+++ b/e2e/tests/crdt/test_live_bound_both_ends.py
@@ -213,36 +213,23 @@ async def test_deaf_live_bound_note_converges_via_socket_replay(vault_b, cdp_b, 
     # `post_wedge` so the live-bind step's own pre-wedge open-heal line can't
     # satisfy them.
     #
-    # Scoped by note_id OR path, for one release only.
+    # Scoped by note_id, not by path.
     #
-    # The plugin stopped printing vault paths in client logs: a path names the
+    # The plugin does not print vault paths in client logs: a path names the
     # sensitive fact (`Medical/`, `Divorce 2026/`) without anyone reading the
     # note, and client logs land in CloudWatch and Loki outside the per-user
-    # encryption boundary. The replacement scope is note_id — opaque, and the
-    # identity the CRDT layer actually keys on, so it also survives a rename.
-    #
-    # Both are accepted because the two repos cannot land together: this PR's
-    # e2e runs against plugin `main` (still path), while the paired plugin PR's
-    # e2e runs against backend `main` (this file). Asserting on note_id alone
-    # deadlocks the pair; asserting on path alone reverts the privacy fix.
-    #
-    # CONTRACT once Engram-obsidian#436 is merged: drop `any_of` and pass
-    # `note_id_x` as a plain needle. Verified green as a pair by dispatching
-    # verify.yml with `-f plugin_branch=fix/no-paths-in-logs`.
+    # encryption boundary. note_id is opaque, and it is the identity the CRDT
+    # layer actually keys on — so unlike a path it also survives a rename.
     wait_for_client_log(api_sync, "gap-heal fired", timeout=CRDT_TIMEOUT, after=post_wedge)
     wait_for_client_log(
-        api_sync,
-        "socket converge",
-        timeout=CRDT_TIMEOUT,
-        after=post_wedge,
-        any_of=(note_id_x, path_x),
+        api_sync, "socket converge", note_id_x, timeout=CRDT_TIMEOUT, after=post_wedge
     )
     wait_for_client_log(
         api_sync,
         "socket converge: STEP2 committed",
+        note_id_x,
         timeout=CRDT_TIMEOUT,
         after=post_wedge,
-        any_of=(note_id_x, path_x),
     )
     logs = api_sync.get_logs(limit=1000).get("logs", [])
     rest_lines = [


### PR DESCRIPTION
Follow-up to the paired privacy change, as planned in Engram#1396.

Both halves are merged, so the plugin emits `note_id=` on the socket-converge lines everywhere. The transitional "accept note_id **or** path" assertion is no longer needed, and neither is the `any_of` parameter that enabled it — it has no other callers, and an untested branch in a shared helper rots before its next use. The technique is documented in `oauth-e2e-pairing-and-token-binding.md`.

Net −34 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC