### PR TITLE
fix(crdt): checkpoints prune only what they folded

### DIFF
--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -123,30 +123,36 @@ defmodule Engram.Notes.CrdtCheckpoint do
   end
 
   defp do_checkpoint(user, user_id, vault_id, note_id, doc, opts) do
-    # Determine the prune boundary. `:prune_ids` (detached callers) is the exact
-    # set of folded rows — safest. Otherwise fall back to the `inserted_at`
-    # watermark path for live-room callers whose doc reflects the whole tail.
+    # Determine the prune boundary. `:prune_ids` is the exact set of rows this
+    # caller FOLDED into `doc`, and it is the only boundary that is safe on its
+    # own terms: a row nobody folded is never in the set, so it survives.
+    #
+    # Omitting it used to fall back to capturing an `inserted_at` watermark and
+    # pruning everything at or below it. That deletes rows regardless of whether
+    # the snapshotted doc contains them, which is safe ONLY while the caller is
+    # the sole tail writer — a property of who else may append, not of the
+    # checkpoint. #1391 established the same rule for the index room ("a
+    # checkpoint that prunes without that list deletes exactly the claims the
+    # tail log exists to protect"), and #1146 spec 0a showed the note-room path
+    # has the identical hole the moment a second writer exists.
+    #
+    # So the DEFAULT is now: prune nothing. Keeping rows is always recoverable
+    # (they replay on next bind, and apply_update is idempotent); deleting an
+    # unfolded row is not. A caller that wants compaction must say what it
+    # folded. `CrdtCheckpointTimer.do_checkpoint/1` folds the tail explicitly
+    # and passes the ids.
+    #
+    # `:watermark` remains as an EXPLICIT opt-in and carries the sole-writer
+    # assumption with it. Prefer `:prune_ids`; see the follow-up to retire this.
     prune =
       case Keyword.fetch(opts, :prune_ids) do
         {:ok, ids} when is_list(ids) ->
           {:ids, ids}
 
         :error ->
-          # Capture the prune watermark BEFORE reading/encoding the doc. Any tail
-          # row inserted while we encode is NOT necessarily in the snapshot, so it
-          # must survive the prune (it replays on next bind — apply_update is
-          # idempotent).
           case Keyword.fetch(opts, :watermark) do
-            {:ok, wm} ->
-              {:watermark, wm}
-
-            :error ->
-              # A capture failure degrades to nil: prune becomes a no-op, which is
-              # the safe direction (rows are kept and replayed on next bind).
-              case Repo.with_tenant(user_id, fn -> tail_watermark(note_id) end) do
-                {:ok, wm} -> {:watermark, wm}
-                _ -> {:watermark, nil}
-              end
+            {:ok, wm} -> {:watermark, wm}
+            :error -> {:ids, []}
           end
       end
 

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -82,8 +82,9 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   """
   use GenServer
 
+  alias Engram.Accounts
   alias Engram.Logger.Metadata
-  alias Engram.Notes.{CrdtCheckpoint, CrdtRegistry, CrdtRoomLru}
+  alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, CrdtPersistence, CrdtRegistry, CrdtRoomLru}
 
   require Logger
 
@@ -444,8 +445,34 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     captured_version = CrdtCheckpoint.current_version(state.user_id, state.room_key)
     doc = Yex.Sync.SharedDoc.get_doc(room_pid)
 
-    CrdtCheckpoint.checkpoint(state.user_id, state.vault_id, state.room_key, doc,
-      captured_version: captured_version
+    # Prune EXACTLY what this snapshot folded (#1146 spec 0a).
+    #
+    # Passing no `:prune_ids` takes the WATERMARK branch, which deletes every
+    # tail row at or below the watermark whether or not the snapshotted doc
+    # folded it. That is safe only while the room is the SOLE tail writer, so
+    # its doc provably reflects every row that exists — a property of who may
+    # append, not of the checkpoint. A row appended by anyone else after the
+    # room bound is in no snapshot and would be deleted unfolded: gone from the
+    # tail AND absent from crdt_state.
+    #
+    # This is the rule #1391 already established for the index room ("a
+    # checkpoint that prunes without that list deletes exactly the claims the
+    # tail log exists to protect"), which sidesteps it by never checkpointing
+    # from a tick. A note room ticks, so it has to fold instead.
+    #
+    # Fold the durable tail into a transient doc seeded from the room's ENCODED
+    # STATE, never from its projected text: a doc rebuilt from text is a
+    # different Yjs lineage and unions into a duplicated body. The room's own
+    # doc is a NIF resource owned by the room process, so it is never mutated
+    # from here.
+    user = Accounts.get_user!(state.user_id)
+    {:ok, encoded} = Yex.encode_state_as_update(doc)
+    {:ok, folded} = CrdtBridge.doc_from_state(encoded)
+    prune_ids = CrdtPersistence.replay_tail(folded, user, state.room_key)
+
+    CrdtCheckpoint.checkpoint(state.user_id, state.vault_id, state.room_key, folded,
+      captured_version: captured_version,
+      prune_ids: prune_ids
     )
   rescue
     err -> log_read_failure(state, err)

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -491,10 +491,21 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
         # all run it under `with_tenant`). Without one, RLS returns no rows,
         # `prune_ids` comes back empty, and compaction silently stops — the
         # tail grows forever and nothing reports it.
-        {:ok, prune_ids} =
-          Repo.with_tenant(state.user_id, fn ->
-            CrdtPersistence.replay_tail(folded, user, state.room_key)
-          end)
+        # Degrade, never abort. `with_tenant/2` does not always return
+        # `{:ok, _}` — `CrdtCheckpoint` has carried a catch-all arm for its own
+        # call since the watermark days. A hard match here would raise into the
+        # rescue below and skip the checkpoint ENTIRELY, so a transient tenant
+        # failure would also stop `notes.content` materializing. That is the one
+        # thing this timer exists to do promptly (see "Eager first flush").
+        # Folding nothing costs a delayed compaction; not checkpointing costs
+        # every non-CRDT reader a stale note.
+        prune_ids =
+          case Repo.with_tenant(state.user_id, fn ->
+                 CrdtPersistence.replay_tail(folded, user, state.room_key)
+               end) do
+            {:ok, ids} when is_list(ids) -> ids
+            _ -> []
+          end
 
         CrdtCheckpoint.checkpoint(state.user_id, state.vault_id, state.room_key, folded,
           captured_version: captured_version,

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -82,7 +82,7 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
   """
   use GenServer
 
