### PR TITLE
docs(spec): decouple CRDT room creation from writes

### DIFF
--- a/docs/superpowers/specs/2026-08-19-detached-writes-room-decoupling-design.md
+++ b/docs/superpowers/specs/2026-08-19-detached-writes-room-decoupling-design.md
@@ -1,0 +1,227 @@
+# Decoupling CRDT room creation from writes
+
+**Date:** 2026-08-19
+**Repos:** `engram-app/engram` (backend), `engram-app/Engram-obsidian` (plugin, read-only impact)
+**Epic:** #1146 (identity/content converge through different channels)
+**Follows:** #1409 / #1424 (genesis seed detached), which piloted this pattern for note creation
+
+> **Placement note:** this belongs in the Engram vault at
+> `50 Engineering/_Superpowers Specs/`. It lives here temporarily because the
+> engram MCP token was expired when it was written. Mirror it to the vault and
+> delete this copy.
+
+---
+
+## Goal
+
+Stop creating a CRDT room as a side effect of receiving a write. Room count
+should scale with the number of notes open in editors, not with vault size.
+
+## The problem
+
+`handle_in("crdt_msg", ...)` calls `ensure_room/2` for every content frame. The
+rule the system implements today is:
+
+> a frame arrived, therefore spawn a stateful actor
+
+Room creation is triggered by **traffic**, not by **demand for collaboration**.
+A `SharedDoc` room is a live Y.Doc plus a checkpoint timer whose purpose is to
+let multiple clients converge on one note in real time. A bulk import has no
+collaboration in it: one writer, no concurrent peers. The correct number of
+rooms for an import is zero.
+
+### Evidence
+
+Measured on staging 2026-08-19, importing a 1,516-note vault, using the
+`[:engram, :crdt, :room_start]` counter added in #1424:
+
+| | count | share |
+|---|---|---|
+| rooms created | 406 | 27% of notes |
+| drained because they went idle | 166 | 41% |
+| **force-evicted by the memory backstop** | **240** | **59%** |
+
+Fifty-nine percent of the rooms created during a normal import were killed by
+`CrdtRoomLru` before they ever went idle. A room that gets force-evicted before
+it idles was created for work that never needed a session.
+
+Residency behaviour from the same run (`cap=64`):
+
+```
+resident=135 backlog=55
+resident=298 backlog=218
+resident=316 backlog=236     <- peak
+resident=300 -> 284 -> 268 -> 252 -> 236 -> 220 ...   <- exact -16 steps
+```
+
+The decay is perfectly linear at `@max_evictions_per_sweep 16` per 30s sweep.
+The peak of 316 is not demand. It is the LRU unable to hold its own cap at 32
+evictions/min. **The LRU is load-bearing during normal operation**, which means
+it is not protecting against abuse, it is concealing a creation bug.
+
+Raising the eviction rate is explicitly rejected as a fix. It changes the graph
+and nothing else.
+
+## The key realisation
+
+`CrdtPersistence.update_v1/4` is the room's write path. It does exactly this:
+
+```
+encrypt(update) -> INSERT crdt_update_log -> invalidate crdt_head -> fan out note_yjs_update
+```
+
+Three properties follow, all already true in the current code:
+
+1. **The tail log is append-only.** Nothing in the write path reads-then-writes
+   shared state. Concurrent appends need no coordination.
+2. **Y-CRDT updates are commutative and idempotent.** Apply order does not
+   affect the converged result. The room's mailbox serialisation was never
+   load-bearing for write correctness.
+3. **Fan-out is already vault-channel based, not room-observer based.** The
+   code says so directly: *"Relay's `document.updated` model... what lets an
+   IDLE note (one the client never STEP1-enrolled) converge."*
+
+Therefore: **a room is a performance cache for hot notes, not a correctness
+requirement.** The snapshot on the note row is a compaction of the tail; the
+tail is authoritative. `checkpoint/5` already takes `:prune_ids` precisely so a
+compaction deletes only the rows it folded. (Omitting `:prune_ids` was the
+data-loss bug found during #1424 review. That was the design signalling this
+model.)
+
+## Architecture
+
+### Routing rule
+
+In `handle_in("crdt_msg", ...)`, replace the unconditional `ensure_room/2` with
+a three-way route. `frame_class_b64/1` already returns `:handshake` vs `:edit`,
+and `:global.whereis_name({:crdt_doc, note_id})` is a non-creating lookup, so
+both inputs exist today and are currently discarded.
+
+| frame | room exists | action |
+|---|---|---|
+| `:handshake` (STEP1/STEP2) | either | `ensure_room` then relay (unchanged) |
+| `:edit` | yes | relay to room (unchanged) |
+| `:edit` | **no** | **detached apply (new)** |
+
+The room, when one exists, remains the sole writer for that note. The route
+never splits writers.
+
+### Detached apply
+
+Reuses the machinery shipped in #1424, generalised from genesis to any update:
+
+1. `fold_row_and_tail/4` in a short tenant transaction: read the note row's
+   snapshot, `replay_tail/3` into a transient `%Yex.Doc{}`, return the doc plus
+   the exact `prune_ids` folded.
+2. Apply the decoded update to the transient doc.
+3. Append the update to `crdt_update_log` (identical to `update_v1`'s insert)
+   and invalidate `crdt_head`.
+4. `CrdtDeliver.fanout_idle/3` with `CrdtTransport.head_marker(doc)` from the
+   transient doc.
+5. Compact conditionally (see below).
+6. Discard the doc.
+
+### Compaction trigger
+
+This is the one genuinely new decision. A room's checkpoint timer performed
+compaction; without it the tail grows and replay slows.
+
+Detached writes already pay full materialisation in step 1, so writing the
+snapshot back is nearly free at that point. But paying a full encrypted
+snapshot write per keystroke would be wasteful.
+
+**Rule: compact when the folded tail exceeds a threshold, otherwise append
+only.** Threshold on folded row count, config-driven with a default, since row
+count is what drives replay cost.
+
+This is self-limiting in practice. A note being typed into rapidly is a note
+open in an editor, which means STEP1 ran, which means it has a room and never
+reaches this path. Detached writes are inherently the low-frequency case.
+
+### Cost profile (why the routing rule is also the right cache policy)
+
+Detached writes are cheap when the doc is small or new (empty snapshot, empty
+tail: the genesis case, already proven at 73% room reduction) and expensive
+when the snapshot is large, because materialisation decrypts it.
+
+A room amortises that cost across many edits. Under the new rule rooms are
+created only by STEP1, and STEP1 happens when a note is opened in an editor.
+So hot notes (open, edited repeatedly) get a room and amortise; cold notes
+(bulk import, background sync, single remote edit) go detached and pay once.
+The routing rule is therefore also a correct cache-admission policy, without
+needing a separate heuristic.
+
+## What this changes about eviction
+
+`CrdtRoomLru` stops being load-bearing and becomes ordinary cache eviction:
+always safe, never data-affecting, because evicting a room can no longer lose a
+write. `max_resident` becomes a cache size that normal operation never reaches,
+and the LRU retains value only as an abuse backstop.
+
+`@max_evictions_per_sweep` stays as it is. It is only a problem while creation
+is wrong.
+
+## Error handling
+
+- **Materialisation failure** (decrypt error, corrupt snapshot): reply with the
+  existing error reason; do not append. The client's frame is held and
+  re-delivered on rejoin, matching current `sendCrdt` refusal behaviour.
+- **Apply failure** (malformed update): `apply_detached/1` already wraps
+  `rescue` plus `catch :exit`. Reject the frame, do not append a row that
+  cannot be replayed.
+- **Race: a room starts between the lookup and the append.** Safe by
+  construction. Both paths append to the same tail, updates are commutative,
+  and the room's next materialisation replays the appended row. Explicitly
+  *not* guarded, and the reasoning is recorded here so a later reader does not
+  add a lock. (#1424 added an advisory lock for the analogous genesis race,
+  measured 7.5-101ms hold, and it was removed as worse than the bug because
+  `DynamicSupervisor` runs `init/1` inline and stalled room starts node-wide.)
+- **Compaction racing an append.** Already handled: `:prune_ids` deletes only
+  the folded ids, so a row appended mid-compaction survives.
+
+## Testing
+
+Unit (`test/engram_web/channels/`, `test/engram/notes/`):
+
+- an `:edit` frame for a note with no room appends a tail row and starts no
+  room (assert against the `room_start` counter, not residency, which is
+  sampled and lags)
+- an `:edit` frame for a note **with** a room still routes to the room
+- a `:handshake` frame still creates a room
+- two concurrent detached applies to one note both survive and converge
+- compaction with `prune_ids` leaves a concurrently-appended row intact
+- detached apply fans out `note_yjs_update` carrying a correct head marker
+
+E2E (`e2e/tests/`), because this class is only ever caught there:
+
+- bulk import of N notes creates zero rooms, and every note's content lands on
+  a second device (guards the fan-out regression that #1424 hit, where device B
+  received a 0-byte file)
+- a note open in an editor on device A still converges live with device B
+
+Regression fence: extend the existing room-count assertion to assert
+`room_start_total == 0` across an import rather than sampling residency.
+
+## Observability
+
+Add a `source` label to `[:engram, :crdt, :room_start]` (`handshake` /
+`create_batch` / other). The 2026-08-19 measurement could not attribute which
+27% of notes still demanded a room because the counter is unlabelled. One label
+settles it in a single import and verifies this change reaches zero.
+
+## Non-goals
+
+- **Detached STEP1 materialisation.** A handshake could also be served from a
+  transient doc, making rooms a pure cache. Out of scope; revisit after this
+  lands and the counter shows what remains.
+- **Awareness and presence.** Untouched.
+- **Plugin changes.** None required. The client cannot tell which path served
+  its frame. `wiring.ts:514` `reEnrollUnsent` enrolling without an `isLiveBound`
+  gate is a real latent bug found during the same investigation, but it is
+  independent and belongs in its own issue.
+
+## Open question for implementation
+
+The compaction threshold default needs a number. Pick it from measured replay
+cost against real tail depths rather than guessing, and log when it fires so a
+badly chosen value is visible rather than silent.

--- a/docs/superpowers/specs/2026-08-19-detached-writes-room-decoupling-design.md
+++ b/docs/superpowers/specs/2026-08-19-detached-writes-room-decoupling-design.md
@@ -1,6 +1,6 @@
 # Decoupling CRDT room creation from writes
 
-**Date:** 2026-08-19
+**Date:** 2026-08-19 (rev 2, after adversarial review)
 **Repos:** `engram-app/engram` (backend), `engram-app/Engram-obsidian` (plugin, read-only impact)
 **Epic:** #1146 (identity/content converge through different channels)
 **Follows:** #1409 / #1424 (genesis seed detached), which piloted this pattern for note creation
@@ -75,36 +75,149 @@ Three properties follow, all already true in the current code:
 1. **The tail log is append-only.** Nothing in the write path reads-then-writes
    shared state. Concurrent appends need no coordination.
 2. **Y-CRDT updates are commutative and idempotent.** Apply order does not
-   affect the converged result. The room's mailbox serialisation was never
-   load-bearing for write correctness.
+   affect the converged result.
 3. **Fan-out is already vault-channel based, not room-observer based.** The
    code says so directly: *"Relay's `document.updated` model... what lets an
    IDLE note (one the client never STEP1-enrolled) converge."*
 
+`CrdtRegistry.terminate_room/1` confirms the model independently: it brutally
+kills rooms and documents why that is safe, *"Nothing is lost: every room
+update is already in the durable tail-log."*
+
 Therefore: **a room is a performance cache for hot notes, not a correctness
-requirement.** The snapshot on the note row is a compaction of the tail; the
-tail is authoritative. `checkpoint/5` already takes `:prune_ids` precisely so a
-compaction deletes only the rows it folded. (Omitting `:prune_ids` was the
-data-loss bug found during #1424 review. That was the design signalling this
-model.)
+requirement.**
 
-## Architecture
+### What that realisation does NOT license
 
-### Routing rule
+Rev 1 of this spec concluded from the above that concurrent writers are safe by
+construction and told reviewers not to add a lock. **That was wrong**, and the
+adversarial review caught it. Commutativity makes append-versus-append safe. It
+says nothing about the three mechanisms below, each of which silently assumes
+the room is the *sole writer*. Removing an actor removes guarantees nobody
+wrote down, which is the same failure mode that produced four separate defects
+during #1424.
 
-In `handle_in("crdt_msg", ...)`, replace the unconditional `ensure_room/2` with
-a three-way route. `frame_class_b64/1` already returns `:handshake` vs `:edit`,
-and `:global.whereis_name({:crdt_doc, note_id})` is a non-creating lookup, so
-both inputs exist today and are currently discarded.
+Those assumptions are enumerated as Phase 0 and are **hard prerequisites**, not
+follow-ups.
 
-| frame | room exists | action |
+---
+
+## Phase 0: remove the sole-writer assumptions
+
+Nothing in Phase 1 may land before all three of these.
+
+### 0a. Watermark pruning must go (CRITICAL, silent data loss)
+
+`crdt_checkpoint_timer.ex:447` passes only `captured_version`, no `:prune_ids`,
+so every live-room checkpoint takes the watermark path:
+
+```elixir
+defp prune_tail(note_id, {:watermark, watermark}) do
+  CrdtUpdateLog |> where([l], l.note_id == ^note_id and l.inserted_at <= ^watermark) |> Repo.delete_all()
+end
+```
+
+This deletes every row at or below the watermark **regardless of whether the
+room's doc folded it**. That is safe only because a room is currently the sole
+writer, so its doc always reflects every tail row in existence. The in-code
+comment protects rows inserted *after* watermark capture; nothing protects a
+row inserted *before* capture but *after* the room's doc last incorporated the
+tail. Today that window is empty by construction.
+
+The Phase 1 routing rule creates it, because lookup-then-append is not atomic:
+
+1. No room, so client A's `:edit` routes detached.
+2. Client B sends STEP1. Room starts, binds, `replay_tail` runs. A's row has not
+   committed, so the room's doc misses it.
+3. A's append commits. Row R is in the tail; the room's doc does not contain it.
+4. The checkpoint timer fires. It captures a watermark after R, snapshots the
+   stale doc, and prunes `<= wm`, **deleting R**.
+
+R is then absent from both the snapshot and the tail. Permanent silent loss.
+The fanout delivered R to clients connected at that instant, so it looks
+correct live and is gone from server state forever. This is the #285 class that
+`:prune_ids` was introduced to fix, reopened through a different door.
+
+**Change:** every checkpoint uses exact `:prune_ids`. Delete the watermark
+branch rather than leaving it available, so no future caller can reintroduce
+the assumption. `replay_tail/3` already returns the folded ids
+(`@spec ... :: [Ecto.UUID.t()]`) and `update_v1` knows the row it inserted, so
+the room can accumulate folded ids cheaply.
+
+**Test:** a row appended by a non-room writer between a room's bind and its
+checkpoint survives the checkpoint and is present after the next bind.
+
+### 0b. Head markers must never be computed from a partial view (CRITICAL)
+
+`head_marker/1` is `sha256(state vector)`, and the client compares the value.
+From `sync.ts:2107`: it gates the *convergence cost gate*
+(`getCrdtHead === serverHead` -> skip).
+
+With a room, every fanout head descends from one authoritative doc, so heads
+form a total order that only advances. Two concurrent detached writes compute
+their markers from independent transient docs, each seeing a different subset,
+producing sibling heads that reflect no state any party actually holds. A client
+can store a head it never reached and have the gate skip convergence while it is
+genuinely behind. That is the deaf-note class in
+`deaf-livebound-base-loss-diagnosis.md`: catch-up faking convergence.
+
+**Change:** the detached path does not send a computed head marker. It sends an
+explicit unknown that can never satisfy the equality gate, so the client
+converges normally. A head marker exists only as a cost optimisation, so
+degrading it to "unknown" costs one handshake and never costs correctness.
+
+The governing rule, and the one rev 1 violated: **never emit a claim of
+convergence you cannot prove.** Same discipline as "a no-op must never report
+as work."
+
+**Test:** two concurrent detached writes to one note leave a client that
+applied both with a head that does not equal the server's, so the cost gate
+does not skip.
+
+### 0c. Compaction is a correctness and abuse boundary, not tuning
+
+Rev 1 argued compaction is self-limiting because "hot notes have rooms". That
+relies on the plugin's client-side `isLiveBound`, which the server does not
+control and must not assume.
+
+A client that repeatedly edits a note without enrolling forces the detached
+path every time. Each write decrypts the full snapshot and replays a growing
+tail: O(n²) in tail depth, plus a full-snapshot decrypt per write on large
+notes. The `:edit` rate lane bounds frames per second, not cost per frame, so
+it does not bound this.
+
+**Change:** the compaction trigger is server-side and mandatory, on folded row
+count, and is not conditional on any client behaviour. Threshold is
+config-driven with a default, and firing is logged so a bad value is visible
+rather than silent.
+
+---
+
+## Phase 1: the routing rule
+
+In `handle_in("crdt_msg", ...)`, replace the unconditional `ensure_room/2`.
+`frame_class_b64/1` already returns `:handshake` vs `:edit`, so the input
+exists today and is discarded.
+
+| frame | resolved room | action |
 |---|---|---|
-| `:handshake` (STEP1/STEP2) | either | `ensure_room` then relay (unchanged) |
-| `:edit` | yes | relay to room (unchanged) |
-| `:edit` | **no** | **detached apply (new)** |
+| `:handshake` (STEP1/STEP2) | any | `ensure_room` then relay (unchanged) |
+| `:edit` | live pid | relay to room (unchanged) |
+| `:edit` | none, or **dying pid** | **detached apply (new)** |
 
-The room, when one exists, remains the sole writer for that note. The route
-never splits writers.
+### Room resolution is not a boolean
+
+Rev 1's table treated "room exists" as binary. It is not.
+`CrdtRegistry.lookup/1` returns the raw `:global.whereis_name` result, and the
+module header warns it *"can hand back a room that is mid-termination"*. Rooms
+run `auto_exit: true` and stop when the last observer leaves, so termination is
+routine rather than exotic. A frame relayed to a dying room is swallowed, which
+is exactly why the drain exists (`cast` to a dead pid returns `:ok`).
+
+`ensure_started/3` already carries bounded-retry discipline for this
+(`@observe_attempts 5`, `@observe_retry_delay_ms 5`). The `:edit` route needs a
+resolver with the same discipline that returns a **live** pid or nothing, and
+falls through to detached rather than relaying into a terminating room.
 
 ### Detached apply
 
@@ -112,44 +225,36 @@ Reuses the machinery shipped in #1424, generalised from genesis to any update:
 
 1. `fold_row_and_tail/4` in a short tenant transaction: read the note row's
    snapshot, `replay_tail/3` into a transient `%Yex.Doc{}`, return the doc plus
-   the exact `prune_ids` folded.
+   the exact ids folded.
 2. Apply the decoded update to the transient doc.
 3. Append the update to `crdt_update_log` (identical to `update_v1`'s insert)
    and invalidate `crdt_head`.
-4. `CrdtDeliver.fanout_idle/3` with `CrdtTransport.head_marker(doc)` from the
-   transient doc.
-5. Compact conditionally (see below).
+4. `CrdtDeliver.fanout_idle/3`, carrying the **unknown** head marker per 0b.
+5. Compact if the folded row count exceeds the Phase 0c threshold, passing
+   exact `:prune_ids`.
 6. Discard the doc.
 
-### Compaction trigger
+### Fan-out is a correctness invariant, not a convenience
 
-This is the one genuinely new decision. A room's checkpoint timer performed
-compaction; without it the tail grows and replay slows.
+Rev 1 cited vault-channel fanout as *evidence* that rooms are caches, and filed
+it as background. Once writes can bypass a room, that broadcast becomes the
+only delivery path for a client whose room bound before the append. It is
+therefore load-bearing and needs an explicit invariant and test.
 
-Detached writes already pay full materialisation in step 1, so writing the
-snapshot back is nearly free at that point. But paying a full encrypted
-snapshot write per keystroke would be wasteful.
+#1424 already lost fanout once while removing a room, and device B wrote a
+0-byte file (`e3b0c44298fc`, the SHA-256 of the empty string). Only the paired
+e2e caught it.
 
-**Rule: compact when the folded tail exceeds a threshold, otherwise append
-only.** Threshold on folded row count, config-driven with a default, since row
-count is what drives replay cost.
-
-This is self-limiting in practice. A note being typed into rapidly is a note
-open in an editor, which means STEP1 ran, which means it has a room and never
-reaches this path. Detached writes are inherently the low-frequency case.
-
-### Cost profile (why the routing rule is also the right cache policy)
+### Cost profile
 
 Detached writes are cheap when the doc is small or new (empty snapshot, empty
 tail: the genesis case, already proven at 73% room reduction) and expensive
-when the snapshot is large, because materialisation decrypts it.
+when the snapshot is large, because materialisation decrypts it. A room
+amortises that across many edits.
 
-A room amortises that cost across many edits. Under the new rule rooms are
-created only by STEP1, and STEP1 happens when a note is opened in an editor.
-So hot notes (open, edited repeatedly) get a room and amortise; cold notes
-(bulk import, background sync, single remote edit) go detached and pay once.
-The routing rule is therefore also a correct cache-admission policy, without
-needing a separate heuristic.
+Under this rule rooms are created only by STEP1, which happens when a note is
+opened in an editor, so hot notes amortise and cold notes pay once. This is a
+useful property but, per 0c, it is **not** relied on for boundedness.
 
 ## What this changes about eviction
 
@@ -167,36 +272,40 @@ is wrong.
   existing error reason; do not append. The client's frame is held and
   re-delivered on rejoin, matching current `sendCrdt` refusal behaviour.
 - **Apply failure** (malformed update): `apply_detached/1` already wraps
-  `rescue` plus `catch :exit`. Reject the frame, do not append a row that
-  cannot be replayed.
-- **Race: a room starts between the lookup and the append.** Safe by
-  construction. Both paths append to the same tail, updates are commutative,
-  and the room's next materialisation replays the appended row. Explicitly
-  *not* guarded, and the reasoning is recorded here so a later reader does not
-  add a lock. (#1424 added an advisory lock for the analogous genesis race,
-  measured 7.5-101ms hold, and it was removed as worse than the bug because
-  `DynamicSupervisor` runs `init/1` inline and stalled room starts node-wide.)
-- **Compaction racing an append.** Already handled: `:prune_ids` deletes only
-  the folded ids, so a row appended mid-compaction survives.
+  `rescue` plus `catch :exit`. Reject the frame; never append a row that cannot
+  be replayed.
+- **A room starts between resolution and append.** Safe once 0a lands, and only
+  then: both paths append to the same tail, updates commute, and the room's
+  next materialisation replays the appended row without any checkpoint pruning
+  it unfolded. Deliberately not locked. #1424 added an advisory lock for the
+  analogous genesis race, measured 7.5-101ms hold, and removed it as worse than
+  the bug because `DynamicSupervisor` runs `init/1` inline and stalled room
+  starts node-wide. **This reasoning is valid only with 0a in place.**
+- **Compaction racing an append.** Handled by `:prune_ids`: a row appended
+  mid-compaction is not in the folded set and survives.
 
 ## Testing
 
-Unit (`test/engram_web/channels/`, `test/engram/notes/`):
+Unit:
 
 - an `:edit` frame for a note with no room appends a tail row and starts no
-  room (assert against the `room_start` counter, not residency, which is
-  sampled and lags)
-- an `:edit` frame for a note **with** a room still routes to the room
+  room (assert the `room_start` counter, not residency, which is sampled and
+  lags)
+- an `:edit` frame for a note with a live room still routes to the room
+- an `:edit` frame whose resolved pid is mid-termination falls through to
+  detached rather than relaying into it
 - a `:handshake` frame still creates a room
+- **0a:** a row appended between a room's bind and its checkpoint survives
+- **0b:** concurrent detached writes leave the client's head unequal to the
+  server's, so the cost gate does not skip
+- **0c:** compaction fires on the row-count threshold with no client signal
 - two concurrent detached applies to one note both survive and converge
-- compaction with `prune_ids` leaves a concurrently-appended row intact
-- detached apply fans out `note_yjs_update` carrying a correct head marker
+- detached apply fans out `note_yjs_update`
 
-E2E (`e2e/tests/`), because this class is only ever caught there:
+E2E, because this class is only ever caught there:
 
-- bulk import of N notes creates zero rooms, and every note's content lands on
-  a second device (guards the fan-out regression that #1424 hit, where device B
-  received a 0-byte file)
+- bulk import of N notes creates zero rooms and every note's content lands on a
+  second device (guards the #1424 fan-out regression)
 - a note open in an editor on device A still converges live with device B
 
 Regression fence: extend the existing room-count assertion to assert
@@ -213,15 +322,23 @@ settles it in a single import and verifies this change reaches zero.
 
 - **Detached STEP1 materialisation.** A handshake could also be served from a
   transient doc, making rooms a pure cache. Out of scope; revisit after this
-  lands and the counter shows what remains.
+  lands and the labelled counter shows what remains.
 - **Awareness and presence.** Untouched.
-- **Plugin changes.** None required. The client cannot tell which path served
-  its frame. `wiring.ts:514` `reEnrollUnsent` enrolling without an `isLiveBound`
-  gate is a real latent bug found during the same investigation, but it is
-  independent and belongs in its own issue.
+- **Plugin changes.** None required. `wiring.ts:514` `reEnrollUnsent` enrolling
+  without an `isLiveBound` gate is a real latent bug found during the same
+  investigation, but it is independent and belongs in its own issue.
 
 ## Open question for implementation
 
-The compaction threshold default needs a number. Pick it from measured replay
-cost against real tail depths rather than guessing, and log when it fires so a
-badly chosen value is visible rather than silent.
+The Phase 0c threshold needs a number, picked from measured replay cost against
+real tail depths rather than guessed.
+
+## Review history
+
+Rev 1 was reviewed adversarially and did not survive. Four of its claims were
+wrong or unsafe: sole-writership (0a), head-marker validity (0b), compaction as
+tuning (0c), and room resolution as a boolean (Phase 1). The diagnosis was
+unaffected; every defect was in the remedy. Recorded here because the same
+class of error, removing an actor and inheriting its unwritten guarantees,
+produced four defects in #1424 and then produced four more in the spec written
+to fix it.


### PR DESCRIPTION
## Summary

Spec only, no behaviour change. Proposes stopping the creation of a CRDT room as a side effect of receiving a write, so room count scales with the number of notes open in editors rather than with vault size.

`handle_in("crdt_msg", ...)` currently calls `ensure_room/2` for every content frame. The rule the system implements today is "a frame arrived, therefore spawn a stateful actor". A `SharedDoc` room is a collaboration session, and a bulk import has no collaboration in it.

> **Rev 2.** Rev 1 was reviewed adversarially and **did not survive**. The diagnosis was unaffected; all four defects were in the remedy. Rev 2 adds Phase 0 as a hard prerequisite and retracts rev 1's "do not add a lock" guidance, which was only valid with 0a in place. Review history is recorded at the end of the spec.

## Evidence

Measured on staging 2026-08-19 importing a 1,516-note vault, using the `[:engram, :crdt, :room_start]` counter added in #1424:

| | count | share |
|---|---|---|
| rooms created | 406 | 27% of notes |
| drained because they went idle | 166 | 41% |
| **force-evicted by the memory backstop** | **240** | **59%** |

Residency from the same run (`cap=64`) peaked at 316 and then decayed in exact `-16` steps, which is `@max_evictions_per_sweep` per 30s sweep. **The 316 peak is not demand, it is `CrdtRoomLru` unable to hold its own cap.** The LRU is load-bearing during normal operation, which means it conceals a creation bug rather than protecting against abuse.

Raising the eviction rate is explicitly rejected in the spec. It changes the graph and nothing else.

## Why the direction is right

`CrdtPersistence.update_v1/4` is append-only (`INSERT crdt_update_log`), Y-CRDT updates are commutative, and fan-out is already vault-channel based rather than room-observer based. `CrdtRegistry.terminate_room/1` confirms it independently: it brutally kills rooms and documents why that is safe, *"Nothing is lost: every room update is already in the durable tail-log."*

So a room is a **performance cache for hot notes, not a correctness requirement**.

## Phase 0 (hard prerequisites, found by review)

Commutativity makes append-versus-append safe. It says nothing about three mechanisms that silently assume the room is the **sole writer**:

- **0a (CRITICAL, silent data loss).** Live-room checkpoints pass no `:prune_ids`, so they take the watermark path, deleting every tail row `inserted_at <= wm` regardless of whether the room's doc folded it. Safe only under sole-writership. A row appended between a room's `bind` and its checkpoint is deleted unfolded and lost from both snapshot and tail. This is the #285 class through a different door. Fix: all checkpoints use exact `:prune_ids`, and the watermark branch is deleted so nothing can reintroduce the assumption.
- **0b (CRITICAL).** `head_marker` is compared by the client to *skip* convergence (`sync.ts:2107`). Concurrent detached writes compute markers from independent transient docs, producing sibling heads reflecting no real state, which lets a client skip convergence while genuinely behind (the deaf-note class). Fix: the detached path emits an explicit unknown. Never emit a claim of convergence you cannot prove.
- **0c.** Compaction was framed as tuning, but "self-limiting because hot notes have rooms" depends on the plugin's client-side `isLiveBound`, which the server does not control. Unenrolled repeat edits are O(n²) in tail depth with a full-snapshot decrypt per write. Fix: server-side mandatory trigger on folded row count.

## Phase 1: routing rule

| frame | resolved room | action |
|---|---|---|
| handshake | any | `ensure_room` (unchanged) |
| edit | live pid | relay to room (unchanged) |
| edit | none, or **dying pid** | **detached apply** (new) |

Rev 1 treated "room exists" as a boolean. `CrdtRegistry.lookup/1` returns raw `:global.whereis_name` and the module header warns it "can hand back a room that is mid-termination"; rooms use `auto_exit: true`, so termination is routine. The edit route needs `ensure_started`-style bounded-retry resolution returning a live pid or nothing, falling through to detached rather than relaying into a terminating room.

Fan-out is also promoted from background to a stated correctness invariant with a test: once writes bypass rooms, the vault-channel broadcast is the only delivery path for a client whose room bound before the append. #1424 already lost fan-out once while removing a room, and device B wrote a 0-byte file.

## Notes for review

- Adds an observability ask: a `source` label on `room_start`. The measurement above could not attribute which 27% of notes still demanded a room because the counter is unlabelled.
- Open item: the 0c threshold needs a number measured against real tail depths, not guessed.
- The spec belongs in the Engram vault under `50 Engineering/_Superpowers Specs/`. It is committed here temporarily because the engram MCP token was expired when it was written.

Refs #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp