### PR TITLE
fix(security): always mark the refresh cookie Secure, pin CORS by path not route

### DIFF
--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -1,5 +1,5 @@
-Config.CSP: Missing Content-Security-Policy,lib/engram_web/router.ex:195,7241304
-Config.CSRFRoute: CSRF via Action Reuse,lib/engram_web/router.ex:608,612C31C
+Config.CSP: Missing Content-Security-Policy,lib/engram_web/router.ex:173,43202C
+Config.CSRFRoute: CSRF via Action Reuse,lib/engram_web/router.ex:586,342E9AB
 Config.CSWH: Cross-Site Websocket Hijacking,lib/engram_web/endpoint.ex:9,68D560D
 Config.CSWH: Cross-Site Websocket Hijacking,lib/engram_web/endpoint.ex:30,6F8AC00
 Config.CSWH: Cross-Site Websocket Hijacking,lib/engram_web/endpoint.ex:45,6EA19F5

--- a/docs/context/edge-cache-request-varying-headers.md
+++ b/docs/context/edge-cache-request-varying-headers.md
@@ -37,11 +37,27 @@ five minutes — the worst possible bug report.
 the entry stays shared. This is the trap: `Vary` is the textbook answer, it
 looks like it works, and at our edge it does nothing.
 
-The fix is to make the header **constant** on exactly the routes that are
-cached. `EngramWeb.Router`'s `:public_cacheable` pipeline pins
-`access-control-allow-origin: *` alongside the `Cache-Control`, and both live
-in one pipeline specifically so a third cached endpoint cannot pick up half
-the pair.
+The fix is to make the header **constant**, and to key that on **path, not
+route**. `EngramWeb.Plugs.CORS` returns `*` for `@cacheable_prefixes` /
+`@cacheable_exact`, which mirror the Cache Rule; the router's
+`:public_cacheable` pipeline only sets `Cache-Control`.
+
+Pinning it per-route (the first attempt) leaves a reachable gap, because the
+edge matches by prefix and a router pipeline only runs for a matched route.
+Verified against prod:
+
+```
+GET /.well-known/oauth-bogus-does-not-exist
+  -> 404
+  -> access-control-allow-origin: https://mcp.engram.page   # echoed
+  -> cf-cache-status: BYPASS                                # the rule DID match
+```
+
+`BYPASS` is the tell: the edge considered the path cacheable and declined only
+because Phoenix's 404 happens to send `private`. That is incidental protection.
+Give any fallback a `public` cache-control later and the poisoning returns
+through a path nobody thinks of as an endpoint. Matching the app's predicate to
+the edge's removes the gap instead of depending on a 404's headers.
 
 `*` is safe **here** and is not a general licence: these are unauthenticated
 RFC 8414 / RFC 9728 discovery documents and the OpenAPI spec, all fetchable by
@@ -95,6 +111,15 @@ Do not copy the `*` onto a route that answers differently per user.
 - **Ordering between the two repos is safe either way.** If the infra rule
   lands first, the app is still sending Phoenix's default `private`, and
   `respect_origin` declines to cache. No window of wrongness.
+- **A cookie's `Secure` flag is decided by the CANONICAL scheme, not the dialed
+  host.** `refresh_cookie_opts/1` in `local_auth_controller.ex` sets `secure`
+  from `Endpoint.url()` alone. Keying it off `conn.host == canonical_host`
+  looks more precise and is worse: it silently drops `Secure` on any *other*
+  TLS hostname in a multi-host `PHX_HOST`, and `SameSite=Lax` does not cover
+  that gap because Lax still rides top-level navigations. The accepted cost is
+  that a plaintext alias can no longer persist a login — the browser takes the
+  201, discards the Secure cookie, and `/api/auth/refresh` 401s an hour later.
+  Serve the alias over TLS; do not reintroduce the host comparison.
 - **`x-request-id` is cached with the body**, so a hit replays the request id
   of whichever request filled the cache. Use `cf-ray` to correlate these
   endpoints; the id is still accurate on a MISS.

--- a/lib/engram_web/controllers/local_auth_controller.ex
+++ b/lib/engram_web/controllers/local_auth_controller.ex
@@ -43,31 +43,37 @@ defmodule EngramWeb.LocalAuthController do
   #      host's scheme. Handled by the host check below rather than ignored:
   #      the alternative (trusting the canonical scheme for every host) breaks
   #      login outright on the plaintext one.
-  defp refresh_cookie_opts(conn) do
-    %URI{scheme: scheme, host: canonical_host} = URI.parse(EngramWeb.Endpoint.url())
+  defp refresh_cookie_opts(_conn) do
+    %URI{scheme: scheme} = URI.parse(EngramWeb.Endpoint.url())
 
-    # BOTH conditions, and the host half is not redundant.
+    # Canonical scheme ONLY. Deliberately not also comparing `conn.host`.
     #
-    # `PHX_HOST` is documented as comma-separated with the FIRST entry
-    # canonical (`.env.example` gives `engram.example.com,10.0.20.5:4000` as an
-    # example), and `HostOrigins.parse/1` admits http AND https for EVERY entry.
-    # So a self-host box is routinely reachable on a TLS public name and a
-    # plaintext LAN address at the same time, and only the canonical one is
-    # described by `Endpoint.url()`.
+    # An earlier version required `conn.host == canonical_host` as well, to
+    # protect the documented mixed deployment: `PHX_HOST` is comma-separated
+    # with the FIRST entry canonical (`.env.example` ships
+    # `engram.example.com,10.0.20.5:4000`), and `HostOrigins.parse/1` admits
+    # http AND https for EVERY entry, so a self-host box is routinely reachable
+    # on a TLS public name and a plaintext LAN address at once. Requiring the
+    # host match kept the LAN user working.
     #
-    # Deriving `secure` from the canonical scheme alone therefore marks the
-    # cookie Secure for the LAN user too. Their login looks fine (201 + a valid
-    # access token), the browser silently discards a Secure cookie sent over
-    # cleartext, and `/api/auth/refresh` 401s forever once that token expires.
-    # Comparing the dialed host keeps the flag tied to the connection it was
-    # actually derived for.
+    # It also silently dropped `Secure` on any OTHER TLS hostname. A self-hoster
+    # serving two HTTPS names got a 30-day refresh token with no `Secure` flag
+    # on the second, and `SameSite=Lax` does not cover that: Lax still sends the
+    # cookie on top-level navigations, so forcing the victim to
+    # `http://second-host/api/auth/refresh` puts it on the wire in cleartext.
     #
-    # Safe against a forged Host: a browser sets Host from the URL the user
-    # navigated to, so an attacker cannot choose the victim's value. And the
-    # only reachable mistake is the SAFE direction — an unexpected host yields
-    # `secure: false`, which is exactly the pre-existing behaviour, never a
-    # downgrade of a cookie that would otherwise be protected.
-    secure = scheme == "https" and conn.host == canonical_host
+    # Chosen trade-off: protect the credential, accept the break. If a
+    # deployment is canonically HTTPS, every refresh cookie it issues is marked
+    # Secure regardless of which host was dialed.
+    #
+    # CONSEQUENCE, so nobody debugs this twice: on a mixed deployment the
+    # plaintext alias no longer works for login persistence. The browser accepts
+    # the 201 and the access token, then silently discards the Secure cookie,
+    # and `/api/auth/refresh` 401s once the access token expires — perhaps an
+    # hour later, far from the cause. That is intended. The fix for an operator
+    # is to serve the alias over TLS too (or drop it from PHX_HOST), NOT to
+    # reintroduce the host comparison.
+    secure = scheme == "https"
 
     Keyword.put(@refresh_cookie_base, :secure, secure)
   end

--- a/lib/engram_web/plugs/cors.ex
+++ b/lib/engram_web/plugs/cors.ex
@@ -12,6 +12,22 @@ defmodule EngramWeb.Plugs.CORS do
 
   import Plug.Conn
 
+  # Paths whose responses Cloudflare is allowed to CACHE, and which therefore
+  # must carry a CONSTANT `access-control-allow-origin`.
+  #
+  # This list has to mirror the Cache Rule in
+  # `engram-infra/main/cloudflare/cache.tf`. Keep them in sync: the edge decides
+  # what to cache by PATH, so anything it may store must be pinned here by PATH
+  # too. Pinning per-ROUTE instead leaves a gap — a request under the prefix
+  # that matches no route (a 404) still gets cached-eligible treatment at the
+  # edge while carrying an echoed Origin. Verified live before this existed:
+  # `GET /.well-known/oauth-bogus` returned `access-control-allow-origin:
+  # <echoed>` with `cf-cache-status: BYPASS`, i.e. the rule matched. Only
+  # Phoenix's default `private` on the 404 kept a poisoned entry out of the
+  # cache, which is incidental protection, not a designed guard.
+  @cacheable_prefixes ["/.well-known/oauth-"]
+  @cacheable_exact ["/api/openapi", "/openapi"]
+
   def init(opts), do: opts
 
   def call(conn, _opts) do
@@ -37,7 +53,31 @@ defmodule EngramWeb.Plugs.CORS do
     |> put_resp_header("access-control-max-age", "86400")
   end
 
-  defp resolve_origin(conn) do
+  # `*` on the edge-cached documents, and this is a CORRECTNESS REQUIREMENT of
+  # caching them rather than a loosening. The echo below is right for per-request
+  # API traffic and fatal for anything a shared cache stores: the body is
+  # identical for every caller, so Cloudflare keeps ONE entry, and whichever
+  # client fills it decides the header every other client sees for the next
+  # 300s. A browser on app.engram.page then gets a document stamped for
+  # mcp.engram.page and the fetch is CORS-blocked.
+  #
+  # `Vary: Origin` is NOT the fix — Cloudflare honours Vary only for
+  # Accept-Encoding, so the entry stays shared.
+  #
+  # `*` is safe HERE specifically: these are unauthenticated public RFC 8414 /
+  # RFC 9728 metadata documents and the OpenAPI spec, all already fetchable by
+  # anyone with no Origin at all, and `*` is incompatible with credentialed CORS
+  # by construction so it cannot widen access to anything holding a token. Do
+  # not extend @cacheable_* to a path that answers differently per user.
+  defp resolve_origin(%Plug.Conn{request_path: path} = conn) do
+    if cacheable_path?(path), do: "*", else: allowlisted_origin(conn)
+  end
+
+  defp cacheable_path?(path) do
+    path in @cacheable_exact or Enum.any?(@cacheable_prefixes, &String.starts_with?(path, &1))
+  end
+
+  defp allowlisted_origin(conn) do
     case Application.get_env(:engram, :cors_origin, "*") do
       "*" ->
         "*"

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -134,33 +134,13 @@ defmodule EngramWeb.Router do
   # browsing session, while a short window keeps a bad deploy from being
   # pinned at the edge.
   #
-  # The `access-control-allow-origin` override is a CORRECTNESS REQUIREMENT of
-  # caching these at all, not a loosening. `EngramWeb.Plugs.CORS` runs in the
-  # endpoint (before this router) and ECHOES the request Origin whenever it is
-  # in the `:cors_origin` allowlist — verified against prod: sending
-  # `Origin: https://mcp.engram.page` returns that same value, while an
-  # unlisted origin gets the canonical `https://app.engram.page`. So the
-  # response VARIES BY REQUEST while its body does not.
-  #
-  # A shared cache storing one such response replays that origin to everyone:
-  # whichever client fills the cache decides who else can read it for the next
-  # 300s, and a browser on `app.engram.page` gets a document stamped
-  # `access-control-allow-origin: https://mcp.engram.page` and is CORS-blocked.
-  #
-  # `Vary: Origin` does NOT fix this. Cloudflare honours `Vary` only for
-  # `Accept-Encoding` on standard caching; any other `Vary` value is ignored,
-  # so the entry would still be shared across origins.
-  #
-  # `*` is the correct answer rather than a concession: these documents are
-  # unauthenticated public metadata (RFC 8414 / RFC 9728 both expect them to be
-  # openly fetchable), carry no user data and no secrets, and are already
-  # readable by anyone without an Origin at all. Nothing here is credentialed,
-  # and `*` is incompatible with credentialed CORS by construction, so this
-  # cannot widen access to anything that needs a token.
-  #
-  # Consequence to know: `x-request-id` is cached along with the body, so a hit
-  # replays the request id of whichever request filled the cache. Use `cf-ray`
-  # to correlate these specific endpoints; the id is still accurate on a MISS.
+  # The OTHER header these paths need — a constant
+  # `access-control-allow-origin` — is NOT set here. It lives in
+  # `EngramWeb.Plugs.CORS`, keyed on PATH, because that is the predicate the
+  # edge uses. A router pipeline only runs for a matched ROUTE, so pinning it
+  # here left a request under `/.well-known/oauth-` that matches no route
+  # getting an echoed Origin on a response the edge already considered
+  # cacheable. See the comment on `@cacheable_prefixes` there.
   #
   # This header alone is NOT sufficient at the edge. Cloudflare's default Cache
   # Level only treats known static file extensions as eligible, so these
@@ -170,9 +150,7 @@ defmodule EngramWeb.Router do
   # paths return the SPA shell on app/staging. If you see DYNAMIC after
   # deploying, that rule is missing or its host list is wrong — not this header.
   defp public_cacheable_headers(conn, _opts) do
-    conn
-    |> Plug.Conn.put_resp_header("cache-control", "public, max-age=300")
-    |> Plug.Conn.put_resp_header("access-control-allow-origin", "*")
+    Plug.Conn.put_resp_header(conn, "cache-control", "public, max-age=300")
   end
 
   # SPA shell pipeline — HTML responses with strict browser-security headers.

--- a/test/engram_web/controllers/local_auth_controller_test.exs
+++ b/test/engram_web/controllers/local_auth_controller_test.exs
@@ -87,26 +87,34 @@ defmodule EngramWeb.LocalAuthControllerTest do
       end)
     end
 
-    test "no Secure flag when the request arrives on a NON-canonical host", %{conn: conn} do
-      # Regression guard. PHX_HOST is comma-separated with the first entry
-      # canonical (`.env.example` ships `engram.example.com,10.0.20.5:4000` as
-      # the example), and HostOrigins admits http AND https for every entry, so
-      # a self-host box is routinely reachable on a TLS public name AND a
-      # plaintext LAN address at once.
+    test "Secure is set on a NON-canonical host too", %{conn: conn} do
+      # Pins the deliberate trade-off, because the obvious "fix" is to make this
+      # test's assertion the opposite.
       #
-      # Deriving `secure` from the canonical scheme alone marked the cookie
-      # Secure for the LAN user too. Login still returned 201 with a valid
-      # access token, so it looked fine, but the browser silently dropped a
-      # Secure cookie sent over cleartext and /api/auth/refresh 401'd forever
-      # once that token expired. Worse than the bug this fix exists for,
-      # because it is a hard break rather than a weakened flag.
+      # PHX_HOST is comma-separated with the first entry canonical
+      # (`.env.example` ships `engram.example.com,10.0.20.5:4000`), and
+      # HostOrigins admits http AND https for every entry, so a self-host box is
+      # routinely reachable on several names at once. An earlier version keyed
+      # `secure` off `conn.host == canonical_host` so the plaintext LAN alias
+      # kept working — and thereby dropped Secure on any OTHER TLS hostname,
+      # handing out a 30-day refresh token in the clear on a host that was
+      # perfectly capable of protecting it. SameSite=Lax does not cover that:
+      # Lax still rides top-level navigations, so a forced navigation to
+      # http://other-host/api/auth/refresh leaks it to the wire.
+      #
+      # The credential wins. A canonically-HTTPS deployment marks every refresh
+      # cookie Secure, whatever host was dialed. The accepted cost is that a
+      # plaintext alias can no longer persist a login: the browser takes the 201
+      # and the access token, silently discards the Secure cookie, and
+      # /api/auth/refresh 401s once the access token expires. Operators fix that
+      # by serving the alias over TLS, not by reintroducing the host check.
       with_endpoint_url("https://engram.example", fn ->
         conn =
           %{conn | host: "10.0.20.5"}
           |> post("/api/auth/register", %{email: "lan@test.com", password: "StrongPass123!"})
 
         assert json_response(conn, 201)
-        refute conn.resp_cookies["refresh_token"].secure
+        assert conn.resp_cookies["refresh_token"].secure == true
       end)
     end
 

--- a/test/engram_web/public_cacheable_headers_test.exs
+++ b/test/engram_web/public_cacheable_headers_test.exs
@@ -73,6 +73,32 @@ defmodule EngramWeb.PublicCacheableHeadersTest do
     end
   end
 
