### PR TITLE
fix(crdt): crdt_create is the web app's rename, so it must claim (+ the e2e that proves the client half)

### DIFF
--- a/docs/context/crdt-create-is-a-rename.md
+++ b/docs/context/crdt-create-is-a-rename.md
@@ -1,0 +1,88 @@
+# Context Doc: `crdt_create` is the web app's rename, so it must claim
+
+_Last verified: 2026-08-17 (Engram #1400, fixed on the #1399 branch)_
+
+## Status
+Fixed. `genesis_crdt_note/5` now claims before the row transaction.
+
+## What This Is
+
+`crdt_create` reads like a create. It is also **the web app's only rename and
+move path**, and that is not obvious from either side of the wire:
+
+- `frontend/src/api/queries.ts` — `useRenameNote` calls `crdtCreateNote(id, new_path)`,
+  commented *"Replaces POST /notes/rename"*.
+- `frontend/src/viewer/folder-tree.tsx:147` — *"A CRDT move = crdt_create per id
+  at its NEW path"*.
+
+Server side it lands in `Notes.genesis_crdt_note/5` → `genesis_relocate_live/6`
+→ `move_note/5` (Phase E2, "rename-as-move"). That chain moved the row and
+claimed nothing in `filemeta_v0`.
+
+## Why that was a latent data-loss bug
+
+`filemeta_v0` is the authority for paths; `ProjectVaultIndex` derives
+`notes.path_*` **from** it, and it *"walks the INDEX ENTRIES and corrects the row
+each one names"*. So:
+
+1. A client claims `note → A.md`.
+2. The user renames it to `B.md` in the web app. Row moves; the entry still says `A.md`.
+3. The index room checkpoints, which enqueues `ProjectVaultIndex`.
+4. Projection reads the entry and repaths the row **back to `A.md`**.
+
+The rename silently reverts — and because projection re-encrypts the path,
+rewrites `path_hmac`, repaths Qdrant and enqueues link rewrites, it is a full
+write, not a display artifact.
+
+`identity.ex` already named this exact failure: *"a rename that moves and a claim
+that does not gets REVERTED by the next projection run."* `claim_rename/5` was
+built to prevent it on the REST path. The CRDT leg simply never got the same
+treatment, and stayed invisible because **no shipped client wrote the index** —
+until Engram-obsidian#362.
+
+## The fix, and why it is deliberately narrow
+
+`claim_crdt_relocate/5` claims **only** a live id moving to a free path.
+
+**Claiming too eagerly is worse than the bug.** A claim is durable and cannot be
+rolled back, so a claim for an operation that then does not happen makes the path
+*permanently unclaimable* — every later claim on it is refused even though the
+rows are free, and if the row holding it is ever deleted, projection performs the
+rename the API rejected. Hence three exclusions:
+
+| Case | Claim? | Why |
+|---|---|---|
+| Live id → free path | **yes** | this is the rename |
+| First-time create | no | projection never acts on absence, so an unclaimed new note is benign |
+| `classify_by_id` → `:taken` | no | genesis **re-mints a fresh id**, so a claim under the client's id names a row that never exists |
+| Target occupied | no | the relocate rejects with `:id_conflict`; the claim would outlive the rejection |
+
+Two other rules inherited from `claim_rename/5`:
+
+- **Claim BEFORE the row transaction.** `Identity.apply_targets/4` calls
+  `warn_if_in_transaction/3` — a claim inside a transaction has *"durability
+  not guaranteed"*, because the tail-log append rolls back with the transaction
+  while the caller treats the claim as committed. Threading the claim through
+  the existing `with` head keeps it outside without re-indenting the body.
+- **The row check is load-bearing, not redundant.** `Identity.claim/3` sees only
+  collisions recorded IN THE MAP. In a vault whose notes predate any client
+  writing it, essentially every collision is invisible there, so a target held by
+  a ROW with no entry would sail straight through.
+
+## Testing it
+
+`test/engram/notes/identity_test.exs`, describe *"the crdt_create relocate leg
+claims, like every other rename"*. Note the two negative tests are the important
+ones — they pass trivially before the fix (nothing claimed at all) and only earn
+their keep afterwards. Both are mutation-proven: dropping the occupied-target
+guard, or claiming for creates, each turns exactly one red.
+
+## Still open
+
+`crdt_delete` and `crdt_create_batch` were not audited. `crdt_delete` plausibly
+owes an `Identity.release` for the same reason — a tombstoned note whose entry
+survives keeps a path reserved that nothing can reuse.
+
+## Related
+- `crdt-identity-authority.md` — why the map is the authority
+- Engram #1400 (this bug), #1146 (the epic), Engram-obsidian#431 (the client that arms it)

--- a/docs/context/crdt-create-is-a-rename.md
+++ b/docs/context/crdt-create-is-a-rename.md
@@ -77,11 +77,21 @@ ones — they pass trivially before the fix (nothing claimed at all) and only ea
 their keep afterwards. Both are mutation-proven: dropping the occupied-target
 guard, or claiming for creates, each turns exactly one red.
 
-## Still open
+## The sibling legs, audited — both already correct
 
-`crdt_delete` and `crdt_create_batch` were not audited. `crdt_delete` plausibly
-owes an `Identity.release` for the same reason — a tombstoned note whose entry
-survives keeps a path reserved that nothing can reuse.
+Worth writing down so nobody re-derives it. The obvious next suspicion is that
+`crdt_delete` owes an `Identity.release` for the same reason a rename owes a
+claim (a tombstoned note whose entry survives keeps a path reserved that nothing
+can reuse). It does not:
+
+- **`crdt_delete`** → `Notes.delete_note_by_id/4`, which is a thin wrapper that
+  resolves the id and delegates to `delete_note/4` — the same function the REST
+  path uses, and it already enqueues `Engram.Workers.ReleaseIndexEntries`.
+- **`crdt_create_batch`** → `prepare_create/4` → the same `genesis_crdt_note/5`,
+  so it inherits the claim above with no separate change.
+
+The relocate leg was the only gap, because it is the only one that reached the
+row through a path the REST equivalent does not share.
 
 ## Related
 - `crdt-identity-authority.md` — why the map is the authority

--- a/e2e/tests/crdt/test_index_crdt_client_writes.py
+++ b/e2e/tests/crdt/test_index_crdt_client_writes.py
@@ -1,0 +1,122 @@
+"""The plugin writes `filemeta_v0`, and the SERVER sees it.
+
+This is the test the whole index-CRDT effort was missing, and its absence is
+why a write-only client shipped through three green CI runs: every existing
+test has our client on both ends. The plugin's unit tests wire two client
+rooms to each other, and the backend's end-to-end test drives a synthetic
+client through the real channel. Neither has ever asked whether the plugin's
+frames are something the server accepts.
+
+So this asserts the one thing nothing else does: a rename performed in a real
+Obsidian vault reaches the real backend and lands in the vault's authoritative
+index. If the wire format, the event name, the join_ref discipline or the
+handshake is wrong in either direction, this is the test that says so.
+
+Engram-obsidian#362 / engram-app/Engram#1146.
+"""
+
+import uuid
+
+import pytest
+
+from helpers.backend_rpc import backend_rpc
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import write_note
+
+# The index doc's map name. Matches the server (`CrdtIndexDoc.map_name/0`),
+# Relay's `SyncStore.ts:20`, and the plugin's `FILEMETA_MAP` — a mismatch here
+# syncs an empty doc forever without erroring, so it is asserted literally.
+FILEMETA = "filemeta_v0"
+
+# The index room checkpoints on exit and the client publishes on a microtask,
+# so allow the same generous budget the other CRDT tests use rather than
+# racing the settle.
+INDEX_TIMEOUT = 45
+
+
+def _index_paths() -> list[str]:
+    """Read the paths claimed in the newest vault's `filemeta_v0`.
+
+    Goes through `load_doc/2` rather than the raw row on purpose: that is the
+    same snapshot+tail recipe `bind/3` uses, so a claim that only reached the
+    tail log (no checkpoint yet) still counts. Reading the snapshot alone would
+    make this test pass or fail on checkpoint timing instead of on delivery.
+    """
+    out = backend_rpc(
+        "import Ecto.Query; "
+        "v = Engram.Repo.one(from(x in Engram.Vaults.Vault, "
+        "order_by: [desc: x.inserted_at], limit: 1)); "
+        "u = Engram.Repo.get(Engram.Accounts.User, v.user_id); "
+        "{:ok, doc} = Engram.Notes.CrdtIndexPersistence.load_doc(u, v.id); "
+        f'doc |> Yex.Doc.get_map("{FILEMETA}") |> Yex.Map.to_map() '
+        '|> Map.keys() |> Enum.join("\\n") |> IO.puts()'
+    )
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _wait_for_index(path: str, present: bool, timeout: int = INDEX_TIMEOUT) -> list[str]:
+    import time
+
+    deadline = time.time() + timeout
+    paths: list[str] = []
+    while time.time() < deadline:
+        paths = _index_paths()
+        if (path in paths) == present:
+            return paths
+        time.sleep(1)
+    verb = "appear in" if present else "leave"
+    raise AssertionError(
+        f"{path!r} did not {verb} the server index within {timeout}s. "
+        f"Index currently claims: {paths!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_rename_reaches_the_server_index(vault_a, vault_b, cdp_a, api_sync):
+    """A rename in a real vault lands in the server's authoritative index."""
+    # Unique per run: the A/B instances are session-scoped and not reset between
+    # reruns, so a fixed path lets a prior attempt's note_id map contaminate the
+    # next one. Old/new share a suffix so the rename maps them as a pair.
+    suffix = uuid.uuid4().hex[:12]
+    old_path = f"E2E/IndexOld-{suffix}.md"
+    new_path = f"E2E/IndexNew-{suffix}.md"
+
+    write_note(vault_a, old_path, "# Index CRDT\nThe client should claim this path.")
+    api_sync.wait_for_note(old_path)
+    wait_for_delivery(vault_b, old_path, api_sync)
+
+    # The claim for the ORIGINAL path has to arrive before the rename means
+    # anything: if the client never published, the rename below has nothing to
+    # move and the assertion after it would pass vacuously on an empty index.
+    _wait_for_index(old_path, present=True)
+
+    # Obsidian's own rename event — the path the plugin's handleRename hooks.
+    await cdp_a.rename_file(old_path, new_path)
+
+    # The move, in the index the server treats as authoritative for paths.
+    paths = _wait_for_index(new_path, present=True)
+    assert new_path in paths
+
+    # And the old claim is released, not left behind. A stale entry is not
+    # cosmetic here: `ProjectVaultIndex` walks the entries and repaths the row
+    # each one names, so two paths claiming one note is how a rename gets
+    # dragged back.
+    _wait_for_index(old_path, present=False)
+
+
+@pytest.mark.asyncio
+async def test_a_created_note_is_claimed_in_the_server_index(vault_a, api_sync):
+    """A plain create reaches the index too, not just a rename.
+
+    Creates are the volume case — `main.ts`'s cold-start loop resolve-or-mints
+    an id for every markdown file — so if the handshake or the wire format is
+    wrong this fails on the simplest possible path.
+    """
+    suffix = uuid.uuid4().hex[:12]
+    path = f"E2E/IndexCreate-{suffix}.md"
+
+    write_note(vault_a, path, "# Created\nClaimed on create.")
+    api_sync.wait_for_note(path)
+
+    paths = _wait_for_index(path, present=True)
+    assert path in paths, f"the client never claimed {path!r} in the server index"

--- a/e2e/tests/crdt/test_index_crdt_client_writes.py
+++ b/e2e/tests/crdt/test_index_crdt_client_writes.py
@@ -34,33 +34,40 @@ FILEMETA = "filemeta_v0"
 INDEX_TIMEOUT = 45
 
 
-def _index_paths() -> list[str]:
-    """Read the paths claimed in the newest vault's `filemeta_v0`.
+def _index_paths(vault_id: str) -> list[str]:
+    """Read the paths claimed in `vault_id`'s `filemeta_v0`.
 
     Goes through `load_doc/2` rather than the raw row on purpose: that is the
     same snapshot+tail recipe `bind/3` uses, so a claim that only reached the
     tail log (no checkpoint yet) still counts. Reading the snapshot alone would
     make this test pass or fail on checkpoint timing instead of on delivery.
+
+    The vault lookup is raw SQL, not Ecto: `vaults` is one of `Repo`'s
+    `@tenant_tables`, so an Ecto query outside `with_tenant/2` trips the
+    tenant guard and raises. Raw SQL is not rewritten by `prepare_query/3`, and
+    resolving user_id is the ONLY thing needed before `load_doc/2` — which
+    establishes tenant context itself. Vault names are encrypted
+    (`name_ciphertext`), so id is the only usable handle from the test side.
     """
     out = backend_rpc(
-        "import Ecto.Query; "
-        "v = Engram.Repo.one(from(x in Engram.Vaults.Vault, "
-        "order_by: [desc: x.inserted_at], limit: 1)); "
-        "u = Engram.Repo.get(Engram.Accounts.User, v.user_id); "
-        "{:ok, doc} = Engram.Notes.CrdtIndexPersistence.load_doc(u, v.id); "
+        f'%{{rows: [[uid]]}} = Engram.Repo.query!("select user_id from vaults where id = $1", [Ecto.UUID.dump!("{vault_id}")]); '
+        "u = Engram.Repo.get(Engram.Accounts.User, Ecto.UUID.load!(uid)); "
+        f'{{:ok, doc}} = Engram.Notes.CrdtIndexPersistence.load_doc(u, "{vault_id}"); '
         f'doc |> Yex.Doc.get_map("{FILEMETA}") |> Yex.Map.to_map() '
         '|> Map.keys() |> Enum.join("\\n") |> IO.puts()'
     )
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
-def _wait_for_index(path: str, present: bool, timeout: int = INDEX_TIMEOUT) -> list[str]:
+def _wait_for_index(
+    vault_id: str, path: str, present: bool, timeout: int = INDEX_TIMEOUT
+) -> list[str]:
     import time
 
     deadline = time.time() + timeout
     paths: list[str] = []
     while time.time() < deadline:
-        paths = _index_paths()
+        paths = _index_paths(vault_id)
         if (path in paths) == present:
             return paths
         time.sleep(1)
@@ -72,7 +79,9 @@ def _wait_for_index(path: str, present: bool, timeout: int = INDEX_TIMEOUT) -> l
 
 
 @pytest.mark.asyncio
-async def test_client_rename_reaches_the_server_index(vault_a, vault_b, cdp_a, api_sync):
+async def test_client_rename_reaches_the_server_index(
+    vault_a, vault_b, cdp_a, api_sync, sync_vault_id
+):
     """A rename in a real vault lands in the server's authoritative index."""
     # Unique per run: the A/B instances are session-scoped and not reset between
     # reruns, so a fixed path lets a prior attempt's note_id map contaminate the
@@ -88,24 +97,24 @@ async def test_client_rename_reaches_the_server_index(vault_a, vault_b, cdp_a, a
     # The claim for the ORIGINAL path has to arrive before the rename means
     # anything: if the client never published, the rename below has nothing to
     # move and the assertion after it would pass vacuously on an empty index.
-    _wait_for_index(old_path, present=True)
+    _wait_for_index(sync_vault_id, old_path, present=True)
 
     # Obsidian's own rename event — the path the plugin's handleRename hooks.
     await cdp_a.rename_file(old_path, new_path)
 
     # The move, in the index the server treats as authoritative for paths.
-    paths = _wait_for_index(new_path, present=True)
+    paths = _wait_for_index(sync_vault_id, new_path, present=True)
     assert new_path in paths
 
     # And the old claim is released, not left behind. A stale entry is not
     # cosmetic here: `ProjectVaultIndex` walks the entries and repaths the row
     # each one names, so two paths claiming one note is how a rename gets
     # dragged back.
-    _wait_for_index(old_path, present=False)
+    _wait_for_index(sync_vault_id, old_path, present=False)
 
 
 @pytest.mark.asyncio
-async def test_a_created_note_is_claimed_in_the_server_index(vault_a, api_sync):
+async def test_a_created_note_is_claimed_in_the_server_index(vault_a, api_sync, sync_vault_id):
     """A plain create reaches the index too, not just a rename.
 
     Creates are the volume case — `main.ts`'s cold-start loop resolve-or-mints
@@ -118,5 +127,5 @@ async def test_a_created_note_is_claimed_in_the_server_index(vault_a, api_sync):
     write_note(vault_a, path, "# Created\nClaimed on create.")
     api_sync.wait_for_note(path)
 
-    paths = _wait_for_index(path, present=True)
+    paths = _wait_for_index(sync_vault_id, path, present=True)
     assert path in paths, f"the client never claimed {path!r} in the server index"

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -841,10 +841,15 @@ defmodule Engram.Notes do
 
     with {:ok, canonical_id} <- Ecto.UUID.cast(id),
          {:ok, user} <- Crypto.ensure_user_dek(user),
-         {:ok, path} <- validate_path(path) do
-      sanitized_path = PathSanitizer.sanitize(path)
-      folder = Helpers.extract_folder(sanitized_path)
-
+         {:ok, path} <- validate_path(path),
+         sanitized_path = PathSanitizer.sanitize(path),
+         folder = Helpers.extract_folder(sanitized_path),
+         # BEFORE the row transaction, because a claim IS the commit and the row
+         # follows — see `claim_rename/5`. Claiming after the row moves is the
+         # dual-write whose failure mode is projection silently reverting a
+         # completed rename, which is exactly what this leg used to do.
+         {:ok, claimed?} <-
+           claim_crdt_relocate(user, vault, canonical_id, sanitized_path, opts) do
       # Repo.with_tenant wraps the fn return in {:ok, _} (transaction).
       # Unwrap once so the public contract matches the @spec above.
       case Repo.with_tenant(user.id, fn ->
@@ -944,16 +949,104 @@ defmodule Engram.Notes do
           {:adopted, note}
 
         {:ok, inner} ->
-          inner
+          report_genesis_orphan(inner, user, vault, claimed?)
 
         {:error, _} = err ->
-          err
+          report_genesis_orphan(err, user, vault, claimed?)
       end
     else
       :error -> {:error, :invalid_id}
       {:error, _} = err -> err
     end
   end
+
+  # The web app renames and moves EVERY note through `crdt_create`: `queries.ts`
+  # `useRenameNote` calls `crdtCreateNote(id, new_path)` under the comment
+  # "Replaces POST /notes/rename", and a folder drag-move sends one per id at its
+  # new path. So the relocate leg IS a rename and has to claim like one, or the
+  # entry keeps naming the old path and `ProjectVaultIndex` — which walks the
+  # entries and corrects the row each one names — drags the rename back.
+  #
+  # Runs OUTSIDE the row transaction, like `rename_note`: `Identity` warns that a
+  # claim inside one has no durability guarantee, because the tail-log append
+  # rolls back with the transaction while the caller treats the claim as
+  # committed.
+  #
+  # Deliberately NARROWER than the genesis path it guards — only a live id moving
+  # to a free path claims. A claim cannot be rolled back, so claiming for an
+  # operation that then does not happen makes the path permanently unclaimable,
+  # which is worse than the stale entry this fixes:
+  #
+  #   * a first-time create claims nothing. Projection never acts on absence, so
+  #     an unclaimed new note is benign — while `classify_by_id` answering
+  #     `:taken` re-mints a FRESH id, and a claim under the client's id would
+  #     name a row that never exists.
+  #   * an OCCUPIED target is `:id_conflict` below, and claiming for a relocate
+  #     that is about to be refused is the same permanent-unclaimability bug.
+  defp claim_crdt_relocate(user, vault, canonical_id, sanitized_path, opts) do
+    if Keyword.get(opts, :index, :claim) == :skip do
+      {:ok, false}
+    else
+      case Repo.with_tenant(user.id, fn -> classify_by_id(vault, canonical_id) end) do
+        {:ok, {:live, live}} -> claim_if_relocating(user, vault, live, sanitized_path)
+        _ -> {:ok, false}
+      end
+    end
+  end
+
+  defp claim_if_relocating(user, vault, live, sanitized_path) do
+    case same_path?(live, user, sanitized_path) do
+      # Already there: idempotent replay, nothing moves, nothing to claim.
+      {:ok, true} -> {:ok, false}
+      {:ok, false} -> claim_free_target(user, vault, live.id, sanitized_path)
+      {:error, _} = err -> err
+    end
+  end
+
+  # The same row check `decide_claim/5` makes, load-bearing for the same reason:
+  # `Identity.claim/3` sees only collisions recorded IN THE MAP, and in a vault
+  # whose notes predate any client writing it, essentially every collision is
+  # invisible there. A target held by a ROW with no entry would sail through and
+  # strand a durable claim on a path the relocate is about to refuse.
+  defp claim_free_target(user, vault, note_id, new_path) do
+    case note_ids_at(user, vault, [new_path]) do
+      {:error, reason} ->
+        {:error, reason}
+
+      held ->
+        case Map.get(held, new_path) do
+          nil -> claim_one(user, vault, new_path, note_id)
+          ^note_id -> claim_one(user, vault, new_path, note_id)
+          # Occupied by someone else. `genesis_relocate_live` rejects this as
+          # `:id_conflict`; claiming first would outlive the rejection.
+          _other -> {:ok, false}
+        end
+    end
+  end
+
+  # A claim is durable and cannot join the row transaction, so a relocate that
+  # claimed and then failed leaves the authority naming a path the row never
+  # reached. Rare (the row check above closes all but a genuine race), but not
+  # eliminable — so it is counted the way `rename_note` counts it rather than
+  # silently dropped.
+  # Calls `orphan_claim/4` directly rather than reusing `report_orphan_claim/5`.
+  # That helper returns whatever `err` it was handed, so feeding it this path's
+  # `{:error, :id_conflict, note}` widened its inferred return type to include a
+  # 3-tuple — and `rename_note/5`, which shares it, then had a spec dialyzer
+  # called incomplete for a shape it cannot actually return. Widening that spec
+  # to silence the warning would have documented a return value that does not
+  # exist, so the narrow helper stays narrow.
+  defp report_genesis_orphan({:error, reason, _note} = err, user, vault, true) do
+    _ = orphan_claim(user, vault, 1, reason)
+    err
+  end
+
+  defp report_genesis_orphan({:error, reason} = err, user, vault, true) do
+    _ = orphan_claim(user, vault, 1, reason)
+    err
+  end
+
+  defp report_genesis_orphan(result, _user, _vault, _claimed?), do: result
 
   # :none-branch of genesis_crdt_note/4: no row by client id, so route by PATH.
   # note_by_path_query is computed HERE (its only consumer), not at the top of

--- a/test/engram/notes/identity_test.exs
+++ b/test/engram/notes/identity_test.exs
@@ -468,4 +468,73 @@ defmodule Engram.Notes.IdentityTest do
              "projection wrote to the authority it derives from — that is a feedback loop"
     end
   end
+
+  describe "the crdt_create relocate leg claims, like every other rename" do
+    # The web app renames and moves EVERY note through `crdt_create`:
+    # `queries.ts` `useRenameNote` calls `crdtCreateNote(id, new_path)` under
+    # the comment "Replaces POST /notes/rename", and a folder drag-move sends
+    # one `crdt_create` per id at its new path. That leg relocated the ROW and
+    # claimed nothing, which is precisely the dual-write `claim_rename/5`
+    # exists to prevent — its own comment says claiming after the row moves has
+    # "the failure mode of projection silently REVERTING a completed rename".
+    #
+    # Latent until a client writes the map. `Engram-obsidian#362` is that
+    # client, so these pin the leg before it ships.
+    test "relocating a CLAIMED note moves the claim to the new path", ctx do
+      a = note(ctx, "a.md")
+      seed_index(ctx, [{"a.md", entry_for(a.id)}])
+
+      assert {:ok, moved} = Notes.genesis_crdt_note(ctx.user, ctx.vault, a.id, "b.md")
+      assert moved.path == "b.md", "the row did not relocate — this test proves nothing"
+
+      entries = index_entries(ctx)
+      note_id = a.id
+
+      assert %{"note_id" => ^note_id} = entries["b.md"],
+             "the row moved to b.md but the authority never followed — ProjectVaultIndex " <>
+               "walks the entries and corrects the row each one names, so the next " <>
+               "checkpoint drags this rename back to a.md"
+
+      refute Map.has_key?(entries, "a.md"),
+             "the old claim survived, so one note is named at two paths — the fixpoint " <>
+               "ProjectVaultIndex cannot converge"
+    end
+
+    # The guard that keeps the fix from being worse than the bug. A claim is
+    # durable and cannot be rolled back, so claiming a path the relocate then
+    # REFUSES makes that path permanently unclaimable — every later claim on it
+    # is refused even though the rows are free.
+    test "a relocate onto an OCCUPIED path leaves no claim behind", ctx do
+      a = note(ctx, "a.md")
+      b = note(ctx, "b.md")
+      seed_index(ctx, [{"a.md", entry_for(a.id)}, {"b.md", entry_for(b.id)}])
+
+      assert {:error, :id_conflict, _} =
+               Notes.genesis_crdt_note(ctx.user, ctx.vault, a.id, "b.md")
+
+      entries = index_entries(ctx)
+      a_id = a.id
+      b_id = b.id
+
+      assert %{"note_id" => ^b_id} = entries["b.md"],
+             "a rejected relocate stole the occupant's claim"
+
+      assert %{"note_id" => ^a_id} = entries["a.md"],
+             "a rejected relocate dropped the mover's own claim"
+    end
+
+    # A plain create is NOT a relocate. Claiming here would be wrong in the one
+    # case that matters: `classify_by_id` answering `:taken` makes genesis
+    # re-mint a FRESH id, so a claim naming the id the client sent would name a
+    # row that never exists — an orphan claim on a path nothing can ever hold.
+    test "a first-time create does not claim under the client's id", ctx do
+      fresh = Ecto.UUID.generate()
+
+      assert {:ok, _} = Notes.genesis_crdt_note(ctx.user, ctx.vault, fresh, "new.md")
+
+      refute Map.has_key?(index_entries(ctx), "new.md"),
+             "genesis claimed for a create; projection never acts on absence, so an " <>
+               "unclaimed new note is benign and claiming here only adds orphan risk"
+    end
+  end
 end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -995,7 +995,21 @@ defmodule EngramWeb.CrdtChannelTest do
              "Expected note_id #{inspect(doc_id)} to be visible in the log, got: #{inspect(log)}"
 
       # ...but only via metadata, never interpolated into the message body.
-      [_meta_and_level, msg] = String.split(log, "[warning]", parts: 2)
+      #
+      # Isolate THIS warning's line first. `capture_log` is global, so under a
+      # loaded suite the capture also holds unrelated concurrent output — the
+      # Prometheus aggregator's "Dropping aggregation for bad tag value"
+      # warnings arrive in bursts. Splitting the whole capture on the FIRST
+      # `[warning]` then landed on one of those, leaving this test's own line —
+      # metadata `note_id=...` included — inside `msg`, and the refute below
+      # failed on metadata it was never meant to read. Same shared-capture
+      # class as #1359.
+      msg =
+        log
+        |> String.split("\n")
+        |> Enum.find(&String.contains?(&1, "dropped crdt_msg"))
+        |> String.split("[warning]", parts: 2)
+        |> List.last()
 
       refute String.contains?(msg, doc_id),
              "note_id must live in metadata, not the message body: #{inspect(msg)}"


### PR DESCRIPTION
The test the index-CRDT effort was missing. Every existing test has our client on both ends: the plugin's unit tests wire two client rooms to each other, and the backend's e2e drives a *synthetic* client through the real channel. Neither has ever asked whether the plugin's frames are something the server accepts — which is how a write-only client shipped through three green CI runs.

Two tests, both green against a real backend + real headless Obsidian:
- a create claims its path in `filemeta_v0`
- a rename moves the claim **and releases the old one**

### It had never been run
The first version was written but never executed, and it had three defects — all in the RPC helper, all of which raised before any assertion ran:

1. `vaults` is one of `Repo`'s `@tenant_tables`, so the Ecto query tripped the tenant guard.
2. The ordering column is `created_at`, not `inserted_at`.
3. "Newest vault" was the wrong handle anyway — vault names are encrypted, and a session may hold several.

It now takes the `sync_vault_id` fixture and resolves `user_id` with raw SQL, which `prepare_query/3` does not rewrite. `load_doc/2` establishes tenant context itself, so that lookup is the only thing needed ahead of it.

Reading through `load_doc/2` rather than the checkpoint row is deliberate: it's the same snapshot+tail recipe `bind/3` uses, so a claim that only reached the tail log still counts and the test doesn't pass/fail on checkpoint timing.

Refs engram-app/Engram#1146, engram-app/Engram-obsidian#362