### PR TITLE
fix(crdt): keep the channel alive when its room is gone

### DIFF
--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -1222,11 +1222,40 @@ defmodule EngramWeb.CrdtChannel do
   # y_ex threw it away — the same silent-drop class as casting into a dead room,
   # one step further down the pipe. guard_frame/1 does NOT cover this: it checks
   # state-vector plausibility, not that the frame is a well-formed Yjs message.
-  defp relay_frame(room, frame) do
+  @doc false
+  # Public for the same reason as release_room/3 below: the dead-room path is
+  # a RACE and cannot be driven deterministically through push/3 — the existing
+  # channel-level room-death test has to sleep past this exact window.
+  #
+  # y_ex dispatches a sync frame as a `GenServer.call`
+  # (deps/y_ex/lib/server/doc_server_worker.ex:16-31), which EXITS the caller
+  # when the room is gone. Uncaught, that exit kills the CHANNEL — and with it
+  # every note syncing over that socket, not just this frame.
+  #
+  # Rooms are `:global` singletons, so the room is routinely on ANOTHER node.
+  # When that node drains, the monitor `:DOWN` that evicts our cached pid
+  # arrives over distribution while the client keeps sending. Observed in prod
+  # 2026-08-18: a full-vault download to mobile died mid-transfer because its
+  # channel called into a room on a task that had just been replaced.
+  #
+  # `:room_unavailable` is deliberately the EXISTING reason, not a new one: it
+  # already routes to a reply that tells the client to retry, and that clause
+  # already reasons that the drain makes teardown the steady state and a retry
+  # re-resolves through ensure_room onto a fresh room. This is the same event
+  # arriving one step later, so it deserves the same heal rather than a second
+  # vocabulary for it.
+  #
+  # No explicit eviction here: the room is monitored, and a monitor fires on
+  # node loss too (`:noconnection`), so the cached pid is gone well before the
+  # client's retry completes a round trip.
+  @spec relay_frame(pid(), binary()) :: :ok | {:error, term()}
+  def relay_frame(room, frame) do
     case SharedDoc.send_yjs_message(room, frame) do
       :ok -> :ok
       {:error, reason} -> {:error, {:rejected_by_ydoc, reason}}
     end
+  catch
+    :exit, _ -> {:error, :room_unavailable}
   end
 
   # NOT log_dropped/3: that keys the id as `note_id`, and an index frame has no

--- a/test/engram_web/channels/crdt_channel_relay_test.exs
+++ b/test/engram_web/channels/crdt_channel_relay_test.exs
@@ -1,0 +1,91 @@
+defmodule EngramWeb.CrdtChannelRelayTest do
+  @moduledoc """
+  `relay_frame/2` against a room that is already gone.
+
+  Driven directly rather than through a channel on purpose. The failure this
+  covers is a RACE — a frame arriving after the room died but before the
+  channel's `:DOWN` evicted the cached pid — and the existing channel-level
+  test for room death has to `Process.sleep(50)` to let that `:DOWN` land, i.e.
+  it deliberately steps around this window. A test that tried to land inside it
+  through `push/3` could only ever be timing-dependent, and one that fails to
+  hit the window would pass while proving nothing.
+
+  Cross-node this window is not small: rooms are `:global` singletons, so the
+  room is routinely on another node, and when that node drains the monitor
+  `:DOWN` arrives over distribution while frames keep arriving from the client.
+  That is the 2026-08-18 production signature — a full-vault download to mobile
+  died mid-transfer when its channel called into a room on a task that had just
+  been replaced.
+  """
+  use ExUnit.Case, async: true
+
+  alias EngramWeb.CrdtChannel
+
+  # A sync_step1 frame, and it MUST be step1 rather than an update.
+  #
+  # y_ex dispatches by frame type (deps/y_ex/lib/server/doc_server_worker.ex):
+  # sync_step1 `<<0,0,…>>` is a `GenServer.call` and EXITS against a dead pid,
+  # while sync_update `<<0,2,…>>` is a `GenServer.cast` and returns `:ok`
+  # having silently dropped the frame. An update frame here would make every
+  # assertion below pass against the UNFIXED code — vacuously.
+  #
+  # The production trace confirms the call path: `{:__yex_sync_step1_raw, …}`.
+  @frame <<0, 0, 1, 0>>
+
+  # The cast counterpart, used only to pin the contrast.
+  @update_frame <<0, 2, 1, 0>>
+
+  defp dead_pid do
+    pid = spawn(fn -> :ok end)
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+    refute Process.alive?(pid)
+    pid
+  end
+
+  test "returns :room_unavailable instead of exiting when the room is dead" do
+    # y_ex dispatches sync frames as a GenServer.call, which EXITS the caller
+    # against a dead pid. Uncaught, that exit kills the channel process and
+    # every note syncing over it, not just this frame.
+    assert {:error, :room_unavailable} = CrdtChannel.relay_frame(dead_pid(), @frame)
+  end
+
+  test "the caller survives — the exit is caught, not merely re-shaped" do
+    # The point is process survival, so assert it directly: a `catch` that
+    # re-raised, or a rescue that missed `:exit`, would still take the caller
+    # down while satisfying the assertion above under a different shape.
+    parent = self()
+
+    caller =
+      spawn(fn ->
+        send(parent, {:result, CrdtChannel.relay_frame(dead_pid(), @frame)})
+        # Stay alive so the test can observe that we were not killed by the call.
+        receive do: (:stop -> :ok)
+      end)
+
+    assert_receive {:result, {:error, :room_unavailable}}, 2_000
+    assert Process.alive?(caller), "relay_frame took its caller down with the dead room"
+    send(caller, :stop)
+  end
+
+  test "a live room still relays normally" do
+    # Guard against 'fixing' this by making relay_frame always return an error.
+    {:ok, room} = Yex.Sync.SharedDoc.start_link(doc_name: "relay-test-#{System.unique_integer()}")
+    # start_link links to the test process, so kill it via an unlinked teardown
+    # rather than taking this test down with it.
+    on_exit(fn -> if Process.alive?(room), do: Process.exit(room, :kill) end)
+    Process.unlink(room)
+
+    assert :ok = CrdtChannel.relay_frame(room, @frame)
+  end
+
+  test "a dead room's UPDATE frame is still silently accepted (known cast path)" do
+    # Not something this change fixes, pinned so the asymmetry is visible: an
+    # update is a cast, so it reports success while dropping the edit. That
+    # silent-drop class is what the room monitor + cache eviction exist to
+    # bound, and it is why the drain releases observers rather than stopping
+    # rooms outright. If this ever starts returning an error, the dispatch
+    # contract changed and relay_frame's reasoning needs revisiting.
+    assert :ok = CrdtChannel.relay_frame(dead_pid(), @update_frame)
+  end
+end


### PR DESCRIPTION
Closes #1410.

## The bug

`relay_frame/2` handled `{:error, reason}` but not an **exit**. y_ex dispatches
`sync_step1` as a `GenServer.call`, which exits the caller against a dead pid —
so the exit killed the **channel**, and with it every note syncing over that
socket.

Rooms are `:global` singletons, so the room is routinely on another node. When
that node drains, the monitor `:DOWN` that evicts our cached pid arrives over
distribution while the client keeps sending.

Prod 2026-08-18 — a full-vault download to mobile died mid-transfer:

```
GenServer.call(#PID<67437.28189.0>, {:__yex_sync_step1_raw, ...}, 5000)
** (EXIT) no process
   y_ex/lib/protocols/shared_doc.ex:37: send_yjs_message/2
   crdt_channel.ex:1226: relay_frame/2
```

The non-zero first field in `#PID<67437....>` means a **remote** node — the room
was on the task that had just been replaced.

## The fix

`catch :exit, _ -> {:error, :room_unavailable}`, matching `room_responsive?/1`
in the same module, which already uses that pattern for the same class.

Deliberately the **existing** `:room_unavailable` reason, not a new one. That
clause already replies telling the client to retry, and already reasons that the
drain makes room teardown the steady state and a retry re-resolves through
`ensure_room` onto a fresh room. This is the same event arriving one step later,
so it deserves the same heal rather than a second vocabulary for it.

No explicit eviction: the room is monitored, and a monitor fires on node loss
too (`:noconnection`), so the cached pid is gone well before a client retry
completes a round trip.

## Tests

Driven against `relay_frame/2` directly. The window is a race, and the existing
channel-level room-death test does `Process.sleep(50)` **specifically to let
`:DOWN` land first** — it steps around this exact case. Anything driven through
`push/3` could only be timing-dependent, and a test that missed the window would
pass while proving nothing.

**The frame type is load-bearing.** `sync_update` is a **cast**: it returns `:ok`
having silently dropped the frame. An update frame would make every assertion
pass against unfixed code — the first draft of this test had exactly that bug and
only surfaced because it was run red first. That asymmetry is now pinned in its
own test so nobody assumes this made all dead-room frames safe. It didn't.

**Negative control:** removing the `catch` fails 2 of the 4 new tests, so they
are pinned to the behaviour change and not to `relay_frame` merely becoming
public.

## Verification

Local: `mix format --check-formatted` ✅, `mix credo --strict` no issues ✅,
`mix test` **4631 tests, 0 failures** ✅, `mix dialyzer` ✅ (26.67s, warm PLT).

## Scope

Does NOT address #1409 (bulk upload creating a room per note), which is the root
cause this mitigates the blast radius of. A deploy will still interrupt in-flight
sync; it will no longer *kill the channel* doing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp