### PR TITLE
fix(web): stop deleted-note red screen and file-tree reconnect flash

### DIFF
--- a/frontend/e2e/tree-ops-sync.spec.ts
+++ b/frontend/e2e/tree-ops-sync.spec.ts
@@ -207,17 +207,19 @@ test.describe("web tree ops sync (web to web)", () => {
 		//      invalidated, only a defunct path-keyed one. Fixed by threading
 		//      the note id through to the broadcast for every "the note is
 		//      really gone" call site.
-		// With both fixed, useNote(id) refetches by id in both tabs, the
-		// backend 404s ("not found"), and NotePage's `error` branch renders
-		// "Failed to load note: not found" in place of the editor. The
-		// route/URL is left untouched (no redirect). That is the graceful
-		// state this test locks in: no dead editor showing stale content, no
-		// crash, no infinite spinner, just an explicit not-found message.
-		await expect(pageA).toHaveURL(noteUrlRe(doomedId));
-		await expect(pageA.getByText(/Failed to load note/u)).toBeVisible({ timeout: 10_000 });
+		// With both fixed, useNote(id) refetches by id in both tabs and the
+		// backend 404s ("not found"). Superseded: NotePage used to render
+		// "Failed to load note: not found" in place of the editor and leave the
+		// URL on the dead note; it now redirects to the bare vault instead (a
+		// deleted note is not a failure to explain, just gone) — see
+		// note-page.tsx's `noteGone` handling. Either way, no dead editor
+		// showing stale content, no crash, no infinite spinner, no stranded
+		// dead-note URL.
+		await expect(pageA).not.toHaveURL(noteUrlRe(doomedId), { timeout: 10_000 });
+		await expect(row(pageA, "survivor")).toBeVisible({ timeout: 10_000 });
 
-		await expect(pageB).toHaveURL(noteUrlRe(doomedId));
-		await expect(pageB.getByText(/Failed to load note/u)).toBeVisible({ timeout: 10_000 });
+		await expect(pageB).not.toHaveURL(noteUrlRe(doomedId), { timeout: 10_000 });
+		await expect(row(pageB, "survivor")).toBeVisible({ timeout: 10_000 });
 
 		// No crash in either tab: the CRDT doc teardown (closeDoc fires from the
 		// effect cleanup once `note` flips to the error state and its derived

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError, api, LimitExceededError, setUpgradeHandler } from "./client";
+import { ApiError, api, isNotFound, LimitExceededError, setUpgradeHandler } from "./client";
+
+describe("isNotFound", () => {
+	it("is true only for a 404 ApiError", () => {
+		expect(isNotFound(new ApiError(404, "not found"))).toBe(true);
+		expect(isNotFound(new ApiError(500, "server error"))).toBe(false);
+		expect(isNotFound(new Error("network down"))).toBe(false);
+		expect(isNotFound(null)).toBe(false);
+	});
+});
 
 describe("api client 402 handling", () => {
 	beforeEach(() => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -102,6 +102,13 @@ export class ApiError extends Error {
 	}
 }
 
+/** The resource is gone (deleted, or never existed) rather than some other
+ *  failure (network, auth, server error) — the distinction every "show a
+ *  missing-state fallback" call site needs. */
+export function isNotFound(err: unknown): boolean {
+	return err instanceof ApiError && err.status === 404;
+}
+
 export class LimitExceededError extends Error {
 	readonly name = "LimitExceededError";
 	constructor(

--- a/frontend/src/viewer/attachment-img.tsx
+++ b/frontend/src/viewer/attachment-img.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ApiError, api } from "../api/client";
+import { ApiError, api, isNotFound } from "../api/client";
 
 // 'missing' only for a real 404; a transient 5xx/network failure must NOT claim
 // the file is missing (the file exists, storage is just unreachable).
@@ -32,7 +32,7 @@ export default function AttachmentImg({ path, alt }: { path: string; alt?: strin
 					// See attachment-page: the path is the user's folder structure.
 					console.error("attachment image load failed", err);
 				}
-				setError(err instanceof ApiError && err.status === 404 ? "missing" : "failed");
+				setError(isNotFound(err) ? "missing" : "failed");
 			});
 		return () => {
 			cancelled = true;

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from "react";
 import { useParams } from "react-router";
-import { ApiError, api } from "../api/client";
+import { ApiError, api, isNotFound } from "../api/client";
 import { useAttachments } from "../api/queries";
 import LoadingPane from "./loading-pane";
 import PreviewColumn from "./preview-column";
@@ -55,7 +55,7 @@ export default function AttachmentPage() {
 					// breadcrumbs as well as sitting in a console the user may screenshot.
 					console.error("attachment load failed", err);
 				}
-				setError(err instanceof ApiError && err.status === 404 ? "missing" : "failed");
+				setError(isNotFound(err) ? "missing" : "failed");
 			});
 		return () => {
 			cancelled = true;

--- a/frontend/src/viewer/note-editor.test.tsx
+++ b/frontend/src/viewer/note-editor.test.tsx
@@ -32,6 +32,33 @@ describe("buildEditorState", () => {
 		expect(state.doc.toString()).toBe("# Seeded heading\n\nbody text");
 	});
 
+	// CodeMirror's content DOM defaults to spellcheck="false" (it's built for
+	// code). This is a prose/markdown editor, so the browser's native
+	// squiggly-underline spellcheck has to be switched back on, or misspelled
+	// words never get flagged.
+	it("enables the browser's native spellcheck on the content DOM", () => {
+		const doc = new Y.Doc();
+		const ytext = doc.getText("content");
+		const awareness = new Awareness(doc);
+
+		const view = new EditorView({
+			state: buildEditorState(
+				ytext,
+				awareness,
+				false,
+				"rendered",
+				resolveWikiLink,
+				openWikiLink,
+				wikiCompletionPaths,
+			),
+		});
+		try {
+			expect(view.contentDOM.getAttribute("spellcheck")).toBe("true");
+		} finally {
+			view.destroy();
+		}
+	});
+
 	it("produces an empty document when the Y.Text is empty", () => {
 		const doc = new Y.Doc();
 		const ytext = doc.getText("content");

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -114,6 +114,11 @@ export function buildEditorState(
 		doc: ytext.toString(),
 		extensions: [
 			...(onFrontmatterShortcut ? [frontmatterShortcut(onFrontmatterShortcut)] : []),
+			// CodeMirror's content DOM sets spellcheck="false" by default (it's
+			// built for code, not prose). This is a markdown/prose editor, so
+			// override it back on — the browser's native spellcheck is the only
+			// squiggly-underline signal this editor gets, there's no in-app one.
+			EditorView.contentAttributes.of({ spellcheck: "true" }),
 			drawSelection(),
 			EditorView.lineWrapping,
 			Prec.highest(keymap.of(yUndoManagerKeymap)),

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
+import { ApiError } from "../api/client";
 import { readRows } from "../crdt/frontmatter-doc";
 import { RightToolsProvider } from "../layout/right-tools-context";
 import { ActiveEditorProvider, useActiveEditor } from "./editor/active-editor-context";
@@ -174,6 +175,46 @@ describe("NotePage (CRDT)", () => {
 		renderPage();
 		await waitFor(() => expect(openDoc).toHaveBeenCalledWith("note-1"));
 		expect(enroll).toHaveBeenCalledWith("note-1");
+	});
+
+	// The routed note 404s — deleted from another device/tab, or by this one's
+	// own delete racing the route. Must bounce to the vault root instead of the
+	// red-text dead end this page used to show.
+	describe("routed note 404s", () => {
+		it("redirects to the vault root instead of showing an error screen", async () => {
+			useNoteMock.mockReturnValue({
+				data: undefined,
+				isLoading: false,
+				error: new ApiError(404, "not found"),
+			});
+			renderPage();
+			await waitFor(() =>
+				expect(navigateMock).toHaveBeenCalledWith("/my-vault", { replace: true }),
+			);
+			expect(screen.queryByText(/Failed to load note/)).not.toBeInTheDocument();
+		});
+
+		it("redirects to / when there is no vault slug", async () => {
+			paramsMock.slug = undefined;
+			useNoteMock.mockReturnValue({
+				data: undefined,
+				isLoading: false,
+				error: new ApiError(404, "not found"),
+			});
+			renderPage();
+			await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/", { replace: true }));
+		});
+
+		it("still shows the error screen for a non-404 failure", async () => {
+			useNoteMock.mockReturnValue({
+				data: undefined,
+				isLoading: false,
+				error: new ApiError(500, "server exploded"),
+			});
+			renderPage();
+			await screen.findByText(/Failed to load note: server exploded/);
+			expect(navigateMock).not.toHaveBeenCalled();
+		});
 	});
 
 	// Switching notes does NOT remount NotePage (React Router reuses the route

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -7,7 +7,7 @@ import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { ApiError } from "../api/client";
+import { isNotFound } from "../api/client";
 import type { Note } from "../api/queries";
 import {
 	useBatchMoveNotes,
@@ -31,6 +31,7 @@ import {
 import { useRightTools } from "../layout/right-tools-context";
 import { copyToClipboard } from "../lib/clipboard";
 import { noteName } from "../lib/note-name";
+import { rlog } from "../observability/remote-log";
 import BacklinksPanel from "./backlinks-panel";
 import { useActiveEditor } from "./editor/active-editor-context";
 import { KeyboardBar } from "./editor/keyboard-bar";
@@ -412,13 +413,17 @@ export default function NotePage() {
 	// The routed note is gone — deleted from another device, or by this one's
 	// own delete action racing the route. A 404 here means there is no note to
 	// show, not a failure to explain, so bounce to the bare vault instead of
-	// stranding the user on a red-text dead end.
-	const noteGone = error instanceof ApiError && error.status === 404;
+	// stranding the user on a red-text dead end. Logged (not silent): a 404 can
+	// also mean a real backend bug (bad auth/vault scoping), and that must stay
+	// diagnosable even though the redirect makes it invisible in the UI.
+	const noteGone = isNotFound(error);
 	useEffect(() => {
-		if (noteGone) {
-			navigate(slug ? `/${slug}` : "/", { replace: true });
+		if (!noteGone || validId === null) {
+			return;
 		}
-	}, [noteGone, navigate, slug]);
+		rlog().warn("note", `note ${validId} 404'd while routed — redirecting to vault root`);
+		navigate(slug ? `/${slug}` : "/", { replace: true });
+	}, [noteGone, validId, navigate, slug]);
 
 	if (validId === null) {
 		return <p className="p-6 text-destructive">Invalid note id.</p>;

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -7,6 +7,7 @@ import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ApiError } from "../api/client";
 import type { Note } from "../api/queries";
 import {
 	useBatchMoveNotes,
@@ -408,13 +409,28 @@ export default function NotePage() {
 		return () => setEditor(null);
 	}, [editorMounted, setEditor]);
 
+	// The routed note is gone — deleted from another device, or by this one's
+	// own delete action racing the route. A 404 here means there is no note to
+	// show, not a failure to explain, so bounce to the bare vault instead of
+	// stranding the user on a red-text dead end.
+	const noteGone = error instanceof ApiError && error.status === 404;
+	useEffect(() => {
+		if (noteGone) {
+			navigate(slug ? `/${slug}` : "/", { replace: true });
+		}
+	}, [noteGone, navigate, slug]);
+
 	if (validId === null) {
 		return <p className="p-6 text-destructive">Invalid note id.</p>;
 	}
+	if (noteGone) {
+		// Redirecting (see the effect above) — nothing to show for the one tick
+		// it takes.
+		return null;
+	}
 	if (error) {
-		// The ROUTED note failed — never paper over that with the held pair. The
-		// note may have just been deleted out from under this route (see
-		// useDeleteNote's invalidateQueries comment).
+		// The ROUTED note failed for a reason other than "it's gone" — never
+		// paper over that with the held pair.
 		return <p className="p-6 text-destructive">Failed to load note: {error.message}</p>;
 	}
 	if (!shown) {

--- a/frontend/src/viewer/tree/use-engram-tree.test.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.test.ts
@@ -140,6 +140,42 @@ describe("useEngramTree", () => {
 		await waitFor(() => expect(spy).toHaveBeenCalled());
 	});
 
+	it("does not rebuild again when a by-id list refetches to the SAME notes", async () => {
+		const qc = new QueryClient();
+		const { result } = renderHook(() => useEngramTree({ ...baseDeps, qc }));
+		const spy = vi.spyOn(result.current.tree, "rebuildTree");
+
+		const note: NoteSummary = {
+			id: "n1",
+			path: "Projects/n1.md",
+			title: "n1",
+			folder: "Projects",
+			tags: [],
+			version: 1,
+			mtime: "",
+			created_at: "",
+			updated_at: "",
+		};
+		act(() => {
+			qc.setQueryData(["folder-notes-by-id", "v", "1"], [note]);
+		});
+		await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+		// A reconnect-driven backfill refetch that lands the identical list (the
+		// common no-op case) must not redraw the tree a second time.
+		act(() => {
+			qc.setQueryData(["folder-notes-by-id", "v", "1"], [{ ...note }]);
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(spy).toHaveBeenCalledTimes(1);
+
+		// A genuine change (version bump) still rebuilds.
+		act(() => {
+			qc.setQueryData(["folder-notes-by-id", "v", "1"], [{ ...note, version: 2 }]);
+		});
+		await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+	});
+
 	it('rebuilds the tree when the root note list (by-id "root") changes', async () => {
 		const qc = new QueryClient();
 		const { result } = renderHook(() => useEngramTree({ ...baseDeps, qc }));

--- a/frontend/src/viewer/tree/use-engram-tree.test.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.test.ts
@@ -176,6 +176,41 @@ describe("useEngramTree", () => {
 		await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
 	});
 
+	// A background write (e.g. a device_type sync touch) can bump `updated_at`
+	// without bumping `version`. The "Modified" sort reads `updated_at`
+	// (loader.ts sortNotes), so the fingerprint has to catch a timestamp-only
+	// change too, or the visible sort order goes stale after a no-op-looking
+	// refetch.
+	it("rebuilds when only updated_at changes (sort order can depend on it)", async () => {
+		const qc = new QueryClient();
+		const { result } = renderHook(() => useEngramTree({ ...baseDeps, qc }));
+		const spy = vi.spyOn(result.current.tree, "rebuildTree");
+
+		const note: NoteSummary = {
+			id: "n1",
+			path: "Projects/n1.md",
+			title: "n1",
+			folder: "Projects",
+			tags: [],
+			version: 1,
+			mtime: "",
+			created_at: "",
+			updated_at: "2026-08-17T00:00:00Z",
+		};
+		act(() => {
+			qc.setQueryData(["folder-notes-by-id", "v", "1"], [note]);
+		});
+		await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+		act(() => {
+			qc.setQueryData(
+				["folder-notes-by-id", "v", "1"],
+				[{ ...note, updated_at: "2026-08-17T00:05:00Z" }],
+			);
+		});
+		await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+	});
+
 	it('rebuilds the tree when the root note list (by-id "root") changes', async () => {
 		const qc = new QueryClient();
 		const { result } = renderHook(() => useEngramTree({ ...baseDeps, qc }));

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -13,7 +13,12 @@ import { useTree } from "@headless-tree/react";
 import type { QueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useEffect, useMemo, useRef } from "react";
-import { type AttachmentSummary, type Folder, type NoteSummary, ROOT_FOLDER_ID } from "../../api/queries";
+import {
+	type AttachmentSummary,
+	type Folder,
+	type NoteSummary,
+	ROOT_FOLDER_ID,
+} from "../../api/queries";
 import { resolveDropMove } from "./drop-redirect";
 import { buildLoader, type LoaderItem, type SortKey } from "./loader";
 import { TREE_SLOT_HEIGHT } from "./row-metrics";
@@ -72,8 +77,14 @@ function noteListFingerprint(data: unknown): string {
 	if (!Array.isArray(data)) {
 		return "";
 	}
+	// id/version/path covers identity + content + rename; updated_at/created_at
+	// are ALSO load-bearing even though they never gate identity — sortNotes
+	// (loader.ts) orders "Modified"/"Created" views by them, and a fingerprint
+	// blind to a timestamp-only change (e.g. a background write that bumps
+	// updated_at without bumping version) would skip the rebuild and leave that
+	// sort order stale.
 	return (data as NoteSummary[])
-		.map((n) => `${n.id}:${n.version}:${n.path}`)
+		.map((n) => `${n.id}:${n.version}:${n.path}:${n.updated_at}:${n.created_at}`)
 		.sort()
 		.join("|");
 }

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -13,7 +13,7 @@ import { useTree } from "@headless-tree/react";
 import type { QueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useEffect, useMemo, useRef } from "react";
-import { type AttachmentSummary, type Folder, ROOT_FOLDER_ID } from "../../api/queries";
+import { type AttachmentSummary, type Folder, type NoteSummary, ROOT_FOLDER_ID } from "../../api/queries";
 import { resolveDropMove } from "./drop-redirect";
 import { buildLoader, type LoaderItem, type SortKey } from "./loader";
 import { TREE_SLOT_HEIGHT } from "./row-metrics";
@@ -59,6 +59,23 @@ function attachmentsFingerprint(attachments?: AttachmentSummary[]): string {
 		}
 	}
 	return `${attachments.length}:${max}`;
+}
+
+// Cheap content fingerprint for a `folder-notes-by-id` list. A reconnect-driven
+// refetch (backfillStructural) hits EVERY loaded folder, whether or not
+// anything actually changed, and each one is a fresh array from a fresh
+// fetch — a reference check alone can't tell a no-op refetch from a real
+// change. Comparing this fingerprint against the last-seen one (below) lets a
+// no-op refetch skip the rebuild instead of redrawing the whole tree for
+// nothing.
+function noteListFingerprint(data: unknown): string {
+	if (!Array.isArray(data)) {
+		return "";
+	}
+	return (data as NoteSummary[])
+		.map((n) => `${n.id}:${n.version}:${n.path}`)
+		.sort()
+		.join("|");
 }
 
 type TreeLoader = ReturnType<typeof buildLoader>;
@@ -247,6 +264,9 @@ export function useEngramTree(deps: Deps) {
 				treeRef.current?.rebuildTree();
 			});
 		};
+		// Per-folder last-seen fingerprint, scoped to this effect so it resets
+		// cleanly on a vault switch instead of comparing across vaults.
+		const lastFingerprint = new Map<string, string>();
 		const unsubscribe = cache.subscribe((event) => {
 			const key = event.query.queryKey;
 			if (!Array.isArray(key) || key[0] !== "folder-notes-by-id" || key[1] !== deps.vaultId) {
@@ -257,6 +277,14 @@ export function useEngramTree(deps: Deps) {
 			if (event.type === "added" || event.type === "removed") {
 				schedule();
 			} else if (event.type === "updated" && event.action.type === "success") {
+				const keyStr = key.join(":");
+				const fingerprint = noteListFingerprint(event.query.state.data);
+				if (lastFingerprint.get(keyStr) === fingerprint) {
+					// A backfill/reconnect refetch that landed the SAME notes — the
+					// common case on a socket hiccup. Nothing to redraw.
+					return;
+				}
+				lastFingerprint.set(keyStr, fingerprint);
 				schedule();
 			}
 		});


### PR DESCRIPTION
## Summary
- A note deleted out from under the open route (from another device, or a race) showed a red "Failed to load note" screen instead of returning to the vault — redirect on a 404 the way the delete button's own `navigate` already does. Logged (not silent), so a non-delete 404 (e.g. a real auth/scoping bug) stays diagnosable.
- Every socket-reconnect-triggered backfill refetches all loaded folders' note lists, and each one independently redrew the whole file tree — visible as a flash/reload every time the live-sync socket reconnects, even when nothing actually changed. Skip the tree redraw when a folder's note list refetches to identical content (id/version/path/updated_at/created_at).
- CodeMirror's content DOM sets `spellcheck="false"` by default (it's built for code, not prose). The note editor is markdown/prose, so misspelled words never got the browser's native red squiggle. Re-enabled it.
- Follow-up from review: extracted a shared `isNotFound()` helper (was duplicated 3x across note-page/attachment-page/attachment-img).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run` — full frontend suite passing
- [x] Regression tests: 404-redirect path, no-op-refetch skip + timestamp-only-change still rebuilds, `isNotFound()` unit test, spellcheck attribute on the content DOM
- [ ] Manual: delete a note while it's open in another tab, confirm redirect to `/vault` instead of red screen
- [ ] Manual: watch the file tree across a socket reconnect (dev tools offline/online toggle), confirm no visible flash
- [ ] Manual: type a misspelled word in the editor, confirm the browser's native squiggly underline appears