-  alias Engram.Accounts
+  alias Engram.{Accounts, Repo}
   alias Engram.Logger.Metadata
   alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, CrdtPersistence, CrdtRegistry, CrdtRoomLru}
 
@@ -442,6 +442,14 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     # nil on read failure is NOT an unfenced write (it was, before #1360). The
     # version CAS is layered ON TOP of `snapshot_fence/2`, which applies to every
     # checkpoint write path unconditionally. nil just drops the extra layer.
+    #
+    # This read stays FIRST even though the fold below now adds DB work between
+    # it and the write, widening the CAS window. Moving it after the fold would
+    # invert the fence: the version could then post-date the doc state we
+    # encoded, so a REST write landing in the gap would MATCH on version while
+    # the snapshot lacks it, and the CAS would let a clobber through. A wider
+    # window only costs extra aborts, which are safe and retried on the next
+    # tick. Wrong order costs content.
     captured_version = CrdtCheckpoint.current_version(state.user_id, state.room_key)
     doc = Yex.Sync.SharedDoc.get_doc(room_pid)
 
@@ -465,15 +473,34 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     # different Yjs lineage and unions into a duplicated body. The room's own
     # doc is a NIF resource owned by the room process, so it is never mutated
     # from here.
-    user = Accounts.get_user!(state.user_id)
-    {:ok, encoded} = Yex.encode_state_as_update(doc)
-    {:ok, folded} = CrdtBridge.doc_from_state(encoded)
-    prune_ids = CrdtPersistence.replay_tail(folded, user, state.room_key)
+    # A deleted user is an expected lifecycle state (vault purge), not an error —
+    # same call and same verdict as `Workers.CheckpointNote.rebuild_detached/3`.
+    # `get_user!/1` would raise into the rescue below and log a "read failure"
+    # that never happened.
+    case Accounts.get_user(state.user_id) do
+      nil ->
+        :ok
 
-    CrdtCheckpoint.checkpoint(state.user_id, state.vault_id, state.room_key, folded,
-      captured_version: captured_version,
-      prune_ids: prune_ids
-    )
+      user ->
+        {:ok, encoded} = Yex.encode_state_as_update(doc)
+        {:ok, folded} = CrdtBridge.doc_from_state(encoded)
+
+        # `replay_tail/3` issues a BARE `Repo.all` — it sets no tenant of its
+        # own. Every other caller supplies one (`bind/3`,
+        # `CheckpointNote.rebuild_detached/3`, `CrdtChannel.fold_row_and_tail/4`
+        # all run it under `with_tenant`). Without one, RLS returns no rows,
+        # `prune_ids` comes back empty, and compaction silently stops — the
+        # tail grows forever and nothing reports it.
+        {:ok, prune_ids} =
+          Repo.with_tenant(state.user_id, fn ->
+            CrdtPersistence.replay_tail(folded, user, state.room_key)
+          end)
+
+        CrdtCheckpoint.checkpoint(state.user_id, state.vault_id, state.room_key, folded,
+          captured_version: captured_version,
+          prune_ids: prune_ids
+        )
+    end
   rescue
     err -> log_read_failure(state, err)
   catch

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -33,10 +33,18 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     {:ok, {ct1, n1}} = Crypto.encrypt_crdt_state("fake_update_1", user, note.id)
     {:ok, {ct2, n2}} = Crypto.encrypt_crdt_state("fake_update_2", user, note.id)
 
+    # Capture the ids: a checkpoint prunes exactly the rows the caller declares
+    # it FOLDED (#1146 spec 0a). These payloads are synthetic and no doc folds
+    # them, so passing them explicitly is what makes this a compaction test
+    # rather than a re-assertion of the watermark bug — that branch deleted
+    # unfolded rows, which is the defect 0a removed.
+    tail_id_1 = Ecto.UUID.generate()
+    tail_id_2 = Ecto.UUID.generate()
+
     Repo.with_tenant(user.id, fn ->
       Repo.insert_all(CrdtUpdateLog, [
         %{
-          id: Ecto.UUID.generate(),
+          id: tail_id_1,
           note_id: note.id,
           user_id: user.id,
           vault_id: vault.id,
@@ -45,7 +53,7 @@ defmodule Engram.Notes.CrdtCheckpointTest do
           inserted_at: DateTime.utc_now()
         },
         %{
-          id: Ecto.UUID.generate(),
+          id: tail_id_2,
           note_id: note.id,
           user_id: user.id,
           vault_id: vault.id,
@@ -65,7 +73,11 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     assert tail_count_before == 2
 
     seq0 = Vaults.current_seq(user.id, vault.id)
-    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    :ok =
+      CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc,
+        prune_ids: [tail_id_1, tail_id_2]
+      )
 
     # get_note resolves by path_hmac — ONLY succeeds if the checkpoint
     # preserved the path/folder HMACs, which requires virtual path/folder
@@ -380,13 +392,16 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     :ok =
       CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), "before FENCED")
 
-    # Seed a tail row to prove the success path still prunes.
+    # Seed a tail row to prove the success path still prunes. Its id is declared
+    # to the checkpoint below: a checkpoint prunes exactly what the caller says
+    # it FOLDED (#1146 spec 0a), so compaction has to be asked for by id.
     {:ok, {ct, n}} = Crypto.encrypt_crdt_state("fake_update", user, note.id)
+    tail_id = Ecto.UUID.generate()
 
     Repo.with_tenant(user.id, fn ->
       Repo.insert_all(CrdtUpdateLog, [
         %{
-          id: Ecto.UUID.generate(),
+          id: tail_id,
           note_id: note.id,
           user_id: user.id,
           vault_id: vault.id,
@@ -399,7 +414,8 @@ defmodule Engram.Notes.CrdtCheckpointTest do
 
     :ok =
       CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc,
-        captured_version: captured_version
+        captured_version: captured_version,
+        prune_ids: [tail_id]
       )
 
     # Version matched → the CAS wrote (did not spuriously abort on equal versions).

--- a/test/engram/notes/crdt_doc_test.exs
+++ b/test/engram/notes/crdt_doc_test.exs
@@ -2,7 +2,7 @@ defmodule Engram.Notes.CrdtDocTest do
   use Engram.DataCase, async: false
 
   alias Engram.{Crypto, Notes, Repo, Vaults}
-  alias Engram.Notes.{CrdtBridge, CrdtRegistry, Note}
+  alias Engram.Notes.{CrdtBridge, CrdtRegistry, CrdtUpdateLog, Note}
 
   setup do
     user = insert(:user)
@@ -61,5 +61,73 @@ defmodule Engram.Notes.CrdtDocTest do
     assert spec.shutdown == 15_000
     # Still :temporary — a crashed room must not be resurrected observer-less.
     assert spec.restart == :temporary
+  end
+
+  # The timer's tick path (#1146 spec 0a). `do_checkpoint/1` now folds the
+  # durable tail itself and passes the exact ids, because passing none used to
+  # take the watermark branch and delete rows nothing folded.
+  #
+  # This exists because the fold was shipped UNTESTED: the 0a unit test drives
+  # `CrdtCheckpoint.checkpoint/5` directly, so every checkpoint suite stayed
+  # green while the timer path was never executed once. Review then found that
+  # `replay_tail/3` issues a bare `Repo.all` and needs a tenant supplied by its
+  # caller — without one the fold returns no ids and compaction silently stops.
+  # A green suite that never runs the code is not coverage.
+  test "a tick checkpoint compacts the tail it folded", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    prev = Application.get_env(:engram, Engram.Notes.CrdtCheckpointTimer, [])
+
+    # Short enough that the tick fires on its own inside this test.
+    Application.put_env(:engram, Engram.Notes.CrdtCheckpointTimer,
+      settle_ms: 50,
+      ceiling_ms: 200,
+      eager_ms: 20
+    )
+
+    on_exit(fn -> Application.put_env(:engram, Engram.Notes.CrdtCheckpointTimer, prev) end)
+
+    {:ok, room} = CrdtRegistry.ensure_started(user.id, vault.id, note.id)
+
+    # Goes through update_v1, which appends a tail row.
+    :ok =
+      Yex.Sync.SharedDoc.update_doc(room, fn doc ->
+        doc
+        |> Yex.Doc.get_text(CrdtBridge.text_name())
+        |> CrdtBridge.diff_into_text("before AND TICKED")
+      end)
+
+    tail_count = fn ->
+      {:ok, n} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.aggregate(from(l in CrdtUpdateLog, where: l.note_id == ^note.id), :count)
+        end)
+
+      n
+    end
+
+    assert tail_count.() > 0, "expected update_v1 to have appended a tail row"
+
+    # Wait for the tick to land rather than sleeping a fixed span.
+    assert eventually(fn -> tail_count.() == 0 end),
+           """
+           the tick checkpoint did not compact the tail it folded. Either the
+           fold produced no ids (a missing tenant makes replay_tail return
+           nothing) or the checkpoint never ran.
+           """
+
+    {:ok, fresh} = Notes.get_note(user, vault, "p.md")
+    assert fresh.content == "before AND TICKED"
+  end
+
+  defp eventually(fun, attempts \\ 100) do
+    Enum.reduce_while(1..attempts, false, fn _, _ ->
+      if fun.() do
+        {:halt, true}
+      else
+        Process.sleep(50)
+        {:cont, false}
+      end
+    end)
   end
 end

--- a/test/engram/notes/crdt_merge_path_test.exs
+++ b/test/engram/notes/crdt_merge_path_test.exs
@@ -4,7 +4,7 @@ defmodule Engram.Notes.CrdtMergePathTest do
   use Engram.DataCase, async: false
 
   alias Engram.{Crypto, Notes, Repo, Vaults}
-  alias Engram.Notes.{CrdtBridge, CrdtUpdateLog, Note}
+  alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, CrdtUpdateLog, Note}
 
   setup do
     user = insert(:user)
@@ -322,5 +322,59 @@ defmodule Engram.Notes.CrdtMergePathTest do
     end)
 
     :ok
+  end
+
+  # Spec 0a (docs/superpowers/specs/2026-08-19-detached-writes-room-decoupling-design.md).
+  #
+  # A live-room checkpoint passes no `:prune_ids`, so it takes the WATERMARK
+  # branch, which deletes every tail row at or below the watermark REGARDLESS of
+  # whether the doc it snapshotted folded them.
+  #
+  # That is safe only while a room is the sole tail writer, because then its doc
+  # provably reflects every row that exists. It is not a property of the
+  # checkpoint; it is a property of who else is allowed to append. The moment a
+  # second writer exists, a row landing after the room bound is snapshotted
+  # by nobody and pruned by the watermark: gone from the tail AND absent from
+  # crdt_state. That is the #285 class.
+  #
+  # Modelled here exactly as it happens: the room's doc is built from the
+  # snapshot alone (what `bind/3` had at the time), and the row lands after.
+  test "a tail row the checkpointed doc never folded is not pruned", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "unfolded.md", "content" => "BODY"})
+
+    # The room's in-memory doc, as of its bind: snapshot only.
+    raw = load_raw(user, note.id)
+    {:ok, state} = Crypto.decrypt_crdt_state(raw, user)
+    {:ok, live} = CrdtBridge.doc_from_state(state)
+
+    # A second writer appends AFTER that bind. The room's doc cannot contain it.
+    append_tail_update!(user, vault, note, " EXTRA")
+
+    # The live-room checkpoint: no :prune_ids, so the watermark branch runs.
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, live)
+
+    stored_text =
+      user
+      |> load_raw(note.id)
+      |> then(fn r -> Crypto.decrypt_crdt_state(r, user) end)
+      |> then(fn {:ok, s} -> s end)
+      |> CrdtBridge.doc_from_state()
+      |> then(fn {:ok, d} -> CrdtBridge.text_of(d) end)
+
+    {:ok, surviving_tail} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.aggregate(from(l in CrdtUpdateLog, where: l.note_id == ^note.id), :count)
+      end)
+
+    # Either the snapshot absorbed it or the tail still holds it. Neither is
+    # true today: the watermark pruned a row nothing folded.
+    assert stored_text =~ "EXTRA" or surviving_tail > 0,
+           """
+           the checkpoint pruned a tail row its doc never folded.
+           crdt_state projects #{inspect(stored_text)} and #{surviving_tail} tail
+           row(s) remain, so the " EXTRA" update exists nowhere: the next bind
+           replays an empty tail over a snapshot that never saw it. Unrecoverable.
+           """
   end
 end


### PR DESCRIPTION
## The bug

A live-room checkpoint passes no `:prune_ids`, so it took the **watermark** branch:

```elixir
defp prune_tail(note_id, {:watermark, watermark}) do
  CrdtUpdateLog |> where([l], l.note_id == ^note_id and l.inserted_at <= ^watermark) |> Repo.delete_all()
end
```

That deletes every tail row at or below the watermark **regardless of whether the snapshotted doc folded it**. It is safe only while the caller is the sole tail writer, so its doc provably reflects every row that exists. That is a property of *who else may append*, not of the checkpoint.

`#1391` already established exactly this rule for the index room:

> Only the room's own persistence state knows which tail rows failed to replay (`:unfolded_ids`), and a checkpoint that prunes without that list deletes exactly the claims the tail log exists to protect.

The index room sidesteps it by never checkpointing from a tick. **A note room ticks, so it cannot.**

## Proof

Test added in the first commit, red before the fix:

```
crdt_state projects "BODY" and 0 tail row(s) remain,
so the " EXTRA" update exists nowhere
```

A row that lands after the room bound is snapshotted by nobody and pruned by the watermark. Gone from the tail *and* absent from `crdt_state`. Unrecoverable. This is the #285 class.

## The fix

1. **`checkpoint/5` defaults to pruning nothing.** Keeping rows is always recoverable (they replay on next bind, `apply_update` is idempotent); deleting an unfolded row is not. `:watermark` survives as an explicit opt-in and carries the sole-writer assumption with it.
2. **`CrdtCheckpointTimer.do_checkpoint/1` folds the tail** into a transient doc seeded from the room's **encoded state** (not projected text, which is a different Yjs lineage and would union into a duplicated body) and passes the exact folded ids. The room's doc is a NIF resource owned by the room process and is never mutated from the timer.

## Two tests changed, and why

`crdt_checkpoint_test.exs:22` and `:416` seeded **synthetic** tail rows (`"fake_update"`) that no doc folds, then asserted the tail pruned to 0. Under the watermark default that passed, which means they were asserting the defect itself. They now declare the ids they seeded, so they still prove the success path prunes without proving it by way of the bug.

## Verification

`mix test` across all checkpoint suites (`crdt_checkpoint`, `crdt_merge_path`, `crdt_checkpoint_timer`, `checkpoint_interleave`, `crdt_checkpoint_rotation_fence`, `crdt_checkpoint_backpressure`): **61 tests, 0 failures**. Format, credo and sobelow clean via the pre-push gate. Dialyzer deferred to CI's `lint` job.

## Context

This is Phase 0a of #1425 (decoupling room creation from writes), and a hard prerequisite for it: that spec introduces a second tail writer, which is what turns this latent assumption into live data loss. It is worth landing on its own regardless, since it removes an unwritten invariant rather than relying on it.

Refs #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp