### PR TITLE
perf(edge): preconnect to cross-origin hosts, make public JSON edge-cacheable

### DIFF
--- a/docs/context/edge-cache-request-varying-headers.md
+++ b/docs/context/edge-cache-request-varying-headers.md
@@ -1,0 +1,135 @@
+# Edge-caching a response whose HEADERS vary by request
+
+_Last verified: 2026-08-18 against prod (`api.engram.page`, `mcp.engram.page`,
+`app.engram.page`, `staging.engram.page`). Shipped in Engram#1422 +
+engram-infra#1014._
+
+## When you need this
+
+You are about to make something edge-cacheable — adding
+`Cache-Control: public` to a route, or adding a hostname or path to the
+Cloudflare Cache Rule in `engram-infra/main/cloudflare/cache.tf`.
+
+## The one idea
+
+"The body is identical for every caller" is **not** sufficient for a shared
+cache. The headers have to be identical too, and ours were not.
+
+`EngramWeb.Plugs.CORS` echoes the request `Origin` back whenever it is in the
+`:cors_origin` allowlist (`lib/engram_web/plugs/cors.ex`, `resolve_origin/1`).
+Verified against prod:
+
+```
+Origin: https://mcp.engram.page   -> access-control-allow-origin: https://mcp.engram.page
+Origin: https://api.engram.page   -> access-control-allow-origin: https://api.engram.page
+Origin: https://evil.example.com  -> access-control-allow-origin: https://app.engram.page
+```
+
+Cache that and the edge stores **one** entry with whichever origin happened to
+fill it. For the next 300s every other client gets that same header replayed,
+so a browser on `app.engram.page` receives a document stamped for
+`mcp.engram.page` and the fetch is CORS-blocked. Which client "wins" is a
+race, so the symptom is intermittent, region-dependent, and clears itself in
+five minutes — the worst possible bug report.
+
+**`Vary: Origin` does NOT fix this.** Cloudflare honours `Vary` only for
+`Accept-Encoding` on standard caching; any other `Vary` value is ignored and
+the entry stays shared. This is the trap: `Vary` is the textbook answer, it
+looks like it works, and at our edge it does nothing.
+
+The fix is to make the header **constant** on exactly the routes that are
+cached. `EngramWeb.Router`'s `:public_cacheable` pipeline pins
+`access-control-allow-origin: *` alongside the `Cache-Control`, and both live
+in one pipeline specifically so a third cached endpoint cannot pick up half
+the pair.
+
+`*` is safe **here** and is not a general licence: these are unauthenticated
+RFC 8414 / RFC 9728 discovery documents and the OpenAPI spec, all fetchable by
+anyone with no `Origin` at all. `*` is also incompatible with credentialed
+CORS by construction, so it cannot widen access to anything holding a token.
+Do not copy the `*` onto a route that answers differently per user.
+
+## The checklist before caching anything
+
+1. **Diff the full response headers, not the body**, from two different
+   origins and two different hosts. Anything that differs is a poisoning
+   vector.
+2. **Check every host the path resolves on.** Same path, same zone, totally
+   different response — measured 2026-08-18:
+
+   | host | `/.well-known/oauth-*` | `/api/openapi` | `/openapi` |
+   |---|---|---|---|
+   | `api.engram.page` | 192 B (doc) | 72408 B | 72408 B |
+   | `mcp.engram.page` | 184 B (doc) | 404 | 404 |
+   | `app.engram.page` | **4339 B (SPA shell)** | **4339 B (SPA)** | **4339 B (SPA)** |
+   | `staging.engram.page` | 200 B (doc) | 72408 B | **3940 B (SPA)** |
+
+   A zone-wide Cache Rule would therefore have made the **SPA HTML shell**
+   edge-cacheable on `app` under three paths. The shell sends no explicit
+   `Cache-Control` (see `frontend/public/_headers`: the `/*` block sets
+   security headers only), so `respect_origin` falls back to Cloudflare's own
+   default TTL and pins a stale shell that survives a deploy and references
+   purged asset hashes. That is an outage produced by a rule whose stated
+   purpose was caching two JSON documents. The rule is now host-scoped to
+   `api` + `mcp`.
+
+3. **Match on the path the EDGE sees, not the one Phoenix routes.**
+   `HostRewrite` maps bare `/openapi` -> `/api/openapi` on `api.engram.page`
+   (`@api_top_segments` in `lib/engram_web/plugs/host_rewrite.ex`). That
+   rewrite happens in Phoenix, *after* the edge has already matched. A rule
+   listing only `/api/openapi` silently leaves the identical 72 KB body
+   uncached on the bare form. It did exactly that until `curl` proved it.
+
+4. **Know that edge and browser TTLs compound.** Both are `respect_origin`, so
+   a browser fetching at edge-second 299 caches a further 300s: worst-case
+   staleness per client is ~600s, not the 300s the header suggests.
+
+## Things that are true and easy to get backwards
+
+- **`Cache-Control: public` alone does nothing at our edge.** Cloudflare's
+  default Cache Level only treats known static file extensions as eligible, so
+  extensionless JSON stays `cf-cache-status: DYNAMIC` regardless of what the
+  origin sends. The app header and the Cache Rule are each useless alone. If
+  you see `DYNAMIC` after deploying, suspect the rule (or its host list), not
+  the header.
+- **Ordering between the two repos is safe either way.** If the infra rule
+  lands first, the app is still sending Phoenix's default `private`, and
+  `respect_origin` declines to cache. No window of wrongness.
+- **`x-request-id` is cached with the body**, so a hit replays the request id
+  of whichever request filled the cache. Use `cf-ray` to correlate these
+  endpoints; the id is still accurate on a MISS.
+- **`crossorigin` on a `rel=preconnect` is about connection POOLS, not
+  credentials.** A hint naming the wrong pool is silently wasted — the real
+  request opens a second connection while the hinted one idles. Verified that
+  `@clerk/shared`'s `loadClerkJsScript.mjs` sets `crossOrigin: "anonymous"`,
+  and saas API auth is a bearer header rather than a cookie, so bare
+  `crossorigin` (= anonymous) is right for both hints in
+  `frontend/public/_headers`. The one credentialed caller,
+  `local-auth-provider.tsx`, is self-host and same-origin.
+- **Early Hints are replayed per URL.** Cloudflare only sends `103` for a URL
+  whose `Link` headers it has already observed, so a *novel* deep link gets no
+  early-hints acceleration. The `Link` header still works as an ordinary
+  response header there, so the preconnect happens — just not early.
+
+## Regression cover
+
+`test/engram_web/public_cacheable_headers_test.exs`. Two things worth knowing
+if you touch it:
+
+- It configures a **prod-shaped `:cors_origin` list**. The test-env default is
+  `"*"`, under which the echo bug cannot reproduce at all — a test written
+  against the default would have passed on the broken code.
+- The health-check assertion asserts the **property** ("nothing `public`")
+  rather than "is not this one exact string". A cached health check reports
+  healthy from the edge while the app is down, which is worse than having no
+  health check, and an exact-string assertion would miss
+  `public, max-age=60`.
+
+The test was confirmed to fail against the unfixed code before being trusted.
+
+## Related
+
+- `engram-infra/main/cloudflare/cache.tf` — the paired Cache Rule
+- `frontend/public/_headers` — preconnect hints + SPA cache headers
+- `docs/context/oauth-discovery-urls-behind-edge-tls.md` — the other way these
+  discovery documents go wrong at the edge

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -45,11 +45,26 @@
   # header starts both while the bundle is still in flight, so by the time the
   # code asks, the pipe is warm.
   #
-  # `crossorigin` is REQUIRED, not decorative. Without it the browser opens an
-  # unauthenticated connection; the script fetch and the credentialed API/WS
-  # calls both need an authenticated one, so it would open a SECOND connection
-  # and the hint would buy nothing while costing a socket. Silent, and it looks
-  # correct in devtools.
+  # `crossorigin` is REQUIRED, not decorative, and the reason is NOT "these are
+  # credentialed" — they are not. A preconnect opens a connection into a
+  # specific pool, and a hint that names the wrong pool is silently wasted: the
+  # real request opens a SECOND connection while the hinted one idles. So the
+  # flag has to match what each origin's real fetch actually does. Verified,
+  # rather than assumed, for both:
+  #
+  #   * Clerk — `@clerk/shared`'s loader sets `crossOrigin: "anonymous"` on the
+  #     script tag it injects (loadClerkJsScript.mjs). Bare `crossorigin` IS
+  #     anonymous, so this matches.
+  #   * api.engram.page — saas auth is a Clerk JWT in an `Authorization`
+  #     header, never a cookie, so these are plain (non-credentialed) CORS
+  #     requests, which also use the anonymous pool.
+  #
+  # The one place credentials DO ride cross-origin is `local-auth-provider.tsx`
+  # (`credentials: "include"` on the refresh call) — that is the SELF-HOST local
+  # auth path, where `VITE_API_BASE` is empty and the call is same-origin, and
+  # self-host never serves this file anyway. If saas ever moves to a cookie on
+  # api.engram.page, this becomes `crossorigin="use-credentials"` or the hint
+  # goes back to buying nothing.
   #
   # This file is saas-only by construction (Phoenix does not read it, per the
   # header comment above), which is the reason this lives here rather than as a
@@ -58,11 +73,18 @@
   # connection to Clerk on every page load.
   #
   # On `/*` rather than just `/` and `/index.html` on purpose: a deep link
-  # (`/notes/<id>`, the shared-link case) is matched by request path, so it
-  # would miss a `/`-scoped rule, and that is exactly the cold-connection case
-  # where the win is largest. The cost of it also landing on `/assets/*` is nil:
+  # (`/notes/<id>`, the shared-link case) is matched by request path and would
+  # miss a `/`-scoped rule. The cost of it also landing on `/assets/*` is nil:
   # browsers only act on Link hints for the main document, and HTTP/2 HPACK
   # indexes the repeated identical header down to a couple of bytes.
+  #
+  # Calibration on the deep-link case, because it is easy to overclaim: the
+  # header always works as an ordinary response header, so the preconnect does
+  # start as soon as the browser parses the response. What a NOVEL deep link
+  # does not get is the `103 Early Hints` acceleration on top — Cloudflare
+  # replays hints it has already observed FOR THAT URL, so the first visitor to
+  # `/notes/<uuid>` primes it and later ones benefit. The win here is real but
+  # smaller than on `/`, which is warm essentially always.
   Link: <https://clerk.engram.page>; rel=preconnect; crossorigin
   Link: <https://api.engram.page>; rel=preconnect; crossorigin
   X-Frame-Options: DENY

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -33,6 +33,38 @@
   Cache-Control: no-cache
 
 /*
+  # Warm the two cross-origin connections the app cannot start without, in
+  # parallel with downloading the bundle instead of serially after it.
+  #
+  # Measured on prod before adding this: ~95ms of DNS + TCP + TLS to each of
+  # these before byte one (~1s on a cold path). The browser cannot begin that
+  # handshake until it discovers it needs the origin, and both discoveries are
+  # LATE: `clerk-auth-provider` is a lazy `import()`, so the Clerk origin is
+  # unknown until the main bundle has downloaded AND parsed, and api.engram.page
+  # is not dialed until the first query fires. A `Link: rel=preconnect` response
+  # header starts both while the bundle is still in flight, so by the time the
+  # code asks, the pipe is warm.
+  #
+  # `crossorigin` is REQUIRED, not decorative. Without it the browser opens an
+  # unauthenticated connection; the script fetch and the credentialed API/WS
+  # calls both need an authenticated one, so it would open a SECOND connection
+  # and the hint would buy nothing while costing a socket. Silent, and it looks
+  # correct in devtools.
+  #
+  # This file is saas-only by construction (Phoenix does not read it, per the
+  # header comment above), which is the reason this lives here rather than as a
+  # <link> in index.html: index.html is shared with the self-host build, and a
+  # self-hoster who deliberately runs no Clerk should not be made to open a
+  # connection to Clerk on every page load.
+  #
+  # On `/*` rather than just `/` and `/index.html` on purpose: a deep link
+  # (`/notes/<id>`, the shared-link case) is matched by request path, so it
+  # would miss a `/`-scoped rule, and that is exactly the cold-connection case
+  # where the win is largest. The cost of it also landing on `/assets/*` is nil:
+  # browsers only act on Link hints for the main document, and HTTP/2 HPACK
+  # indexes the repeated identical header down to a couple of bytes.
+  Link: <https://clerk.engram.page>; rel=preconnect; crossorigin
+  Link: <https://api.engram.page>; rel=preconnect; crossorigin
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   # `origin`, not `strict-origin-when-cross-origin`: the latter sends the FULL

--- a/lib/engram_web/controllers/well_known_controller.ex
+++ b/lib/engram_web/controllers/well_known_controller.ex
@@ -29,27 +29,19 @@ defmodule EngramWeb.WellKnownController do
   # made that non-negotiable: `private` forbids a shared cache from storing it
   # at all, so the edge reported `cf-cache-status: DYNAMIC` and passed through.
   #
-  # Correctness note: the body VARIES BY HOST. Cloudflare's cache key includes
-  # the hostname, so `mcp.` and `app.` get separate entries and cannot be
-  # crossed. Do not "optimise" this into a host-independent constant.
+  # The headers themselves are set by the `:public_cacheable` pipeline in the
+  # router, shared with `/api/openapi`, NOT here. They belong together because
+  # caching these safely requires a second, non-obvious header change (pinning
+  # `access-control-allow-origin` to a constant, since the CORS plug otherwise
+  # echoes the request Origin into a shared cache entry) — see the long comment
+  # on `public_cacheable_headers/2`. Splitting them across two files is how one
+  # of the pair gets changed alone.
   #
-  # TTL is deliberately short. These documents carry `authorization_endpoint`
-  # and `registration_endpoint`; a client that caches a stale endpoint after we
-  # move one fails auth in a way that looks like a client bug. Five minutes
-  # removes essentially all of the repeat-connect cost (a client reconnecting
-  # within a session is already a hit) while bounding staleness to something a
-  # deploy can outrun. A day would buy almost nothing more and take real risk.
-  #
-  # NOTE: this header alone is not sufficient at the edge. Cloudflare's default
-  # Cache Level only treats known static extensions as eligible, so an
-  # extensionless JSON path stays DYNAMIC no matter what we send. The paired
-  # Cache Rule lives in engram-infra (`main/cloudflare/cache.tf`). If you see
-  # DYNAMIC here after deploying, that rule is missing, not this header.
-  @discovery_cache_control "public, max-age=300"
-
-  defp cacheable(conn) do
-    Plug.Conn.put_resp_header(conn, "cache-control", @discovery_cache_control)
-  end
+  # Correctness note that constrains BOTH: the body VARIES BY HOST.
+  # Cloudflare's cache key includes the hostname, so `mcp.` and `app.` get
+  # separate entries and cannot be crossed. Do not "optimise" this into a
+  # host-independent constant, and do not add a Cache Rule that normalises the
+  # host out of the cache key.
 
   # RFC 9728 `resource_documentation` — where a developer is sent to learn how
   # to use this resource. Optional in the spec, which is exactly why a link that
@@ -72,7 +64,7 @@ defmodule EngramWeb.WellKnownController do
   def protected_resource(conn, _params) do
     base = OAuthMetadata.base_url(conn)
 
-    json(cacheable(conn), %{
+    json(conn, %{
       # The advertised `resource` must be the URL at which THIS host actually
       # serves MCP — RFC 9728 lets us advertise only one, and strict clients
       # bind the token audience to it (and self-check it == the dialed URL).
@@ -103,7 +95,7 @@ defmodule EngramWeb.WellKnownController do
     base = OAuthMetadata.base_url(conn)
 
     json(
-      cacheable(conn),
+      conn,
       %{
         issuer: base,
         authorization_endpoint: base <> "/oauth/authorize",

--- a/lib/engram_web/controllers/well_known_controller.ex
+++ b/lib/engram_web/controllers/well_known_controller.ex
@@ -17,6 +17,40 @@ defmodule EngramWeb.WellKnownController do
 
   alias EngramWeb.OAuthMetadata
 
+  # Edge-cacheable. Both documents are pure functions of (dialed host, deploy):
+  # every value is either a compile-time literal or derived from
+  # `OAuthMetadata.base_url/1`, which resolves from the Host header against the
+  # `:cors_origin` allowlist. No user, no token, no request body. Verified by
+  # diffing two live responses byte-for-byte.
+  #
+  # Without this every MCP client connect (Claude, Cursor, ChatGPT probe these
+  # on EVERY connect, before auth) crossed Cloudflare -> ALB -> Fargate to
+  # render a constant. Phoenix's default `max-age=0, private, must-revalidate`
+  # made that non-negotiable: `private` forbids a shared cache from storing it
+  # at all, so the edge reported `cf-cache-status: DYNAMIC` and passed through.
+  #
+  # Correctness note: the body VARIES BY HOST. Cloudflare's cache key includes
+  # the hostname, so `mcp.` and `app.` get separate entries and cannot be
+  # crossed. Do not "optimise" this into a host-independent constant.
+  #
+  # TTL is deliberately short. These documents carry `authorization_endpoint`
+  # and `registration_endpoint`; a client that caches a stale endpoint after we
+  # move one fails auth in a way that looks like a client bug. Five minutes
+  # removes essentially all of the repeat-connect cost (a client reconnecting
+  # within a session is already a hit) while bounding staleness to something a
+  # deploy can outrun. A day would buy almost nothing more and take real risk.
+  #
+  # NOTE: this header alone is not sufficient at the edge. Cloudflare's default
+  # Cache Level only treats known static extensions as eligible, so an
+  # extensionless JSON path stays DYNAMIC no matter what we send. The paired
+  # Cache Rule lives in engram-infra (`main/cloudflare/cache.tf`). If you see
+  # DYNAMIC here after deploying, that rule is missing, not this header.
+  @discovery_cache_control "public, max-age=300"
+
+  defp cacheable(conn) do
+    Plug.Conn.put_resp_header(conn, "cache-control", @discovery_cache_control)
+  end
+
   # RFC 9728 `resource_documentation` — where a developer is sent to learn how
   # to use this resource. Optional in the spec, which is exactly why a link that
   # does not resolve is worse than no link: a client following it lands nowhere.
@@ -38,7 +72,7 @@ defmodule EngramWeb.WellKnownController do
   def protected_resource(conn, _params) do
     base = OAuthMetadata.base_url(conn)
 
-    json(conn, %{
+    json(cacheable(conn), %{
       # The advertised `resource` must be the URL at which THIS host actually
       # serves MCP — RFC 9728 lets us advertise only one, and strict clients
       # bind the token audience to it (and self-check it == the dialed URL).
@@ -69,7 +103,7 @@ defmodule EngramWeb.WellKnownController do
     base = OAuthMetadata.base_url(conn)
 
     json(
-      conn,
+      cacheable(conn),
       %{
         issuer: base,
         authorization_endpoint: base <> "/oauth/authorize",

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -106,7 +106,14 @@ defmodule EngramWeb.Router do
   # bare `pipe_through` can't supply, so it lives in its own pipeline.
   pipeline :openapi do
     plug OpenApiSpex.Plug.PutApiSpec, module: EngramWeb.ApiSpec
-    plug :cache_public_deploy_static
+  end
+
+  # Applied to the handful of PUBLIC, UNAUTHENTICATED documents that are pure
+  # functions of (dialed host, deploy) and are cached at the Cloudflare edge:
+  # the OAuth discovery documents and the OpenAPI spec. One pipeline for all of
+  # them so the cache header and the CORS correction below cannot drift apart.
+  pipeline :public_cacheable do
+    plug :public_cacheable_headers
   end
 
   # `/api/openapi` is ~72 KB of JSON that `OpenApiSpex.Plug.RenderSpec`
@@ -126,8 +133,46 @@ defmodule EngramWeb.Router do
   # docs reader fetches it once per page and 5 minutes already covers a
   # browsing session, while a short window keeps a bad deploy from being
   # pinned at the edge.
-  defp cache_public_deploy_static(conn, _opts) do
-    Plug.Conn.put_resp_header(conn, "cache-control", "public, max-age=300")
+  #
+  # The `access-control-allow-origin` override is a CORRECTNESS REQUIREMENT of
+  # caching these at all, not a loosening. `EngramWeb.Plugs.CORS` runs in the
+  # endpoint (before this router) and ECHOES the request Origin whenever it is
+  # in the `:cors_origin` allowlist — verified against prod: sending
+  # `Origin: https://mcp.engram.page` returns that same value, while an
+  # unlisted origin gets the canonical `https://app.engram.page`. So the
+  # response VARIES BY REQUEST while its body does not.
+  #
+  # A shared cache storing one such response replays that origin to everyone:
+  # whichever client fills the cache decides who else can read it for the next
+  # 300s, and a browser on `app.engram.page` gets a document stamped
+  # `access-control-allow-origin: https://mcp.engram.page` and is CORS-blocked.
+  #
+  # `Vary: Origin` does NOT fix this. Cloudflare honours `Vary` only for
+  # `Accept-Encoding` on standard caching; any other `Vary` value is ignored,
+  # so the entry would still be shared across origins.
+  #
+  # `*` is the correct answer rather than a concession: these documents are
+  # unauthenticated public metadata (RFC 8414 / RFC 9728 both expect them to be
+  # openly fetchable), carry no user data and no secrets, and are already
+  # readable by anyone without an Origin at all. Nothing here is credentialed,
+  # and `*` is incompatible with credentialed CORS by construction, so this
+  # cannot widen access to anything that needs a token.
+  #
+  # Consequence to know: `x-request-id` is cached along with the body, so a hit
+  # replays the request id of whichever request filled the cache. Use `cf-ray`
+  # to correlate these specific endpoints; the id is still accurate on a MISS.
+  #
+  # This header alone is NOT sufficient at the edge. Cloudflare's default Cache
+  # Level only treats known static file extensions as eligible, so these
+  # extensionless JSON paths stay `cf-cache-status: DYNAMIC` no matter what we
+  # send here. The paired Cache Rule lives in engram-infra
+  # (`main/cloudflare/cache.tf`) and is host-scoped to api/mcp, because the same
+  # paths return the SPA shell on app/staging. If you see DYNAMIC after
+  # deploying, that rule is missing or its host list is wrong — not this header.
+  defp public_cacheable_headers(conn, _opts) do
+    conn
+    |> Plug.Conn.put_resp_header("cache-control", "public, max-age=300")
+    |> Plug.Conn.put_resp_header("access-control-allow-origin", "*")
   end
 
   # SPA shell pipeline — HTML responses with strict browser-security headers.
@@ -194,7 +239,7 @@ defmodule EngramWeb.Router do
   # MCP clients (Claude Connectors, Cursor, ChatGPT custom GPTs, etc.)
   # probe these to learn how to negotiate auth against /api/mcp.
   scope "/.well-known", EngramWeb do
-    pipe_through :api
+    pipe_through [:api, :public_cacheable]
 
     get "/oauth-protected-resource", WellKnownController, :protected_resource
     get "/oauth-authorization-server", WellKnownController, :authorization_server
@@ -244,7 +289,7 @@ defmodule EngramWeb.Router do
   # No EngramWeb alias on this scope: RenderSpec is an open_api_spex plug,
   # not an Engram controller.
   scope "/api" do
-    pipe_through [:api, :openapi]
+    pipe_through [:api, :openapi, :public_cacheable]
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
   end
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -106,6 +106,28 @@ defmodule EngramWeb.Router do
   # bare `pipe_through` can't supply, so it lives in its own pipeline.
   pipeline :openapi do
     plug OpenApiSpex.Plug.PutApiSpec, module: EngramWeb.ApiSpec
+    plug :cache_public_deploy_static
+  end
+
+  # `/api/openapi` is ~72 KB of JSON that `OpenApiSpex.Plug.RenderSpec`
+  # re-renders on EVERY request, and it changes only when a deploy changes the
+  # spec. It was going out as `max-age=0, private, must-revalidate` (Phoenix's
+  # default), so the edge reported `cf-cache-status: DYNAMIC` and every docs
+  # page load, API explorer and codegen run crossed Cloudflare -> ALB ->
+  # Fargate to rebuild a constant.
+  #
+  # Safe for the CI drift gate: that gate generates the spec locally with
+  # `mix openapi.spec.json` and diffs it against the committed `openapi.json`
+  # (verify.yml). It never fetches this endpoint, so a cached copy cannot make
+  # it pass on stale content.
+  #
+  # Same 5 minute TTL as the OAuth discovery documents, deliberately. This
+  # payload is far bigger so a longer TTL is tempting, but it buys little: a
+  # docs reader fetches it once per page and 5 minutes already covers a
+  # browsing session, while a short window keeps a bad deploy from being
+  # pinned at the edge.
+  defp cache_public_deploy_static(conn, _opts) do
+    Plug.Conn.put_resp_header(conn, "cache-control", "public, max-age=300")
   end
 
   # SPA shell pipeline — HTML responses with strict browser-security headers.

--- a/test/engram_web/controllers/well_known_controller_test.exs
+++ b/test/engram_web/controllers/well_known_controller_test.exs
@@ -29,6 +29,17 @@ defmodule EngramWeb.WellKnownControllerTest do
       assert ["application/json" <> _] = get_resp_header(conn, "content-type")
     end
 
+    test "is edge-cacheable, and not marked private", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-protected-resource")
+
+      # `private` is the specific thing that must not come back: it forbids a
+      # SHARED cache (Cloudflare) from storing the response at all, which is
+      # what pinned every MCP client connect to a Fargate round trip. Phoenix's
+      # default is `max-age=0, private, must-revalidate`, so a future change
+      # that drops the explicit header regresses silently and invisibly.
+      assert ["public, max-age=300"] = get_resp_header(conn, "cache-control")
+    end
+
     # `resource_documentation` is where a developer is sent to learn how to use
     # this resource, so a link that does not resolve is worse than the field
     # being absent — RFC 9728 makes it optional precisely so you can omit it.
@@ -81,6 +92,14 @@ defmodule EngramWeb.WellKnownControllerTest do
   end
 
   describe "GET /.well-known/oauth-authorization-server" do
+    test "is edge-cacheable, and not marked private", %{conn: conn} do
+      # Same contract as the protected-resource document above. Both are probed
+      # by every MCP client on every connect, so both must stay shared-cacheable.
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+
+      assert ["public, max-age=300"] = get_resp_header(conn, "cache-control")
+    end
+
     test "returns RFC 8414 server metadata with required fields", %{conn: conn} do
       conn = get(conn, "/.well-known/oauth-authorization-server")
       body = json_response(conn, 200)

--- a/test/engram_web/openapi_endpoint_test.exs
+++ b/test/engram_web/openapi_endpoint_test.exs
@@ -7,4 +7,24 @@ defmodule EngramWeb.OpenApiEndpointTest do
     assert %{"openapi" => "3.0.0", "paths" => paths} = json_response(conn, 200)
     assert Map.has_key?(paths, "/api/health")
   end
+
+  test "the spec is edge-cacheable, and not marked private", %{conn: conn} do
+    # ~72 KB re-rendered per request, changing only on deploy. `private` is the
+    # specific regression to catch: it forbids a SHARED cache (Cloudflare) from
+    # storing the response at all, and it is what Phoenix sends by default, so
+    # dropping the pipeline plug would silently restore a full origin round trip
+    # for every docs page load and codegen run.
+    conn = get(conn, "/api/openapi")
+
+    assert ["public, max-age=300"] = get_resp_header(conn, "cache-control")
+  end
+
+  test "health checks are NOT cached", %{conn: conn} do
+    # Guards the blast radius of the `:openapi` pipeline plug and of any future
+    # broad cache rule. A cached health check reports healthy from the edge
+    # while the app is down, which is worse than having no health check.
+    conn = get(conn, "/api/health")
+
+    refute get_resp_header(conn, "cache-control") == ["public, max-age=300"]
+  end
 end

--- a/test/engram_web/openapi_endpoint_test.exs
+++ b/test/engram_web/openapi_endpoint_test.exs
@@ -19,12 +19,8 @@ defmodule EngramWeb.OpenApiEndpointTest do
     assert ["public, max-age=300"] = get_resp_header(conn, "cache-control")
   end
 
-  test "health checks are NOT cached", %{conn: conn} do
-    # Guards the blast radius of the `:openapi` pipeline plug and of any future
-    # broad cache rule. A cached health check reports healthy from the edge
-    # while the app is down, which is worse than having no health check.
-    conn = get(conn, "/api/health")
-
-    refute get_resp_header(conn, "cache-control") == ["public, max-age=300"]
-  end
+  # Health-check cacheability and the CORS pinning both live in
+  # EngramWeb.PublicCacheableHeadersTest, which asserts the PROPERTY ("nothing
+  # public") rather than one exact string, and needs async: false to configure
+  # a prod-shaped :cors_origin allowlist.
 end

--- a/test/engram_web/public_cacheable_headers_test.exs
+++ b/test/engram_web/public_cacheable_headers_test.exs
@@ -1,0 +1,105 @@
+defmodule EngramWeb.PublicCacheableHeadersTest do
+  @moduledoc """
+  The `:public_cacheable` pipeline (router) puts two headers on the public,
+  edge-cached documents, and the SECOND one is the non-obvious half.
+
+  `EngramWeb.Plugs.CORS` echoes the request Origin back whenever it is in the
+  `:cors_origin` allowlist. That is correct for per-request API traffic and
+  fatal for anything a shared cache stores: the response body is identical for
+  every caller, so Cloudflare keeps ONE entry, and whichever client fills it
+  decides the `access-control-allow-origin` every other client sees for the
+  next 300s. A browser on `app.engram.page` then receives a document stamped
+  for `mcp.engram.page` and the fetch is CORS-blocked.
+
+  `Vary: Origin` is not a fix — Cloudflare honours `Vary` only for
+  `Accept-Encoding` — so the pipeline pins the header to a constant `*`
+  instead. These documents are unauthenticated public metadata, so `*` grants
+  nothing that was not already public.
+
+  `async: false`: these tests swap `:cors_origin` in application env.
+  """
+  use EngramWeb.ConnCase, async: false
+
+  @allowlisted "https://mcp.example.test"
+  @cacheable_paths [
+    "/.well-known/oauth-protected-resource",
+    "/.well-known/oauth-authorization-server",
+    "/api/openapi"
+  ]
+
+  setup do
+    prev = Application.get_env(:engram, :cors_origin)
+
+    # A LIST is what makes CORS echo. With the test default (`"*"`) the bug
+    # cannot reproduce at all, which is why these tests configure prod's shape
+    # rather than trusting the default.
+    Application.put_env(:engram, :cors_origin, [
+      "https://app.example.test",
+      @allowlisted
+    ])
+
+    on_exit(fn ->
+      case prev do
+        nil -> Application.delete_env(:engram, :cors_origin)
+        value -> Application.put_env(:engram, :cors_origin, value)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "edge-cached documents" do
+    test "pin access-control-allow-origin to a constant, ignoring the request Origin", %{
+      conn: conn
+    } do
+      for path <- @cacheable_paths do
+        resp =
+          conn
+          |> put_req_header("origin", @allowlisted)
+          |> get(path)
+
+        assert get_resp_header(resp, "access-control-allow-origin") == ["*"],
+               "#{path} echoed the request Origin into a cacheable response"
+      end
+    end
+
+    test "are shared-cacheable and never private", %{conn: conn} do
+      for path <- @cacheable_paths do
+        resp = get(conn, path)
+
+        assert get_resp_header(resp, "cache-control") == ["public, max-age=300"],
+               "#{path} is not edge-cacheable"
+      end
+    end
+  end
+
+  describe "everything else" do
+    test "still echoes an allowlisted Origin", %{conn: conn} do
+      # The override must be scoped to the cached documents. If it leaked into
+      # the `:api` pipeline it would silently break every browser client that
+      # relies on an exact-origin match, so pin the normal behaviour too.
+      resp =
+        conn
+        |> put_req_header("origin", @allowlisted)
+        |> get("/api/health")
+
+      assert get_resp_header(resp, "access-control-allow-origin") == [@allowlisted]
+    end
+
+    test "health checks are not shared-cacheable", %{conn: conn} do
+      # Deliberately stronger than "is not exactly `public, max-age=300`": any
+      # `public` directive at all lets the edge serve a cached 200 while the
+      # app is down, which is worse than having no health check. Assert the
+      # property, not one string.
+      cache_control =
+        conn
+        |> get("/api/health")
+        |> get_resp_header("cache-control")
+        |> List.first()
+        |> Kernel.||("")
+
+      refute cache_control =~ "public",
+             "health check is shared-cacheable: #{inspect(cache_control)}"
+    end
+  end
+end


### PR DESCRIPTION
Origin-side half of an edge-performance pair. The Cloudflare half is **engram-app/engram-infra#1014** — neither half does much alone, see "Why two PRs" below.

## What and why

### 1. Preconnect to the two cross-origin hosts

The SPA is on `app.engram.page` but cannot do anything without **two other origins**: `clerk.engram.page` (auth) and `api.engram.page` (every query + the WS). It discovers both **late** — `clerk-auth-provider` is a lazy `import()`, so the Clerk origin is unknown until the main bundle has downloaded *and* parsed.

Measured on prod before this change:

```
tcp=1.026s  tls=1.078s   ← cold
tcp=0.024s  tls=0.092s   ← warm
```

~95 ms per hop before byte one, ~1 s cold — all of it **serial dead time** on the sign-in path. A response `Link: rel=preconnect` header starts both handshakes while the bundle is still downloading.

Two deliberate choices:
- **`_headers`, not a `<link>` in `index.html`.** `index.html` is shared with the self-host build. A self-hoster who deliberately runs no Clerk should not open a connection to Clerk on every page load. Phoenix does not read `_headers`, so this is SaaS-only by construction.
- **`crossorigin` is required**, not decorative. Without it the browser opens an *unauthenticated* connection, then a second authenticated one for the real credentialed fetch — the hint buys nothing while costing a socket, and it looks correct in devtools.

### 2 & 3. Make the deploy-static public JSON cacheable

| Path | Size | Was |
|---|---|---|
| `/.well-known/oauth-authorization-server` | small | `DYNAMIC` |
| `/.well-known/oauth-protected-resource` | small | `DYNAMIC` |
| `/api/openapi` | **~72 KB** | `DYNAMIC` |

Every MCP client (Claude, Cursor, ChatGPT) probes the discovery documents on **every connect, before auth**. `/api/openapi` is re-rendered by OpenApiSpex on every request. All three are pure functions of (host, deploy) — I verified the discovery responses are byte-identical across requests.

Phoenix's default `max-age=0, private, must-revalidate` is what pinned them: **`private` forbids a shared cache from storing the response at all**, so Cloudflare passed straight through to Fargate every time.

## Correctness notes

- **The discovery bodies vary by `Host`** (`OAuthMetadata.base_url/1` resolves the dialed host against the `:cors_origin` allowlist). Cloudflare's cache key includes hostname, so `mcp.` and `app.` get separate entries and cannot be crossed. Called out in the code so nobody "optimises" it into a host-independent constant.
- **The CI OpenAPI drift gate is unaffected.** It generates the spec locally with `mix openapi.spec.json` and diffs the committed `openapi.json`; it never fetches this endpoint, so a cached copy cannot make it pass on stale content.
- **TTL is 5 minutes on all three, deliberately.** These carry `authorization_endpoint` / `registration_endpoint`; a client caching a stale endpoint after we move one fails auth in a way that looks like a client bug. Five minutes takes essentially all of the repeat-connect win while bounding staleness to something a deploy outruns.

## Why two PRs

The app header alone does nothing at the edge: Cloudflare's default Cache Level only treats known static **file extensions** as eligible, so extensionless JSON stays `DYNAMIC` regardless of what the origin sends. The Cache Rule in engram-infra#1014 grants eligibility; this PR decides the TTL. Merge order does not matter — neither half breaks anything on its own.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` — no issues
- [x] `mix sobelow --exit low` — clean
- [x] `mix test` — 1 property, **4635 tests, 0 failures**
- [x] New tests pin `cache-control` on all three endpoints
- [x] New test asserts **`/api/health` is NOT cached** — a cached health check reports healthy from the edge while the app is down, the classic broad-cache-rule outage

After both merge, expect `cf-cache-status: HIT` on a second request to the discovery docs and `/api/openapi`, and a `103` early hint on `app.engram.page`.