+  describe "paths the edge may cache but no route serves" do
+    test "a 404 under the cached prefix still gets a constant origin", %{conn: conn} do
+      # The gap this closes. The Cloudflare rule matches by PATH PREFIX
+      # (/.well-known/oauth-), the router pins headers per matched ROUTE, and
+      # the difference between those two is reachable. Verified against prod
+      # before the fix: GET /.well-known/oauth-bogus-does-not-exist returned
+      # `access-control-allow-origin: https://mcp.engram.page` (echoed) with
+      # `cf-cache-status: BYPASS` — BYPASS meaning the cache rule DID match and
+      # the edge declined only because Phoenix's 404 happens to send `private`.
+      #
+      # That is incidental protection. Give a fallback a `public` cache-control
+      # someday and the poisoning is back, via a path nobody thinks of as an
+      # endpoint. Pinning in the CORS plug by path removes the gap instead of
+      # relying on the 404's headers.
+      resp =
+        conn
+        |> put_req_header("origin", @allowlisted)
+        |> get("/.well-known/oauth-bogus-does-not-exist")
+
+      assert resp.status == 404
+
+      assert get_resp_header(resp, "access-control-allow-origin") == ["*"],
+             "an unrouted path under the cached prefix echoed the request Origin"
+    end
+  end
+
   describe "everything else" do
     test "still echoes an allowlisted Origin", %{conn: conn} do
       # The override must be scoped to the cached documents. If it leaked into


### PR DESCRIPTION
Two findings from reviewing what #1407 shipped. Both are in code that PR added, so this is a follow-up on my own work rather than a pre-existing bug.

## 1. Refresh cookie lost `Secure` on a second HTTPS hostname

`secure` was `scheme == "https" and conn.host == canonical_host`. The host half existed for a real reason: `PHX_HOST` is comma-separated and `HostOrigins.parse/1` admits http **and** https for every entry, so a self-host box is routinely reachable on a TLS public name and a plaintext LAN address at once — and marking the LAN cookie `Secure` breaks refresh permanently.

But it also silently dropped `Secure` on any *other* TLS hostname. A self-hoster serving two HTTPS names got a 30-day refresh token with no `Secure` flag on the second. `SameSite=Lax` does not close that gap: Lax still rides top-level navigations, so forcing a victim to `http://second-host/api/auth/refresh` puts the token on the wire in cleartext.

Now keyed on the canonical scheme alone, per an explicit call on the trade-off: **protect the credential, accept the break.** The cost is real and documented in both the code comment and the test — a plaintext alias can no longer persist a login, and it fails an hour later at token expiry rather than at login. Operators serve the alias over TLS; they do not put the host comparison back.

## 2. The constant CORS origin was pinned per-route, but the edge caches per-path

The `*` pin lived in a router pipeline, which only runs for a **matched route**. The Cloudflare rule matches by **path prefix**. Verified against prod that the difference is reachable:

```
GET /.well-known/oauth-bogus-does-not-exist
  -> 404
  -> access-control-allow-origin: https://mcp.engram.page   (echoed)
  -> cf-cache-status: BYPASS                                (the rule DID match)
```

`BYPASS` is the tell: the edge considered the path cacheable and declined only because Phoenix's 404 happens to send `private`. That is incidental protection, not a designed guard — give any fallback a `public` cache-control later and the poisoning I just fixed returns through a path nobody thinks of as an endpoint.

Moved the pin into `EngramWeb.Plugs.CORS`, keyed on path, mirroring the edge's own predicate. Unrouted paths under the prefix are now covered, and `access-control-allow-origin` has **one** owner instead of two. The router pipeline keeps only `Cache-Control`.

## Verification

Full local gate green: format, `compile --warnings-as-errors`, `credo --strict`, `sobelow --exit low --skip`, dialyzer, and **4649 tests, 0 failures**.

Both new assertions were confirmed to fail against the unfixed code before being trusted.

Skip list regenerated with `rm` first (it appends, it does not replace) after the router line shift — same 21 findings, only `Config.CSP` 195→173 and `Config.CSRFRoute` 608→586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DhZTrvajwXLrxpSkq1XAp