### PR TITLE
fix(auth): gate WebSocket sync joins on onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,6 +369,8 @@ Grouped index into `docs/context/`. Each entry is a trigger → doc; read the do
 - Attachment MIME/extension whitelist abuse defense (Pricing v2 §H) → `docs/context/attachment-mime-whitelist.md`
 
 **Auth, OAuth & MCP**
+- Gating a Phoenix **channel** on onboarding/billing, or a paywalled account is syncing anyway (`RequireOnboarding` is a Plug and never runs on a socket; `user:` must stay UNGATED) → `docs/context/onboarding-gate-is-http-only.md`
+- A test asserting paywall/tier/onboarding behavior passes but shouldn't (`config/runtime.exs` clobbers `billing_enabled` to false for the whole suite) → `docs/context/onboarding-gate-is-http-only.md`
 - OAuth 2.1 + DCR on `/api/mcp` — wire flow, endpoints, token model, scopes → `docs/context/mcp-oauth.md`
 - MCP vault selection design — stateless `set_vault`, fate of the default vault → `docs/context/mcp-vault-selection.md`
 - Refresh-token rotation — leeway/overlap window, token-family reuse detection → `docs/context/refresh-token-reuse-detection.md`

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -1,0 +1,91 @@
+# Context Doc: Onboarding/billing gate vs. the WebSocket sync path
+
+_Last verified: 2026-08-19_
+
+## Status
+Working — gate now enforced on both transports (PR #1426). Test-suite coverage still compromised, see Gotchas + issue #1427.
+
+## What This Is
+Why `EngramWeb.Plugs.RequireOnboarding` could not stop an un-onboarded account from
+syncing a whole vault, and where the gate actually lives now.
+
+## Environment
+Backend (`engram-app/Engram`), Elixir/Phoenix. SaaS mode only —
+self-host (`billing_enabled=false`) auto-passes terms + subscription.
+
+## The failure
+Reproduced on staging 2026-08-19: an account that had **neither accepted the ToS nor
+selected a plan** synced a full vault from Obsidian, and the plugin displayed it as
+"Free tier" (`Billing.tier/1` returns `:free` for "no subscription", which reads as a
+normal state rather than a blocked one).
+
+`RequireOnboarding` was wired only on the vault-scoped **router** pipeline
+(`router.ex:55`). It correctly 403'd `/api/notes`, `/api/search`, `/api/folders`.
+But a Plug takes a `conn` and **never runs on a socket** — and sync had moved to
+Phoenix Channels. The live path checked exactly two things:
+
+- `lib/engram_web/user_socket.ex` `connect/3` — is the token valid?
+- `lib/engram_web/channels/crdt_channel.ex` `join/3` — do you own this vault, and is
+  `crdt_proto` new enough?
+
+Both yes → join → full read/write sync. The plugin barely touches REST, so it never
+met the gate it was supposed to fail. `POST /api/vaults/register` (user-scoped
+pipeline, intentionally ungated so the wizard can create a first vault) supplied the
+vault.
+
+## Where the gate lives now
+`Engram.Onboarding.gate/1` is the **single authority**. Returns `:ok` or
+`{:error, missing, next_step}` and keeps the `GateCache` pass-caching.
+
+- `EngramWeb.Plugs.RequireOnboarding` — thin 403-shaping wrapper (HTTP).
+- `SyncChannel.join/3` + `CrdtChannel.join/3` — reply
+  `{:error, %{reason: "onboarding_required", missing: [...], next_step: ...}}`.
+
+**Adding a route to the vault pipeline gets you the plug. Adding a _channel_ does
+not — call `Onboarding.gate/1` from its `join/3`.**
+
+## Failed Approaches / Dead Ends
+- **Gating `UserSocket.connect/3`.** Tidier-looking and wrong: it deadlocks signup.
+  The FTUX vault screen joins `user:{id}` mid-wizard to wait for `vault_created` /
+  `vault_populated` (`user_channel.ex`), so gating the socket blocks the only path to
+  *passing* the gate. `user:` must stay open; there is a test pinning it open.
+- **Gating only the `/link` + vault-select OAuth flow.** That is one caller. A device
+  linked before the check, a PAT, or an MCP token all still open the socket. The
+  socket is where every caller converges — fix it there. (The link path is *also*
+  gated now, but purely so the failure is a readable 403 instead of a silent
+  channel-join refusal.)
+- **Setting `free_tier_accepted_at` in `user_factory` to un-break the suite once
+  `billing_enabled` is honored.** Fixes the `subscription` slice only
+  (284 → ~2 failures in `controllers/`); the dominant remainder is
+  `missing: ["terms"]` from a `VersionCache` leak. See Gotchas.
+
+## Gotchas
+- **`POST /api/auth/device/authorize` does NOT inherit the gate.** It sits on the
+  user-scoped pipeline because it must stay reachable for first-vault creation, so it
+  declares `plug EngramWeb.Plugs.RequireOnboarding when action in [:authorize]`
+  itself. Same for anything else added to that scope.
+- **`Billing.tier/1` returning `:free` is a pricing default, not an authorization
+  answer.** Never treat "tier resolved" as "user is allowed here".
+- **The SaaS onboarding gate has never run in the test suite.**
+  `config/runtime.exs` sets `:billing_enabled` *unguarded by `config_env()`*, and
+  runtime.exs loads last — so it clobbers `config/test.exs`'s `true` to `false` for
+  the whole suite. Every onboarding gate is a no-op unless a case does its own
+  `Application.put_env`. This is *why this bug survived*. Turning it on for real
+  gives **429 failures / 4677**; the bulk is `Engram.Legal.VersionCache` (node-local
+  ETS, not sandboxed) leaking a required terms floor into later `async: true` tests
+  whose own rows were rolled back. Tracked in issue #1427 — do not "just add the
+  guard" without (2) and (3) from that issue.
+- Tests that need the real SaaS gate must `Application.put_env(:engram,
+  :billing_enabled, true)` in setup **and** `GateCache.evict_all()` — the pass
+  verdict is cached for 60s and is not sandboxed either.
+- The factory user's "already onboarded" comment is only true because the flag is
+  off. It has no `free_tier_accepted_at`.
+
+## References
+- `lib/engram/onboarding.ex` — `gate/1`, `status/1`
+- `lib/engram/onboarding/gate_cache.ex` — pass-cache + eviction contract
+- `lib/engram_web/plugs/require_onboarding.ex`
+- `lib/engram_web/channels/{sync,crdt}_channel.ex`, `lib/engram_web/user_socket.ex`
+- `test/engram_web/onboarding_gate_channel_test.exs`,
+  `test/engram_web/onboarding_gate_integration_test.exs`
+- PR #1426 (fix), issue #1427 (test-config follow-up), #142 (RequireOnboarding)

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -22,13 +22,16 @@ normal state rather than a blocked one).
 `RequireOnboarding` was wired only on the vault-scoped **router** pipeline
 (`router.ex:55`). It correctly 403'd `/api/notes`, `/api/search`, `/api/folders`.
 But a Plug takes a `conn` and **never runs on a socket** — and sync had moved to
-Phoenix Channels. The live path checked exactly two things:
+Phoenix Channels. The live path checked token validity (`user_socket.ex`
+`connect/3`), `crdt_proto` version, `RotationGate.check/1` (DEK rotation lock),
+topic ownership, and `Vaults.check_api_key_access/2`. What it did **not** check
+was entitlement: nothing asked about ToS, plan, or wizard completion.
 
-- `lib/engram_web/user_socket.ex` `connect/3` — is the token valid?
-- `lib/engram_web/channels/crdt_channel.ex` `join/3` — do you own this vault, and is
-  `crdt_proto` new enough?
+Note the rotation check in that list — the gate is now ordered deliberately
+around it (see Gotchas). A summary that omits it gives a future reader no
+reason to preserve the ordering.
 
-Both yes → join → full read/write sync. The plugin barely touches REST, so it never
+All the existing checks passing → join → full read/write sync. The plugin barely touches REST, so it never
 met the gate it was supposed to fail. `POST /api/vaults/register` (user-scoped
 pipeline, intentionally ungated so the wizard can create a first vault) supplied the
 vault.
@@ -59,6 +62,22 @@ not — call `Onboarding.gate/1` from its `join/3`.**
   (284 → ~2 failures in `controllers/`); the dominant remainder is
   `missing: ["terms"]` from a `VersionCache` leak. See Gotchas.
 
+## Ordering (do not "tidy" this)
+In `CrdtChannel`: `crdt_proto` → `RotationGate.check/1` → **topic ownership
+match** → `Onboarding.gate/1` → vault resolve. In `SyncChannel`: topic
+ownership match → `Onboarding.gate/1` → vault resolve.
+
+The gate goes last because:
+- the ownership match is free, and the verdict costs ~4 DB round-trips
+  (including an RLS transaction) with **no join rate limiter** — a
+  `crdt:<other-user>:<uuid>` probe must not buy that;
+- the plugin's identity self-heal keys on `reason === "unauthorized"`
+  specifically (`channel.ts`, e2e test_84) — replacing that reason wedges it;
+- a user mid-DEK-rotation must still hear `rotation_in_progress` (T3.7).
+
+There are mutation-checked tests for all three in
+`onboarding_gate_channel_test.exs` ("gate ordering").
+
 ## Gotchas
 - **`POST /api/auth/device/authorize` does NOT inherit the gate.** It sits on the
   user-scoped pipeline because it must stay reachable for first-vault creation, so it
@@ -78,6 +97,26 @@ not — call `Onboarding.gate/1` from its `join/3`.**
 - Tests that need the real SaaS gate must `Application.put_env(:engram,
   :billing_enabled, true)` in setup **and** `GateCache.evict_all()` — the pass
   verdict is cached for 60s and is not sandboxed either.
+- **`gate/2` re-reads the user row.** `status/1` derives `subscription_ok`
+  partly from `user.free_tier_accepted_at` on the STRUCT while every other
+  input is queried fresh. `Plugs.Auth` reloads the user per HTTP request, but
+  `UserSocket` assigns `current_user` **once** at `connect/3` — so without the
+  re-read a Free user who clicks "Continue with Free" mid-session re-derives
+  from a stale struct on every rejoin and stays locked out for the life of the
+  connection (Free is the default cohort; paid users self-heal because
+  `Billing.tier/1` queries). `accept_free_tier/1` is a bare `Repo.update` with
+  no socket disconnect, unlike the billing paths which pair eviction with
+  `SessionInvalidator.disconnect_user/1`.
+- **`user:` has a catch-all `handle_in/3`** and needs it. Phoenix dispatches
+  inbound events unconditionally (`Phoenix.Channel.Server` → `handle_in/3`);
+  with no clause, one client frame kills the channel process. Server-push-only
+  is a client convention, not an enforced one — and this topic is reachable
+  pre-onboarding by design.
+- **`POST /api/auth/device/authorize` passes `skip_vault: true`.** It creates
+  the first vault, so gating it on "you already have one" makes it permanently
+  unreachable for the user who needs it. The relaxed verdict is deliberately
+  **not** written to `GateCache` — the channels read the same cache and enforce
+  the strict rule.
 - The factory user's "already onboarded" comment is only true because the flag is
   off. It has no `free_tier_accepted_at`.
 

--- a/e2e/tests/api_only/test_71_connections.py
+++ b/e2e/tests/api_only/test_71_connections.py
@@ -193,6 +193,24 @@ def _make_clerk_user(clerk_client) -> tuple[str, str, str]:
         f"User DB provisioning failed: {resp.status_code} {resp.text}"
     )
 
+    # Complete the FTUX questionnaire, mirroring helpers/clerk_auth.py and
+    # helpers/oauth.py. Provisioning the DB row is not the same as onboarding:
+    # `POST /api/auth/device/authorize` is gated on the same verdict the
+    # sync channels use (`Engram.Onboarding.gate/1`), so a user who never
+    # answered `tools` gets 403 onboarding_required missing=["profile"].
+    # A real user answers this on the `tools` step, which precedes the vault
+    # step where they link the plugin — so onboarding here is what makes the
+    # fixture resemble a real account, not a workaround.
+    prof = requests.patch(
+        f"{API_URL}/onboarding/profile",
+        json={"uses_obsidian": True, "tools": ["claude"]},
+        headers={"Authorization": f"Bearer {initial_jwt}"},
+        timeout=10,
+    )
+    assert prof.status_code in (200, 201), (
+        f"Onboarding profile PATCH failed: {prof.status_code} {prof.text}"
+    )
+
     jwt_token = clerk_client.create_session_token(clerk_user_id)
     return clerk_user_id, jwt_token, email
 

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -10,6 +10,7 @@ defmodule Engram.Onboarding do
   step (questionnaire + first vault) gates in every mode.
   """
 
+  alias Engram.Accounts
   alias Engram.Legal
   alias Engram.Legal.VersionCache
   alias Engram.Onboarding.Action
@@ -217,26 +218,46 @@ defmodule Engram.Onboarding do
   PASS verdicts are cached per node (`Engram.Onboarding.GateCache`); failing
   users always take the authoritative slow path.
   """
-  @spec gate(Engram.Accounts.User.t()) :: :ok | {:error, [String.t()], atom()}
-  def gate(%{id: user_id} = user) do
-    if GateCache.passed?(user_id), do: :ok, else: derive_gate(user, status(user))
+  @spec gate(Engram.Accounts.User.t(), keyword()) :: :ok | {:error, [String.t()], atom()}
+  def gate(%{id: user_id} = user, opts \\ []) do
+    if GateCache.passed?(user_id) do
+      :ok
+    else
+      # Re-read the row. `status/1` derives `subscription_ok` partly from
+      # `user.free_tier_accepted_at` on the STRUCT, while every other input
+      # (terms, profile, vault, subscription row) is queried fresh. That was
+      # harmless when the only caller was a Plug — `Plugs.Auth` reloads the
+      # user per request. `UserSocket` assigns `current_user` ONCE at
+      # `connect/3`, so a Free user who clicks "Continue with Free" mid-session
+      # would re-derive from a stale struct on every rejoin and stay locked out
+      # for the life of the connection. `accept_free_tier/1` is a bare
+      # `Repo.update` with no socket disconnect, so nothing else would clear it.
+      user = Accounts.get_user(user_id) || user
+      derive_gate(user, status(user), opts)
+    end
   end
 
-  defp derive_gate(user, %{next_step: :done}) do
+  defp derive_gate(user, %{next_step: :done}, _opts) do
     :ok = GateCache.mark_passed(user.id)
     :ok
   end
 
-  defp derive_gate(user, status) do
+  defp derive_gate(user, status, opts) do
+    # Every key is destructured, none defaulted. `has_vault` and `profile` used
+    # to come from `Map.get/3` with fail-OPEN defaults three lines under four
+    # strictly-matched siblings: dropping `:next_step` from `status/1` would
+    # raise, while dropping `:has_vault` would silently pass the vault rule for
+    # every user on both transports, with no compile error and no test failure.
     %{
       terms_ok: terms_ok,
       subscription_ok: sub_ok,
       profile_complete: profile_ok,
+      has_vault: has_vault,
+      profile: profile,
       next_step: next_step
     } = status
 
-    has_vault = Map.get(status, :has_vault, true)
-    profile = Map.get(status, :profile) || %{}
+    profile = profile || %{}
     # uses_obsidian users bypass the vault gate (the plugin creates the vault).
     vault_required = profile_ok and Map.get(profile, "uses_obsidian") != true
 
@@ -248,15 +269,23 @@ defmodule Engram.Onboarding do
       |> then(&if not vault_required or has_vault, do: &1, else: ["vault" | &1])
       |> Enum.sort()
 
-    if missing == [] do
-      # All enforced gates pass even though wizard navigation isn't `:done`
-      # yet (e.g. obsidian user mid-flow whose plugin is about to first-sync).
-      # Runtime traffic permission and wizard state are intentionally
-      # decoupled — see `next_step/5`.
-      :ok = GateCache.mark_passed(user.id)
-      :ok
-    else
-      {:error, missing, next_step}
+    cond do
+      missing == [] ->
+        # All enforced gates pass even though wizard navigation isn't `:done`
+        # yet (e.g. obsidian user mid-flow whose plugin is about to first-sync).
+        # Runtime traffic permission and wizard state are intentionally
+        # decoupled — see `next_step/5`.
+        :ok = GateCache.mark_passed(user.id)
+        :ok
+
+      # Deliberately NOT cached. The cache is shared with the channel joins,
+      # which enforce the strict rule — writing a relaxed PASS here would hand
+      # the full sync path to a user `gate/1` rejects.
+      missing == ["vault"] and Keyword.get(opts, :skip_vault, false) ->
+        :ok
+
+      true ->
+        {:error, missing, next_step}
     end
   end
 

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -14,6 +14,7 @@ defmodule Engram.Onboarding do
   alias Engram.Legal.VersionCache
   alias Engram.Onboarding.Action
   alias Engram.Onboarding.Agreement
+  alias Engram.Onboarding.GateCache
   alias Engram.Onboarding.TermsCache
   alias Engram.Repo
   alias Engram.Vaults
@@ -197,6 +198,66 @@ defmodule Engram.Onboarding do
       next_step: next,
       steps: steps
     }
+  end
+
+  @doc """
+  Authoritative runtime-traffic gate: may `user` reach vault data paths?
+
+  Returns `:ok`, or `{:error, missing, next_step}` where `missing` is the
+  sorted list of unmet requirements (`"terms"`, `"subscription"`, `"profile"`,
+  `"vault"`).
+
+  Both enforcement points route through here — `EngramWeb.Plugs.RequireOnboarding`
+  (HTTP) and the `sync:` / `crdt:` channel joins (WebSocket). Sync lives on
+  Phoenix Channels and a Plug never runs on a socket, so this rule cannot live
+  in the router pipeline alone: it did, and an account that skipped ToS and
+  plan selection synced a whole vault over the socket while every REST route
+  correctly 403'd it.
+
+  PASS verdicts are cached per node (`Engram.Onboarding.GateCache`); failing
+  users always take the authoritative slow path.
+  """
+  @spec gate(Engram.Accounts.User.t()) :: :ok | {:error, [String.t()], atom()}
+  def gate(%{id: user_id} = user) do
+    if GateCache.passed?(user_id), do: :ok, else: derive_gate(user, status(user))
+  end
+
+  defp derive_gate(user, %{next_step: :done}) do
+    :ok = GateCache.mark_passed(user.id)
+    :ok
+  end
+
+  defp derive_gate(user, status) do
+    %{
+      terms_ok: terms_ok,
+      subscription_ok: sub_ok,
+      profile_complete: profile_ok,
+      next_step: next_step
+    } = status
+
+    has_vault = Map.get(status, :has_vault, true)
+    profile = Map.get(status, :profile) || %{}
+    # uses_obsidian users bypass the vault gate (the plugin creates the vault).
+    vault_required = profile_ok and Map.get(profile, "uses_obsidian") != true
+
+    missing =
+      []
+      |> then(&if terms_ok, do: &1, else: ["terms" | &1])
+      |> then(&if sub_ok, do: &1, else: ["subscription" | &1])
+      |> then(&if profile_ok, do: &1, else: ["profile" | &1])
+      |> then(&if not vault_required or has_vault, do: &1, else: ["vault" | &1])
+      |> Enum.sort()
+
+    if missing == [] do
+      # All enforced gates pass even though wizard navigation isn't `:done`
+      # yet (e.g. obsidian user mid-flow whose plugin is about to first-sync).
+      # Runtime traffic permission and wizard state are intentionally
+      # decoupled — see `next_step/5`.
+      :ok = GateCache.mark_passed(user.id)
+      :ok
+    else
+      {:error, missing, next_step}
+    end
   end
 
   # Enumerates the full step chain so the frontend can render "Step X of N"

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -122,18 +122,7 @@ defmodule EngramWeb.CrdtChannel do
 
     user_id_str = to_string(user.id)
 
-    # The onboarding gate is enforced here, not by a router pipeline:
-    # `RequireOnboarding` is a Plug and Plugs never run on a socket. This is
-    # the live sync write path, so an account that skipped ToS / plan
-    # selection reached a full read-write vault through it while every REST
-    # route correctly 403'd. Same verdict function as the plug.
-    case Engram.Onboarding.gate(user) do
-      :ok ->
-        join_rotation_checked(ids, user, user_id_str, socket)
-
-      {:error, missing, next_step} ->
-        {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
-    end
+    join_rotation_checked(ids, user, user_id_str, socket)
   end
 
   defp join_rotation_checked(ids, user, user_id_str, socket) do
@@ -149,7 +138,36 @@ defmodule EngramWeb.CrdtChannel do
     end
   end
 
+  # Enforced here, not by a router pipeline: `RequireOnboarding` is a Plug and
+  # Plugs never run on a socket, and this is the live sync write path — an
+  # account that skipped ToS / plan selection reached a full read-write vault
+  # through it while every REST route correctly 403'd. Same verdict function
+  # as the plug (`Engram.Onboarding.gate/1`).
+  #
+  # Deliberately positioned AFTER the topic ownership match and after
+  # `RotationGate.check/1`: the match is free, so a `crdt:<other-user>:<uuid>`
+  # probe must not buy ~4 DB round-trips (there is no join rate limiter), and
+  # a user mid-DEK-rotation must still get `rotation_in_progress` rather than
+  # this. The plugin's identity self-heal also keys on `unauthorized`
+  # specifically (channel.ts, e2e test_84) — gating ahead of the match would
+  # have replaced that reason and wedged the heal.
   defp join_vault("crdt:" <> ids, user, user_id_str, socket) do
+    case String.split(ids, ":") do
+      [^user_id_str, _vid] ->
+        case Engram.Onboarding.gate(user) do
+          :ok ->
+            join_gated_vault("crdt:" <> ids, user, user_id_str, socket)
+
+          {:error, missing, next_step} ->
+            {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
+        end
+
+      _ ->
+        {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  defp join_gated_vault("crdt:" <> ids, user, user_id_str, socket) do
     case String.split(ids, ":") do
       [^user_id_str, vid_str] ->
         case Ecto.UUID.cast(vid_str) do

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -122,6 +122,21 @@ defmodule EngramWeb.CrdtChannel do
 
     user_id_str = to_string(user.id)
 
+    # The onboarding gate is enforced here, not by a router pipeline:
+    # `RequireOnboarding` is a Plug and Plugs never run on a socket. This is
+    # the live sync write path, so an account that skipped ToS / plan
+    # selection reached a full read-write vault through it while every REST
+    # route correctly 403'd. Same verdict function as the plug.
+    case Engram.Onboarding.gate(user) do
+      :ok ->
+        join_rotation_checked(ids, user, user_id_str, socket)
+
+      {:error, missing, next_step} ->
+        {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
+    end
+  end
+
+  defp join_rotation_checked(ids, user, user_id_str, socket) do
     # T3.7 (#1092): the crdt: channel is the live write path — refuse to open it
     # while a DEK rotation holds the user's lock. check/1 re-reads the row so a
     # reconnect mid-rotation is caught even if the socket's user struct predates

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -31,28 +31,31 @@ defmodule EngramWeb.SyncChannel do
   end
 
   defp do_join(ids, params, socket, user) do
-    # Enforced here, not by a router pipeline: `RequireOnboarding` is a Plug
-    # and Plugs never run on a socket. See `Engram.Onboarding.gate/1`.
-    case Engram.Onboarding.gate(user) do
-      :ok ->
-        do_join_onboarded(ids, params, socket, user)
-
-      {:error, missing, next_step} ->
-        {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
-    end
-  end
-
-  defp do_join_onboarded(ids, params, socket, user) do
     case String.split(ids, ":") do
       [user_id_str, vault_id_str] ->
         if to_string(user.id) == user_id_str do
-          resolve_vault_and_join(vault_id_str, params, socket, user)
+          gate_and_join(vault_id_str, params, socket, user)
         else
           {:error, %{reason: "unauthorized"}}
         end
 
       _ ->
         {:error, %{reason: "invalid_topic"}}
+    end
+  end
+
+  # Enforced here, not by a router pipeline: `RequireOnboarding` is a Plug and
+  # Plugs never run on a socket. Same verdict function as the plug
+  # (`Engram.Onboarding.gate/1`). Runs AFTER the topic ownership match, which
+  # is free — deriving the verdict costs ~4 DB round-trips and there is no
+  # join rate limiter, so a `sync:<other-user>:<uuid>` probe must not pay it.
+  defp gate_and_join(vault_id_str, params, socket, user) do
+    case Engram.Onboarding.gate(user) do
+      :ok ->
+        resolve_vault_and_join(vault_id_str, params, socket, user)
+
+      {:error, missing, next_step} ->
+        {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
     end
   end
 

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -31,6 +31,18 @@ defmodule EngramWeb.SyncChannel do
   end
 
   defp do_join(ids, params, socket, user) do
+    # Enforced here, not by a router pipeline: `RequireOnboarding` is a Plug
+    # and Plugs never run on a socket. See `Engram.Onboarding.gate/1`.
+    case Engram.Onboarding.gate(user) do
+      :ok ->
+        do_join_onboarded(ids, params, socket, user)
+
+      {:error, missing, next_step} ->
+        {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
+    end
+  end
+
+  defp do_join_onboarded(ids, params, socket, user) do
     case String.split(ids, ":") do
       [user_id_str, vault_id_str] ->
         if to_string(user.id) == user_id_str do

--- a/lib/engram_web/channels/user_channel.ex
+++ b/lib/engram_web/channels/user_channel.ex
@@ -22,4 +22,15 @@ defmodule EngramWeb.UserChannel do
       {:error, %{reason: "unauthorized"}}
     end
   end
+
+  # Server-push-only is a CLIENT convention; Phoenix does not enforce it.
+  # `Phoenix.Channel.Server.handle_info/2` dispatches inbound events straight
+  # to `socket.channel.handle_in/3`, so with no clause here any frame a client
+  # sends raises UndefinedFunctionError and kills the channel process. This
+  # topic is deliberately reachable before onboarding completes (the FTUX vault
+  # screen needs it), which means it is reachable by accounts that have
+  # accepted nothing and paid nothing — so it has to tolerate being talked to.
+  # Ignore rather than reply: there is no client request shape to answer.
+  @impl true
+  def handle_in(_event, _payload, socket), do: {:noreply, socket}
 end

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -10,7 +10,14 @@ defmodule EngramWeb.DeviceAuthController do
   # `RequireOnboarding` from the vault-scoped pipeline — declare it here. The
   # socket-side gate in `SyncChannel`/`CrdtChannel` is the authority; this is
   # the readable error.
-  plug EngramWeb.Plugs.RequireOnboarding when action in [:authorize]
+  # `skip_vault: true`: this endpoint CREATES the first vault (`vault_id: "new"`),
+  # so gating it on "you already have one" makes it permanently unreachable for
+  # the exact user who needs it. `Vaults.delete_vault/2` evicts the gate cache
+  # on last-vault deletion precisely because zero-vault users are a real state.
+  # Every other requirement (terms, subscription, profile) still applies, and
+  # the sync channels enforce the vault rule too — nothing reaches data through
+  # this relaxation.
+  plug EngramWeb.Plugs.RequireOnboarding, [skip_vault: true] when action in [:authorize]
 
   # Gate new plugin connections at the per-tier obsidian cap. Only on
   # :authorize — start/token/refresh do not mint new connection families.

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -4,6 +4,14 @@ defmodule EngramWeb.DeviceAuthController do
   alias Engram.Auth.DeviceFlow
   alias Engram.Vaults
 
+  # Fail the link at the moment the user clicks "connect", not later with a
+  # silent socket refusal. This route sits on the user-scoped pipeline (it must
+  # stay reachable for vault creation), so it does not inherit
+  # `RequireOnboarding` from the vault-scoped pipeline — declare it here. The
+  # socket-side gate in `SyncChannel`/`CrdtChannel` is the authority; this is
+  # the readable error.
+  plug EngramWeb.Plugs.RequireOnboarding when action in [:authorize]
+
   # Gate new plugin connections at the per-tier obsidian cap. Only on
   # :authorize — start/token/refresh do not mint new connection families.
   plug EngramWeb.Plugs.EnforceDeviceCap when action in [:authorize]

--- a/lib/engram_web/plugs/require_onboarding.ex
+++ b/lib/engram_web/plugs/require_onboarding.ex
@@ -7,6 +7,12 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
   Self-host (billing off): profile + vault. SaaS: agreement + billing +
   profile + vault.
 
+  This is the HTTP half of the gate only. The verdict itself lives in
+  `Engram.Onboarding.gate/1` because the WebSocket sync path (`sync:` /
+  `crdt:` channel joins) must enforce the same rule and a Plug never runs
+  on a socket. Adding a route to the vault pipeline gets you this plug;
+  adding a *channel* does not — call `Onboarding.gate/1` from its `join/3`.
+
   Must run after `EngramWeb.Plugs.Auth` (needs `conn.assigns.current_user`)
   and after `EngramWeb.Plugs.RotationLockCheck`. May run before or after
   `VaultPlug`; in this codebase it runs immediately before VaultPlug so
@@ -14,7 +20,6 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
   """
 
   alias Engram.Onboarding
-  alias Engram.Onboarding.GateCache
   alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
@@ -25,60 +30,17 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
         Halt.json(conn, 401, %{error: "authentication_required"})
 
       user ->
-        # Deriving status costs ~3 DB round-trips (profile re-read +
-        # has_vault? in its own RLS transaction) on EVERY vault-scoped
-        # request. The verdict is cached on pass; failing users always
-        # take the authoritative slow path. Eviction contract lives in
-        # the GateCache moduledoc.
-        if GateCache.passed?(user.id) do
-          conn
-        else
-          gate(conn, Onboarding.status(user), user)
+        case Onboarding.gate(user) do
+          :ok ->
+            conn
+
+          {:error, missing, next_step} ->
+            Halt.json(conn, 403, %{
+              error: "onboarding_required",
+              missing: missing,
+              next_step: next_step
+            })
         end
-    end
-  end
-
-  defp gate(conn, %{next_step: :done}, user) do
-    :ok = GateCache.mark_passed(user.id)
-    conn
-  end
-
-  defp gate(
-         conn,
-         %{
-           terms_ok: terms_ok,
-           subscription_ok: sub_ok,
-           profile_complete: profile_ok,
-           next_step: next_step
-         } = status,
-         user
-       ) do
-    has_vault = Map.get(status, :has_vault, true)
-    # uses_obsidian users bypass the vault gate (plugin creates vault later).
-    profile = Map.get(status, :profile, %{})
-    vault_required = profile_ok and Map.get(profile || %{}, "uses_obsidian") != true
-
-    missing =
-      []
-      |> then(&if terms_ok, do: &1, else: ["terms" | &1])
-      |> then(&if sub_ok, do: &1, else: ["subscription" | &1])
-      |> then(&if profile_ok, do: &1, else: ["profile" | &1])
-      |> then(&if not vault_required or has_vault, do: &1, else: ["vault" | &1])
-      |> Enum.sort()
-
-    if missing == [] do
-      # All enforced gates pass even though wizard navigation isn't `:done`
-      # yet (e.g. obsidian user mid-flow whose plugin is about to first-sync).
-      # Runtime traffic permission and wizard state are intentionally
-      # decoupled — see `Engram.Onboarding.next_step/5`.
-      :ok = GateCache.mark_passed(user.id)
-      conn
-    else
-      Halt.json(conn, 403, %{
-        error: "onboarding_required",
-        missing: missing,
-        next_step: next_step
-      })
     end
   end
 end

--- a/lib/engram_web/plugs/require_onboarding.ex
+++ b/lib/engram_web/plugs/require_onboarding.ex
@@ -13,6 +13,10 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
   on a socket. Adding a route to the vault pipeline gets you this plug;
   adding a *channel* does not — call `Onboarding.gate/1` from its `join/3`.
 
+  Accepts the same options as `Engram.Onboarding.gate/2` — notably
+  `skip_vault: true`, for routes whose own job is creating the first vault
+  (see `EngramWeb.DeviceAuthController`).
+
   Must run after `EngramWeb.Plugs.Auth` (needs `conn.assigns.current_user`)
   and after `EngramWeb.Plugs.RotationLockCheck`. May run before or after
   `VaultPlug`; in this codebase it runs immediately before VaultPlug so
@@ -24,13 +28,13 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
 
   def init(opts), do: opts
 
-  def call(conn, _opts) do
+  def call(conn, opts) do
     case conn.assigns[:current_user] do
       nil ->
         Halt.json(conn, 401, %{error: "authentication_required"})
 
       user ->
-        case Onboarding.gate(user) do
+        case Onboarding.gate(user, opts) do
           :ok ->
             conn
 

--- a/test/engram/onboarding_gate_test.exs
+++ b/test/engram/onboarding_gate_test.exs
@@ -1,0 +1,99 @@
+defmodule Engram.OnboardingGateTest do
+  @moduledoc """
+  Direct unit tests for `Engram.Onboarding.gate/2` — the verdict function both
+  the HTTP plug and the `sync:`/`crdt:` channel joins delegate to. Everything
+  else tests it through a transport; this pins the contract itself.
+  """
+  use Engram.DataCase, async: false
+
+  alias Engram.Legal.VersionCache
+  alias Engram.LegalFixtures
+  alias Engram.Onboarding
+  alias Engram.Onboarding.GateCache
+
+  setup do
+    prev = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+
+    LegalFixtures.insert_version(
+      document: "terms_of_service",
+      version: "2026-05-15",
+      content_hash: "canonical",
+      material: true,
+      effective_date: nil
+    )
+
+    VersionCache.invalidate_all()
+    GateCache.evict_all()
+
+    on_exit(fn ->
+      Application.put_env(:engram, :billing_enabled, prev)
+      VersionCache.invalidate_all()
+      GateCache.evict_all()
+    end)
+
+    :ok
+  end
+
+  test "a fresh account is missing terms and subscription" do
+    user = insert_user(onboarding_profile: %{})
+    assert {:error, missing, :agreement} = Onboarding.gate(user)
+    assert "terms" in missing
+    assert "subscription" in missing
+    assert "profile" in missing
+  end
+
+  test "passing marks the cache; failing never does" do
+    blocked = insert_user(onboarding_profile: %{})
+    assert {:error, _, _} = Onboarding.gate(blocked)
+    refute GateCache.passed?(blocked.id), "a FAIL verdict must not be cached"
+
+    passing = onboarded_user()
+    assert :ok = Onboarding.gate(passing)
+    assert GateCache.passed?(passing.id)
+  end
+
+  test "uses_obsidian bypasses the vault requirement; the fresh path does not" do
+    obsidian = onboarded_user(uses_obsidian: true)
+    refute Engram.Vaults.has_vault?(obsidian)
+    assert :ok = Onboarding.gate(obsidian)
+
+    fresh = onboarded_user(uses_obsidian: false)
+    refute Engram.Vaults.has_vault?(fresh)
+    assert {:error, ["vault"], _} = Onboarding.gate(fresh)
+  end
+
+  test "skip_vault relaxes ONLY the vault rule" do
+    fresh = onboarded_user(uses_obsidian: false)
+    assert {:error, ["vault"], _} = Onboarding.gate(fresh)
+    assert :ok = Onboarding.gate(fresh, skip_vault: true)
+
+    # Still gated on everything else.
+    blocked = insert_user(onboarding_profile: %{})
+    assert {:error, missing, _} = Onboarding.gate(blocked, skip_vault: true)
+    assert "terms" in missing
+    assert "subscription" in missing
+  end
+
+  test "self-host disables terms and billing, NOT profile" do
+    Application.put_env(:engram, :billing_enabled, false)
+    GateCache.evict_all()
+
+    user = insert_user(onboarding_profile: %{})
+    assert {:error, ["profile"], _} = Onboarding.gate(user)
+
+    {:ok, done} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+    GateCache.evict_all()
+    assert :ok = Onboarding.gate(done)
+  end
+
+  defp onboarded_user(opts \\ []) do
+    uses_obsidian = Keyword.get(opts, :uses_obsidian, true)
+    user = insert_user(onboarding_profile: %{})
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, user} = Onboarding.accept_free_tier(user)
+    {:ok, user} = Onboarding.set_profile(user, %{uses_obsidian: uses_obsidian, tools: ["claude"]})
+    GateCache.evict_all()
+    user
+  end
+end

--- a/test/engram_web/onboarding_gate_channel_test.exs
+++ b/test/engram_web/onboarding_gate_channel_test.exs
@@ -1,0 +1,137 @@
+defmodule EngramWeb.OnboardingGateChannelTest do
+  @moduledoc """
+  Sync moved to Phoenix Channels; `RequireOnboarding` is a Plug and a Plug
+  never runs on a socket. These tests pin the WebSocket half of the gate so a
+  user who skipped ToS + plan selection cannot sync a vault anyway.
+
+  The `user:` channel is deliberately NOT gated — the FTUX vault screen joins
+  it mid-wizard to wait for `vault_created`/`vault_populated`, so gating it
+  would deadlock the very onboarding step it is meant to enforce.
+  """
+  use EngramWeb.ChannelCase, async: false
+
+  alias Engram.Legal.VersionCache
+  alias Engram.LegalFixtures
+  alias Engram.Onboarding
+  alias Engram.Onboarding.GateCache
+  alias Engram.Vaults
+
+  setup do
+    prev_enabled = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+
+    LegalFixtures.insert_version(
+      document: "terms_of_service",
+      version: "2026-05-15",
+      content_hash: "canonical",
+      material: true,
+      effective_date: nil
+    )
+
+    VersionCache.invalidate_all()
+    GateCache.evict_all()
+
+    on_exit(fn ->
+      Application.put_env(:engram, :billing_enabled, prev_enabled)
+      VersionCache.invalidate_all()
+      GateCache.evict_all()
+    end)
+
+    # The reported staging account: signed up, never accepted ToS, never
+    # picked a plan. `onboarding_profile: %{}` is the factory's documented
+    # opt-out of its "already onboarded" default.
+    user = insert_user(onboarding_profile: %{})
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, vault} = Vaults.create_vault(user, %{name: "Ungated"})
+
+    {:ok, user: user, vault: vault, socket: user_socket(user)}
+  end
+
+  defp complete_onboarding!(user) do
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, user} = Onboarding.accept_free_tier(user)
+    {:ok, user} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+    GateCache.evict_all()
+    user
+  end
+
+  describe "crdt: channel (the live sync write path)" do
+    test "join is refused for an un-onboarded user", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
+      assert {:error, %{reason: "onboarding_required"} = err} =
+               subscribe_and_join(
+                 socket,
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      assert "terms" in err.missing
+      assert "subscription" in err.missing
+    end
+
+    test "join succeeds once onboarding completes", %{user: user, vault: vault} do
+      user = complete_onboarding!(user)
+
+      assert {:ok, _, joined} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, self(), joined.channel_pid)
+    end
+
+    test "self-host (billing disabled) is unaffected", %{user: user, vault: vault} do
+      Application.put_env(:engram, :billing_enabled, false)
+      GateCache.evict_all()
+      {:ok, user} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      GateCache.evict_all()
+
+      assert {:ok, _, joined} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, self(), joined.channel_pid)
+    end
+  end
+
+  describe "sync: channel (manifest / legacy pull path)" do
+    test "join is refused for an un-onboarded user", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
+      assert {:error, %{reason: "onboarding_required"}} =
+               subscribe_and_join(
+                 socket,
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+    end
+
+    test "join succeeds once onboarding completes", %{user: user, vault: vault} do
+      user = complete_onboarding!(user)
+      assert {:ok, _, _} = join_sync(user_socket(user), user, vault)
+    end
+  end
+
+  describe "user: channel (wizard notifications)" do
+    test "join is ALLOWED un-onboarded — the FTUX vault screen depends on it", %{
+      socket: socket,
+      user: user
+    } do
+      assert {:ok, %{plan: %{tier: :free}}, _} =
+               subscribe_and_join(socket, EngramWeb.UserChannel, "user:#{user.id}")
+    end
+  end
+end

--- a/test/engram_web/onboarding_gate_channel_test.exs
+++ b/test/engram_web/onboarding_gate_channel_test.exs
@@ -10,10 +10,12 @@ defmodule EngramWeb.OnboardingGateChannelTest do
   """
   use EngramWeb.ChannelCase, async: false
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias Engram.Legal.VersionCache
   alias Engram.LegalFixtures
   alias Engram.Onboarding
   alias Engram.Onboarding.GateCache
+  alias Engram.Repo
   alias Engram.Vaults
 
   setup do
@@ -84,7 +86,28 @@ defmodule EngramWeb.OnboardingGateChannelTest do
                  %{"crdt_proto" => 2}
                )
 
-      Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, self(), joined.channel_pid)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+    end
+
+    # Counterpart to the positive self-host test below, mirroring
+    # `require_onboarding_test.exs`. Without this, short-circuiting `gate/1`
+    # to `:ok` whenever `billing_enabled` is false passes the entire suite:
+    # the positive test satisfies every precondition for a pass, so it stays
+    # green even if the gate is deleted from both channels outright.
+    test "self-host still gates on profile — billing off is not auth off", %{
+      user: user,
+      vault: vault
+    } do
+      Application.put_env(:engram, :billing_enabled, false)
+      GateCache.evict_all()
+
+      assert {:error, %{reason: "onboarding_required", missing: ["profile"]}} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
     end
 
     test "self-host (billing disabled) is unaffected", %{user: user, vault: vault} do
@@ -101,7 +124,87 @@ defmodule EngramWeb.OnboardingGateChannelTest do
                  %{"crdt_proto" => 2}
                )
 
-      Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, self(), joined.channel_pid)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+    end
+  end
+
+  describe "gate ordering (the checks it must not displace)" do
+    # A `crdt:<other-user>:<uuid>` probe costs zero DB work. Deriving the
+    # onboarding verdict costs ~4 round-trips including an RLS transaction,
+    # and there is no join rate limiter — so the free ownership match has to
+    # come first. The plugin's identity self-heal also keys on this exact
+    # reason (channel.ts, e2e test_84); replacing it wedges the heal.
+    test "a foreign topic still returns unauthorized, not onboarding_required", %{
+      socket: socket,
+      vault: vault
+    } do
+      other = insert_user(onboarding_profile: %{})
+
+      assert {:error, %{reason: "unauthorized"}} =
+               subscribe_and_join(
+                 socket,
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{other.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+    end
+
+    test "sync: foreign topic likewise", %{socket: socket, vault: vault} do
+      other = insert_user(onboarding_profile: %{})
+
+      assert {:error, %{reason: "unauthorized"}} =
+               subscribe_and_join(socket, EngramWeb.SyncChannel, "sync:#{other.id}:#{vault.id}")
+    end
+
+    # T3.7: a user mid-DEK-rotation must hear rotation_in_progress. Gating
+    # ahead of RotationGate.check/1 would have swallowed it.
+    test "rotation_in_progress outranks onboarding_required", %{user: user, vault: vault} do
+      {:ok, _} =
+        user
+        |> Ecto.Changeset.change(dek_rotation_locked_at: DateTime.utc_now())
+        |> Repo.update()
+
+      assert {:error, %{reason: "rotation_in_progress"}} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+    end
+  end
+
+  describe "socket-frozen user struct" do
+    # `UserSocket` assigns current_user ONCE at connect/3. A Free user who
+    # finishes onboarding mid-session (accept_free_tier is a bare Repo.update
+    # with no socket disconnect) must not be judged on the stale struct — it
+    # would lock them out for the life of the connection, and Free is the
+    # default cohort. Note the socket is built BEFORE onboarding completes.
+    test "completing onboarding on an already-open socket takes effect", %{
+      user: user,
+      vault: vault,
+      socket: socket
+    } do
+      assert {:error, %{reason: "onboarding_required"}} =
+               subscribe_and_join(
+                 socket,
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      _ = complete_onboarding!(user)
+
+      # Same stale socket, no reconnect.
+      assert {:ok, _, joined} =
+               subscribe_and_join(
+                 socket,
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      Sandbox.allow(Repo, self(), joined.channel_pid)
     end
   end
 
@@ -132,6 +235,26 @@ defmodule EngramWeb.OnboardingGateChannelTest do
     } do
       assert {:ok, %{plan: %{tier: :free}}, _} =
                subscribe_and_join(socket, EngramWeb.UserChannel, "user:#{user.id}")
+    end
+
+    # Leaving `user:` open is deliberate, so it has to survive being talked to.
+    # Phoenix dispatches inbound events unconditionally
+    # (`Phoenix.Channel.Server.handle_info/2` -> `socket.channel.handle_in/3`),
+    # so a channel with no `handle_in/3` clause raises UndefinedFunctionError
+    # and the process dies. Server-push-only is a client convention, not an
+    # enforced one — and this topic is reachable by accounts that have accepted
+    # nothing and paid nothing.
+    test "an unsolicited client push does not kill the channel", %{
+      socket: socket,
+      user: user
+    } do
+      {:ok, _, joined} = subscribe_and_join(socket, EngramWeb.UserChannel, "user:#{user.id}")
+      ref = Process.monitor(joined.channel_pid)
+
+      push(joined, "definitely_not_a_real_event", %{"x" => 1})
+
+      refute_receive {:DOWN, ^ref, :process, _, _}, 300
+      assert Process.alive?(joined.channel_pid)
     end
   end
 end

--- a/test/engram_web/onboarding_gate_integration_test.exs
+++ b/test/engram_web/onboarding_gate_integration_test.exs
@@ -5,6 +5,9 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
   alias Engram.Auth.DeviceFlow
   alias Engram.Legal.VersionCache
   alias Engram.LegalFixtures
+  alias Engram.Onboarding
+  alias Engram.Onboarding.GateCache
+  alias Engram.Vaults
 
   setup %{conn: conn} do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
@@ -34,11 +37,11 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
     end)
 
     user = insert_user()
-    _vault = insert(:vault, user: user, is_default: true)
+    vault = insert(:vault, user: user, is_default: true)
     {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
     grant_api_write!(user)
     conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
-    {:ok, conn: conn, user: user}
+    {:ok, conn: conn, user: user, vault: vault}
   end
 
   test "GET /api/folders returns 403 onboarding_required for new user", %{conn: conn} do
@@ -50,11 +53,11 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
   end
 
   test "GET /api/folders returns 200 after onboarding completes", %{conn: conn, user: user} do
-    {:ok, _} = Engram.Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
     insert(:subscription, user: user, status: "active")
     # Setup already inserts a vault — pair with uses_obsidian=false so the
     # new vault gate sees has_vault=true and lets the request through.
-    {:ok, _} = Engram.Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
+    {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
 
     conn = get(conn, "/api/folders")
     assert conn.status == 200
@@ -127,9 +130,9 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
     conn: conn,
     user: user
   } do
-    {:ok, _} = Engram.Onboarding.accept_terms(user, "2026-05-15", %{})
-    {:ok, _} = Engram.Onboarding.accept_free_tier(user)
-    {:ok, _} = Engram.Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, _} = Onboarding.accept_free_tier(user)
+    {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
 
     vault = insert(:vault, user: user)
     {:ok, auth} = DeviceFlow.start_device_flow("client_1")
@@ -143,13 +146,65 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
     assert json_response(resp, 200)["ok"] == true
   end
 
+  # Catch-22: `vault_id: "new"` is the endpoint that CREATES the first vault,
+  # so gating it on "you must already have a vault" makes it permanently
+  # unreachable for the exact user who needs it. `Vaults.delete_vault/2`
+  # evicts the gate cache on last-vault deletion specifically because it
+  # "can flip the onboarding gate back to failing" — so zero-vault users are
+  # an anticipated state, not a hypothetical.
+  test "device authorize with vault_id=new works for a user with NO vault", %{
+    conn: conn,
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, _} = Onboarding.accept_free_tier(user)
+    # uses_obsidian=false is what makes the vault gate apply at all.
+    {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
+    # The real path into this state: delete_vault/2 evicts the gate cache
+    # itself, precisely because the last deletion can flip the gate.
+    {:ok, _} = Vaults.delete_vault(user, vault.id)
+    GateCache.evict_all()
+
+    refute Vaults.has_vault?(user)
+    {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+
+    resp =
+      post(conn, "/api/auth/device/authorize", %{
+        user_code: auth.user_code,
+        vault_id: "new",
+        vault_name: "First Vault"
+      })
+
+    assert json_response(resp, 200)["ok"] == true
+  end
+
+  # The relaxed verdict must never reach the cache: the channels read the same
+  # cache, and a cached PASS earned by skipping the vault rule would hand the
+  # full sync path to a user the strict rule rejects.
+  test "skip_vault passes WITHOUT caching the verdict" do
+    user = insert_user()
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, _} = Onboarding.accept_free_tier(user)
+    {:ok, user} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
+    GateCache.evict_all()
+
+    refute Vaults.has_vault?(user)
+
+    # `user` here is deliberately the struct from BEFORE accept_free_tier —
+    # gate/2 must re-read the row rather than trust it (socket-frozen structs).
+    assert :ok = Onboarding.gate(user, skip_vault: true)
+    refute GateCache.passed?(user.id)
+    assert {:error, ["vault"], _} = Onboarding.gate(user)
+  end
+
   test "suspended user gets 402 from RequireActiveSubscription on vault routes",
        %{conn: conn, user: user} do
     # Pass onboarding fully: terms accepted, Free tier accepted (counts as
     # subscription_ok), profile complete, vault present (setup already added one).
-    {:ok, _} = Engram.Onboarding.accept_terms(user, "2026-05-15", %{})
-    {:ok, user} = Engram.Onboarding.accept_free_tier(user)
-    {:ok, _} = Engram.Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, user} = Onboarding.accept_free_tier(user)
+    {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
 
     # Now suspend the user — RequireOnboarding still passes (Free accepted),
     # but RequireActiveSubscription should halt with 402 account_suspended.

--- a/test/engram_web/onboarding_gate_integration_test.exs
+++ b/test/engram_web/onboarding_gate_integration_test.exs
@@ -2,6 +2,7 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
   use EngramWeb.ConnCase, async: false
 
   alias Engram.Accounts
+  alias Engram.Auth.DeviceFlow
   alias Engram.Legal.VersionCache
   alias Engram.LegalFixtures
 
@@ -99,6 +100,47 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
     body = %{path: "Test/note.md", content: "# Hi", mtime: 1_700_000_000.0}
     resp = post(conn, "/api/notes", body)
     assert resp.status in [200, 201]
+  end
+
+  # The device-link flow lives on the user-scoped pipeline (it must stay
+  # reachable so the wizard can create a first vault), so it does NOT inherit
+  # RequireOnboarding from the vault pipeline — it declares the plug itself.
+  # Without this the plugin links happily and only discovers the problem as a
+  # silent channel-join refusal.
+  test "POST /api/auth/device/authorize is gated", %{conn: conn, user: user} do
+    vault = insert(:vault, user: user)
+    {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+
+    resp =
+      post(conn, "/api/auth/device/authorize", %{
+        user_code: auth.user_code,
+        vault_id: vault.id
+      })
+
+    assert json_response(resp, 403)["error"] == "onboarding_required"
+
+    assert {:error, :authorization_pending} =
+             DeviceFlow.exchange_device_code(auth.device_code)
+  end
+
+  test "POST /api/auth/device/authorize succeeds once onboarding completes", %{
+    conn: conn,
+    user: user
+  } do
+    {:ok, _} = Engram.Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, _} = Engram.Onboarding.accept_free_tier(user)
+    {:ok, _} = Engram.Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+
+    vault = insert(:vault, user: user)
+    {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+
+    resp =
+      post(conn, "/api/auth/device/authorize", %{
+        user_code: auth.user_code,
+        vault_id: vault.id
+      })
+
+    assert json_response(resp, 200)["ok"] == true
   end
 
   test "suspended user gets 402 from RequireActiveSubscription on vault routes",


### PR DESCRIPTION
## The bug

Reproduced on staging: an account that had **neither accepted the ToS nor selected a plan** synced a full vault from Obsidian, and the plugin showed it as "Free tier".

`EngramWeb.Plugs.RequireOnboarding` is wired on the vault-scoped pipeline (`router.ex:55`) and correctly 403s `/api/notes`, `/api/search`, `/api/folders`. But a Plug takes a `conn` and **never runs on a socket** — and sync moved to Phoenix Channels. So the live data path checked exactly two things:

- `user_socket.ex:15` — is the token valid?
- `crdt_channel.ex:99` — do you own this vault, and is your `crdt_proto` new enough?

Both yes → join granted → full read/write sync. The plugin barely touches REST, so it never met the gate it was supposed to fail.

## The fix

Move the *verdict* out of the plug so both transports can share it.

- **`Engram.Onboarding.gate/1`** is the new single authority. Returns `:ok` or `{:error, missing, next_step}`, and keeps the existing `GateCache` pass-caching.
- `RequireOnboarding` becomes a thin 403-shaping wrapper over it (70 → 46 lines). No behavior change on the HTTP side.
- `SyncChannel.join/3` and `CrdtChannel.join/3` call it, replying `{:error, %{reason: "onboarding_required", missing: [...], next_step: ...}}`.
- `POST /api/auth/device/authorize` declares the plug directly. It lives on the user-scoped pipeline (it must stay reachable so the wizard can create a first vault), so it does not inherit the gate — without this the plugin links successfully and only discovers the problem as a silent channel-join refusal.

### `user:` is deliberately NOT gated

The FTUX vault screen joins `user:{id}` mid-wizard to wait for `vault_created` / `vault_populated` (`user_channel.ex:6`). Gating it — or gating `UserSocket.connect/3`, which would have been the tidier-looking fix — deadlocks the only path to *passing* the gate. There's a test pinning this open.

## Verification

- New `test/engram_web/onboarding_gate_channel_test.exs`: crdt + sync joins refused un-onboarded, allowed once onboarded, unaffected in self-host (`billing_enabled=false`), and `user:` still open. The two "refused" cases fail on `main` and pass here.
- Extended `onboarding_gate_integration_test.exs` with the device-authorize gate (and asserts the device code stays unexchangeable).
- 444 targeted tests green (`channels/`, `plugs/`, both gate suites, device auth, onboarding).
- `mix format`, `mix credo --strict`, `mix dialyzer` all exit 0.

## Follow-up filed separately

`config/runtime.exs` sets `:billing_enabled` **unguarded by `config_env()`**, so it clobbers `config/test.exs`'s `true` to `false` for the whole suite — the SaaS onboarding gate has never been exercised in a test. That is the reason this bug survived. Turning the flag on for real produces **429 failures / 4677**, mostly `VersionCache` leaking a terms floor across `async: true` cases. Not bundled here; it needs its own change.

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DhZTrvajwXLrxpSkq1XAp
