### PR TITLE
fix(auth): gate WebSocket sync on account lifecycle too

### DIFF
--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -56,9 +56,9 @@ miscount is what let the gaps below go unnoticed.
 | `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
 | `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 |
 | `BumpActivity` | stamps `last_active_at` | ✅ #1429 (see below — load-bearing) |
-| `RotationLockCheck` | 423 | ⚠️ `crdt:` only, `sync:` has none → #1434 |
-| `RequireApiWriteEnabled` | 402 | ❌ → #1433 |
-| `RequireApiRpsBudget` | 429 | ❌ → #1433 |
+| `RotationLockCheck` | 423 | ✅ #1434 — in `ChannelGate`, both channels |
+| `RequireApiWriteEnabled` | 402 | ✅ #1433 — write frames only |
+| `RequireApiRpsBudget` | 429 | ✅ #1433 — refuses the JOIN when the key's tier has `api_rps_cap: 0` |
 | `EnforceSearchCap` | 402 | ❌ (no channel equivalent) |
 | `PreAuthRateLimit` | 429 | ❌ — **there is no join rate limiter at all** |
 | `DeviceFingerprint` | — | ❌ |
@@ -69,6 +69,19 @@ miscount is what let the gaps below go unnoticed.
 `AccountLifecycle` is a *different, richer* plug on the user-scoped and
 onboarding pipelines — **not** on `:authed_api`. Getting those two confused is
 how you conclude `RequireActiveSubscription` is redundant and drop it.
+
+**API-key sockets are gated; JWT sockets are not.** Pricing v2 §G is a
+paid-API entitlement, and the exemption keys on `current_api_key` being
+**non-nil**, not on the assign existing — `UserSocket.accept/4` ALWAYS sets
+that key (nil for JWT), so porting the plugs' `not is_map_key/2` guard
+literally gates every web and plugin user on the platform. Device-flow and
+Clerk tokens resolve with a nil key and are unaffected.
+
+Consequence for tests: any test that mints an API key to exercise something
+*else* (vault restriction, join tracing, channel logging) must first call
+`grant_api_write!/1` or `grant_api_read!/1` from
+`Engram.ApiEntitlementHelpers`, or it fails on entitlement before reaching
+what it is actually testing.
 
 **`BumpActivity` is not bookkeeping.** It is the only writer of
 `usage_meters.last_active_at`, and `Workers.InactivityCleanup` soft-deletes

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -46,13 +46,36 @@ Two layers:
   vault-scoped pipeline. Composes lifecycle + onboarding and returns the map to
   reply straight from `join/3`. `SyncChannel` and `CrdtChannel` both call it.
 
-The pipeline runs three access gates; **all three now apply to sockets**:
+The vault scope pipes `:authed_api` (`router.ex:49-60`), which runs **eleven**
+plugs — not three. Do not trust a summary that says otherwise; that
+miscount is what let the gaps below go unnoticed.
 
-| `router.ex` plug | HTTP | Socket |
+| `:authed_api` plug | HTTP | Socket |
 |---|---|---|
-| `AccountLifecycle` | 410 `account_deleted` / 403 `account_suspended` | ✅ #1429 |
+| `AccountDeleted` | 410 `account_deleted` (`deleted_at` only) | ✅ #1429 |
 | `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
-| `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 (collapses into the suspended check — since 2026-06-07 every tier passes, Free included; only `suspended_at` rejects) |
+| `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 |
+| `BumpActivity` | stamps `last_active_at` | ✅ #1429 (see below — load-bearing) |
+| `RotationLockCheck` | 423 | ⚠️ `crdt:` only, `sync:` has none → #1434 |
+| `RequireApiWriteEnabled` | 402 | ❌ → #1433 |
+| `RequireApiRpsBudget` | 429 | ❌ → #1433 |
+| `EnforceSearchCap` | 402 | ❌ (no channel equivalent) |
+| `PreAuthRateLimit` | 429 | ❌ — **there is no join rate limiter at all** |
+| `DeviceFingerprint` | — | ❌ |
+| `Auth` | 401 | `UserSocket.connect/3` |
+
+`RequireActiveSubscription` collapses into the suspended check — since
+2026-06-07 every tier passes (Free included) and only `suspended_at` rejects.
+`AccountLifecycle` is a *different, richer* plug on the user-scoped and
+onboarding pipelines — **not** on `:authed_api`. Getting those two confused is
+how you conclude `RequireActiveSubscription` is redundant and drop it.
+
+**`BumpActivity` is not bookkeeping.** It is the only writer of
+`usage_meters.last_active_at`, and `Workers.InactivityCleanup` soft-deletes
+Free accounts whose stamp has aged out. Enforcing lifecycle on sockets without
+also stamping liveness there turns "plugin user who syncs over CRDT and rarely
+touches REST" into a permanently locked-out account in daily active use.
+Port the enforcement half and the liveness half together, always.
 
 **Adding a route to the vault pipeline gets you the plugs. Adding a _channel_
 gets you nothing — call `ChannelGate.check/1` from its `join/3`. And adding a
@@ -80,8 +103,8 @@ plumbing. #1429 closed the other two.
 
 ## Ordering (do not "tidy" this)
 In `CrdtChannel`: `crdt_proto` → `RotationGate.check/1` → **topic ownership
-match** → `Onboarding.gate/1` → vault resolve. In `SyncChannel`: topic
-ownership match → `Onboarding.gate/1` → vault resolve.
+match** → `ChannelGate.check/1` → vault resolve. In `SyncChannel`: topic
+ownership match → `ChannelGate.check/1` → vault resolve.
 
 The gate goes last because:
 - the ownership match is free, and the verdict costs ~4 DB round-trips

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -76,8 +76,7 @@ Clerk tokens resolve with a nil key and are unaffected.
 
 Consequence for tests: any test that mints an API key to exercise something
 *else* (vault restriction, join tracing, channel logging) must first call
-`grant_api_write!/1` or `grant_api_read!/1` from
-`Engram.ApiEntitlementHelpers`, or it fails on entitlement before reaching
+`grant_api_write!/1` from `Engram.ApiEntitlementHelpers`, or it fails on entitlement before reaching
 what it is actually testing.
 
 **`BumpActivity` is not bookkeeping.** It is the only writer of

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -36,16 +36,32 @@ met the gate it was supposed to fail. `POST /api/vaults/register` (user-scoped
 pipeline, intentionally ungated so the wizard can create a first vault) supplied the
 vault.
 
-## Where the gate lives now
-`Engram.Onboarding.gate/1` is the **single authority**. Returns `:ok` or
-`{:error, missing, next_step}` and keeps the `GateCache` pass-caching.
+## Where the gates live now
+Two layers:
 
-- `EngramWeb.Plugs.RequireOnboarding` — thin 403-shaping wrapper (HTTP).
-- `SyncChannel.join/3` + `CrdtChannel.join/3` — reply
-  `{:error, %{reason: "onboarding_required", missing: [...], next_step: ...}}`.
+- **`Engram.Onboarding.gate/2`** — the onboarding verdict itself. `:ok` or
+  `{:error, missing, next_step}`, with `GateCache` pass-caching.
+  `EngramWeb.Plugs.RequireOnboarding` is a thin 403-shaping wrapper over it.
+- **`EngramWeb.ChannelGate.check/1`** — the socket-side equivalent of the whole
+  vault-scoped pipeline. Composes lifecycle + onboarding and returns the map to
+  reply straight from `join/3`. `SyncChannel` and `CrdtChannel` both call it.
 
-**Adding a route to the vault pipeline gets you the plug. Adding a _channel_ does
-not — call `Onboarding.gate/1` from its `join/3`.**
+The pipeline runs three access gates; **all three now apply to sockets**:
+
+| `router.ex` plug | HTTP | Socket |
+|---|---|---|
+| `AccountLifecycle` | 410 `account_deleted` / 403 `account_suspended` | ✅ #1429 |
+| `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
+| `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 (collapses into the suspended check — since 2026-06-07 every tier passes, Free included; only `suspended_at` rejects) |
+
+**Adding a route to the vault pipeline gets you the plugs. Adding a _channel_
+gets you nothing — call `ChannelGate.check/1` from its `join/3`. And adding a
+plug to the pipeline does NOT add it to sockets: decide explicitly and put it
+in `ChannelGate`.**
+
+#1426 shipped with only the middle row ported, which is exactly how the
+original bug happened one layer up — a rule that lived in one transport's
+plumbing. #1429 closed the other two.
 
 ## Failed Approaches / Dead Ends
 - **Gating `UserSocket.connect/3`.** Tidier-looking and wrong: it deadlocks signup.
@@ -112,6 +128,13 @@ There are mutation-checked tests for all three in
   with no clause, one client frame kills the channel process. Server-push-only
   is a client convention, not an enforced one — and this topic is reachable
   pre-onboarding by design.
+- **Lifecycle is never cached and never read off the socket struct.**
+  `ChannelGate.check/1` re-reads the row on every join. An admin suspension has
+  to bite on the *next* join: `SessionInvalidator` kills the live socket, but
+  the JWT stays valid and the client reconnects within seconds. `GateCache`
+  holds PASS verdicts for 60s, so routing the lifecycle check through it would
+  leave a suspended account syncing for up to a minute per node.
+  `Onboarding.gate/2` takes `fresh: true` so that shared read is not paid twice.
 - **`POST /api/auth/device/authorize` passes `skip_vault: true`.** It creates
   the first vault, so gating it on "you already have one" makes it permanently
   unreachable for the user who needs it. The relaxed verdict is deliberately
@@ -127,4 +150,8 @@ There are mutation-checked tests for all three in
 - `lib/engram_web/channels/{sync,crdt}_channel.ex`, `lib/engram_web/user_socket.ex`
 - `test/engram_web/onboarding_gate_channel_test.exs`,
   `test/engram_web/onboarding_gate_integration_test.exs`
-- PR #1426 (fix), issue #1427 (test-config follow-up), #142 (RequireOnboarding)
+- `lib/engram_web/channel_gate.ex` — the socket-side pipeline equivalent
+- `test/engram_web/lifecycle_gate_channel_test.exs`
+- PR #1426 (onboarding), PR for #1429 (lifecycle), issue #1427 (test-config
+  follow-up), #1430 (SPA drops writes on a refused join),
+  Engram-obsidian#455 (plugin degrades to a dead REST path), #142

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -23,7 +23,7 @@ normal state rather than a blocked one).
 (`router.ex:55`). It correctly 403'd `/api/notes`, `/api/search`, `/api/folders`.
 But a Plug takes a `conn` and **never runs on a socket** — and sync had moved to
 Phoenix Channels. The live path checked token validity (`user_socket.ex`
-`connect/3`), `crdt_proto` version, `RotationGate.check/1` (DEK rotation lock),
+`connect/3`), `crdt_proto` version, the DEK rotation lock,
 topic ownership, and `Vaults.check_api_key_access/2`. What it did **not** check
 was entitlement: nothing asked about ToS, plan, or wizard completion.
 
@@ -50,15 +50,19 @@ The vault scope pipes `:authed_api` (`router.ex:49-60`), which runs **eleven**
 plugs — not three. Do not trust a summary that says otherwise; that
 miscount is what let the gaps below go unnoticed.
 
-| `:authed_api` plug | HTTP | Socket |
-|---|---|---|
-| `AccountDeleted` | 410 `account_deleted` (`deleted_at` only) | ✅ #1429 |
-| `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
-| `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 |
-| `BumpActivity` | stamps `last_active_at` | ✅ #1429 (see below — load-bearing) |
-| `RotationLockCheck` | 423 | ✅ #1434 — in `ChannelGate`, both channels |
-| `RequireApiWriteEnabled` | 402 | ✅ #1433 — write frames only |
-| `RequireApiRpsBudget` | 429 | ✅ #1433 — refuses the JOIN when the key's tier has `api_rps_cap: 0` |
+Listed in **pipeline execution order** (`router.ex:49-60`) — `ChannelGate`'s
+`with` chain follows this order deliberately, so a reader deriving one from
+the other must not be handed a re-sorted table:
+
+| # | `:authed_api` plug | HTTP | Socket |
+|---|---|---|---|
+| 1 | 2 | 3 | `AccountDeleted` | 410 `account_deleted` (`deleted_at` only) | ✅ #1429 |
+| 4 | 5 | `RotationLockCheck` | 503 `rotation_in_progress` | ✅ #1434 |
+| 6 | `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
+| 7 | `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 |
+| 8 | `BumpActivity` | stamps `last_active_at` | ✅ #1429 (load-bearing, see below) |
+| 9 | `RequireApiRpsBudget` | 429 | ✅ #1433 — refuses the JOIN at `cap: 0` |
+| 10 | 11 | `RequireApiWriteEnabled` | 402 | ✅ #1433 — write frames only |
 | `EnforceSearchCap` | 402 | ❌ (no channel equivalent) |
 | `PreAuthRateLimit` | 429 | ❌ — **there is no join rate limiter at all** |
 | `DeviceFingerprint` | — | ❌ |
@@ -115,9 +119,14 @@ plumbing. #1429 closed the other two.
   `missing: ["terms"]` from a `VersionCache` leak. See Gotchas.
 
 ## Ordering (do not "tidy" this)
-In `CrdtChannel`: `crdt_proto` → `RotationGate.check/1` → **topic ownership
-match** → `ChannelGate.check/1` → vault resolve. In `SyncChannel`: topic
-ownership match → `ChannelGate.check/1` → vault resolve.
+In `CrdtChannel`: `crdt_proto` → **topic ownership match** →
+`ChannelGate.check/2` → vault resolve. In `SyncChannel`: topic ownership
+match → `ChannelGate.check/2` → vault resolve.
+
+Rotation used to sit ahead of the ownership match in `CrdtChannel`; #1434
+moved it inside `ChannelGate` so `SyncChannel` gets it too. Behaviour change
+worth knowing: a user mid-rotation joining a topic they do NOT own now gets
+`unauthorized` rather than `rotation_in_progress`.
 
 The gate goes last because:
 - the ownership match is free, and the verdict costs ~4 DB round-trips

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -42,7 +42,7 @@ Two layers:
 - **`Engram.Onboarding.gate/2`** — the onboarding verdict itself. `:ok` or
   `{:error, missing, next_step}`, with `GateCache` pass-caching.
   `EngramWeb.Plugs.RequireOnboarding` is a thin 403-shaping wrapper over it.
-- **`EngramWeb.ChannelGate.check/1`** — the socket-side equivalent of the whole
+- **`EngramWeb.ChannelGate.check/2`** — the socket-side equivalent of the whole
   vault-scoped pipeline. Composes lifecycle + onboarding and returns the map to
   reply straight from `join/3`. `SyncChannel` and `CrdtChannel` both call it.
 
@@ -88,7 +88,7 @@ touches REST" into a permanently locked-out account in daily active use.
 Port the enforcement half and the liveness half together, always.
 
 **Adding a route to the vault pipeline gets you the plugs. Adding a _channel_
-gets you nothing — call `ChannelGate.check/1` from its `join/3`. And adding a
+gets you nothing — call `ChannelGate.check/2` from its `join/3`. And adding a
 plug to the pipeline does NOT add it to sockets: decide explicitly and put it
 in `ChannelGate`.**
 
@@ -127,11 +127,13 @@ The gate goes last because:
   `crdt:<other-user>:<uuid>` probe must not buy that;
 - the plugin's identity self-heal keys on `reason === "unauthorized"`
   specifically (`channel.ts`, e2e test_84) — replacing that reason wedges it;
-- (retired) rotation used to be checked ahead of the match, so a mid-rotation
-  user on a foreign topic heard `rotation_in_progress`; #1434 moved rotation
-  into `ChannelGate`, so that case now correctly reports `unauthorized`.
+- a user mid-DEK-rotation on their OWN topic must still hear
+  `rotation_in_progress` — `check/2` runs `rotation/1` before `onboarding/1`
+  for exactly this, and there is a test on it. Only the FOREIGN-topic case
+  changed: #1434 moved rotation behind the ownership match, so a mid-rotation
+  user probing someone else's topic now correctly gets `unauthorized`.
 
-There are mutation-checked tests for the two live rules in
+There are mutation-checked tests for all three in
 `onboarding_gate_channel_test.exs` ("gate ordering").
 
 ## Gotchas
@@ -169,7 +171,7 @@ There are mutation-checked tests for the two live rules in
   is a client convention, not an enforced one — and this topic is reachable
   pre-onboarding by design.
 - **Lifecycle is never cached and never read off the socket struct.**
-  `ChannelGate.check/1` re-reads the row on every join. An admin suspension has
+  `ChannelGate.check/2` re-reads the row on every join. An admin suspension has
   to bite on the *next* join: `SessionInvalidator` kills the live socket, but
   the JWT stays valid and the client reconnects within seconds. `GateCache`
   holds PASS verdicts for 60s, so routing the lifecycle check through it would

--- a/docs/context/onboarding-gate-is-http-only.md
+++ b/docs/context/onboarding-gate-is-http-only.md
@@ -50,29 +50,22 @@ The vault scope pipes `:authed_api` (`router.ex:49-60`), which runs **eleven**
 plugs — not three. Do not trust a summary that says otherwise; that
 miscount is what let the gaps below go unnoticed.
 
-Listed in **pipeline execution order** (`router.ex:49-60`) — `ChannelGate`'s
-`with` chain follows this order deliberately, so a reader deriving one from
-the other must not be handed a re-sorted table:
+Listed in **pipeline execution order** (`router.ex:50-60`) — `ChannelGate`'s
+`with` chain follows the same order deliberately, so do not re-sort this.
 
-| # | `:authed_api` plug | HTTP | Socket |
-|---|---|---|---|
-| 1 | 2 | 3 | `AccountDeleted` | 410 `account_deleted` (`deleted_at` only) | ✅ #1429 |
-| 4 | 5 | `RotationLockCheck` | 503 `rotation_in_progress` | ✅ #1434 |
-| 6 | `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
-| 7 | `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 |
-| 8 | `BumpActivity` | stamps `last_active_at` | ✅ #1429 (load-bearing, see below) |
-| 9 | `RequireApiRpsBudget` | 429 | ✅ #1433 — refuses the JOIN at `cap: 0` |
-| 10 | 11 | `RequireApiWriteEnabled` | 402 | ✅ #1433 — write frames only |
-| `EnforceSearchCap` | 402 | ❌ (no channel equivalent) |
+| `:authed_api` plug | HTTP | Socket |
+|---|---|---|
 | `PreAuthRateLimit` | 429 | ❌ — **there is no join rate limiter at all** |
-| `DeviceFingerprint` | — | ❌ |
 | `Auth` | 401 | `UserSocket.connect/3` |
-
-`RequireActiveSubscription` collapses into the suspended check — since
-2026-06-07 every tier passes (Free included) and only `suspended_at` rejects.
-`AccountLifecycle` is a *different, richer* plug on the user-scoped and
-onboarding pipelines — **not** on `:authed_api`. Getting those two confused is
-how you conclude `RequireActiveSubscription` is redundant and drop it.
+| `AccountDeleted` | 410 `account_deleted` | ✅ #1429 |
+| `DeviceFingerprint` | — | ❌ |
+| `RotationLockCheck` | 503 `rotation_in_progress` | ✅ #1434 |
+| `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
+| `RequireActiveSubscription` | 402 `account_suspended` | ✅ #1429 |
+| `BumpActivity` | stamps `last_active_at` | ✅ #1429 — load-bearing, see below |
+| `RequireApiRpsBudget` | 429 | ⚠️ #1433 — only the `cap == 0` case, at join |
+| `EnforceSearchCap` | 402 | ❌ |
+| `RequireApiWriteEnabled` | 402 | ❌ — attempted and reverted, see `channel_gate.ex` |
 
 **API-key sockets are gated; JWT sockets are not.** Pricing v2 §G is a
 paid-API entitlement, and the exemption keys on `current_api_key` being
@@ -134,9 +127,11 @@ The gate goes last because:
   `crdt:<other-user>:<uuid>` probe must not buy that;
 - the plugin's identity self-heal keys on `reason === "unauthorized"`
   specifically (`channel.ts`, e2e test_84) — replacing that reason wedges it;
-- a user mid-DEK-rotation must still hear `rotation_in_progress` (T3.7).
+- (retired) rotation used to be checked ahead of the match, so a mid-rotation
+  user on a foreign topic heard `rotation_in_progress`; #1434 moved rotation
+  into `ChannelGate`, so that case now correctly reports `unauthorized`.
 
-There are mutation-checked tests for all three in
+There are mutation-checked tests for the two live rules in
 `onboarding_gate_channel_test.exs` ("gate ordering").
 
 ## Gotchas

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -239,6 +239,11 @@ defmodule Engram.Onboarding do
           do: user,
           else: Accounts.get_user(user_id) || user
 
+      # A purged row (`Accounts.Lifecycle.hard_delete/2`) leaves the `|| user`
+      # fallback above holding a struct that predates the deletion. Callers on
+      # the socket side go through `EngramWeb.ChannelGate`, which refuses
+      # outright before reaching here; this is the belt for any HTTP caller,
+      # where `Plugs.Auth` has already 401'd a missing user in practice.
       derive_gate(user, status(user), opts)
     end
   end

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -233,7 +233,7 @@ defmodule Engram.Onboarding do
       # for the life of the connection. `accept_free_tier/1` is a bare
       # `Repo.update` with no socket disconnect, so nothing else would clear it.
       # `fresh: true` means the caller already re-read this row this join
-      # (see `EngramWeb.ChannelGate.check/1`) — don't pay for it twice.
+      # (see `EngramWeb.ChannelGate.check/2`) — don't pay for it twice.
       user =
         if Keyword.get(opts, :fresh, false),
           do: user,

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -232,7 +232,13 @@ defmodule Engram.Onboarding do
       # would re-derive from a stale struct on every rejoin and stay locked out
       # for the life of the connection. `accept_free_tier/1` is a bare
       # `Repo.update` with no socket disconnect, so nothing else would clear it.
-      user = Accounts.get_user(user_id) || user
+      # `fresh: true` means the caller already re-read this row this join
+      # (see `EngramWeb.ChannelGate.check/1`) — don't pay for it twice.
+      user =
+        if Keyword.get(opts, :fresh, false),
+          do: user,
+          else: Accounts.get_user(user_id) || user
+
       derive_gate(user, status(user), opts)
     end
   end

--- a/lib/engram/usage_meters.ex
+++ b/lib/engram/usage_meters.ex
@@ -10,7 +10,9 @@ defmodule Engram.UsageMeters do
   """
 
   import Ecto.Query
+
   alias Engram.Repo
+  alias Engram.UsageMeters.ActivityCache
 
   defmodule Meter do
     use Ecto.Schema
@@ -187,8 +189,53 @@ defmodule Engram.UsageMeters do
   end
 
   @doc """
+  Debounced liveness stamp: writes `last_active_at` only when the stored value
+  is stale by more than the `ActivityCache` debounce window, so a busy client
+  does not hammer the meter row. A warm cache inside the window touches no DB
+  at all.
+
+  This is what tells `Engram.Workers.InactivityCleanup` who is actually using
+  Engram — the sweep soft-deletes Free accounts whose `last_active_at` has
+  aged past the window. It must therefore be called from EVERY transport a
+  user can be "active" on, not just HTTP: `EngramWeb.Plugs.BumpActivity` for
+  requests, `EngramWeb.ChannelGate` for `sync:`/`crdt:` joins. A plugin user
+  who syncs daily over WebSocket and never touches REST would otherwise age
+  into the sweep while in constant active use.
+  """
+  @spec touch_active(Ecto.UUID.t()) :: :ok
+  def touch_active(user_id) when is_binary(user_id) do
+    case ActivityCache.get(user_id) do
+      {:ok, ts} ->
+        if stale?(ts), do: do_touch(user_id), else: :ok
+
+      :miss ->
+        last = last_active_at(user_id)
+
+        if stale?(last) do
+          do_touch(user_id)
+        else
+          ActivityCache.put(user_id, last)
+          :ok
+        end
+    end
+  end
+
+  defp do_touch(user_id) do
+    now = DateTime.utc_now()
+    :ok = bump_last_active(user_id)
+    ActivityCache.put(user_id, now)
+    :ok
+  end
+
+  defp stale?(nil), do: true
+
+  defp stale?(%DateTime{} = ts) do
+    DateTime.diff(DateTime.utc_now(), ts, :second) > ActivityCache.debounce_seconds()
+  end
+
+  @doc """
   Stamps `last_active_at = now()` for the user. Lazy-inits the row.
-  Called from the auth pipeline plug (debounced to once per hour).
+  Undebounced — callers go through `touch_active/1`, which owns the debounce.
   """
   @spec bump_last_active(Ecto.UUID.t()) :: :ok
   def bump_last_active(user_id) when is_binary(user_id) do

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -30,19 +30,33 @@ defmodule EngramWeb.ChannelGate do
       a substitute: it uses fixed compile-time budgets per device and never
       reads the plan, so Starter (10 req/s) and Pro (30 req/s) are metered
       identically and both far above their REST entitlement. #1433.
-    * `RequireApiWriteEnabled`. Attempted and REVERTED: no tier has
-      `api_rps_cap > 0` with `api_write_enabled: false` (Free 0/false,
-      Starter 10/true, Pro 30/true), so it guards only an admin-override
-      state — while screening `crdt_msg` by payload broke reads twice.
+    * `RequireApiWriteEnabled`. Attempted and REVERTED — **this is a real,
+      currently-open entitlement gap, not a no-op**. An earlier version of
+      this note claimed "no tier has `api_rps_cap > 0` with
+      `api_write_enabled: false`". That is wrong: `Billing.do_effective_limit/2`
+      resolves EACH KEY independently (override → env → plan → tier default),
+      so a single `user_limit_overrides` row raising a Free user's
+      `api_rps_cap` leaves `api_write_enabled` at false. That user is refused
+      every non-GET REST route and, after the revert, writes freely over
+      `crdt_create` / `crdt_delete` / `sync_update`. The mechanism is
+      first-class (dedicated table, pg NOTIFY trigger, OverrideCache, expiry
+      sweeper), so treat it as reachable in prod.
+
+      It was reverted because screening `crdt_msg` by payload broke reads
+      twice.
       SyncStep1 is a read, but the server answers it with its own SyncStep1
       whose protocol-mandated reply is a SyncStep2, so "block SyncStep2"
       breaks the handshake. Entitlement decided on a wire byte also sits
       ahead of `ensure_room/3`, i.e. ahead of real side effects. If this is
       ever wanted, gate it where the write happens, not on the frame. #1433.
-    * `EnforceSearchCap`, `DeviceFingerprint`, `PreAuthRateLimit` — no channel
-      equivalent. `PreAuthRateLimit` notably means there is **no join rate
-      limiter** at all, which is why `check/2` sits behind the free topic
+    * `PreAuthRateLimit` (plug 1) — no equivalent, so there is **no join rate
+      limiter at all**, which is why `check/2` sits behind the free topic
       ownership match.
+    * `DeviceFingerprint` (4) — no equivalent.
+    * `EnforceSearchCap` (10) — no equivalent; there is no channel search.
+
+  (`Auth` (2) is not mirrored HERE because `UserSocket.connect/3` already is
+  it — that is the eleventh plug, and the one an 11-vs-10 count trips over.)
 
   `RequireActiveSubscription` collapses into the suspended check — since
   2026-06-07 it passes every tier (Free counts as active) and only rejects
@@ -108,7 +122,7 @@ defmodule EngramWeb.ChannelGate do
   """
   # `api_key` is MANDATORY, deliberately. It defaulted to nil, which made the
   # ungated arity the convenient one: `check(user)` compiled, passed dialyzer
-  # and looked complete while silently skipping both Pricing v2 §G gates —
+  # and looked complete while silently skipping the Pricing v2 §G join gate —
   # the identical fail-open shape this module exists to prevent one layer up.
   # Pass `socket.assigns[:current_api_key]`; nil is the JWT case.
   @spec check(Engram.Accounts.User.t(), term()) :: :ok | {:error, map()}

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -15,19 +15,21 @@ defmodule EngramWeb.ChannelGate do
     * `RequireOnboarding`         → 403 `onboarding_required` ✅ (#1426)
     * `RequireActiveSubscription` → 402 `account_suspended` ✅ (#1429)
 
-  plus `BumpActivity`'s liveness stamp (see `## Activity`), and `CrdtChannel`
-  separately open-codes `RotationGate.check/1`.
+    * `RotationLockCheck`         → 423 `rotation_in_progress` ✅ (#1434)
+    * `RequireApiWriteEnabled`    → WRITE frames only ✅ (#1433), see
+      `api_write_blocked?/2` and `CrdtChannel`'s `@write_events` clause
+
+  plus `BumpActivity`'s liveness stamp (see `## Activity`).
 
   **NOT mirrored — sockets are more permissive than HTTP here:**
 
-    * `RequireApiWriteEnabled` / `RequireApiRpsBudget` — a Free-tier PAT is
-      402'd and 429'd on `POST /api/notes` but writes freely over `crdt_msg`.
-      Tracked in #1433. Port trap: both exempt via
-      `not is_map_key(assigns, :current_api_key)`, and `UserSocket.accept/4`
-      ALWAYS sets that key (nil for JWT), so a literal port gates every JWT
-      socket.
-    * `RotationLockCheck` — `CrdtChannel` has an equivalent, `SyncChannel` has
-      none. Tracked in #1434.
+    * `RequireApiRpsBudget` — Free's `api_rps_cap` is 0 and that plug has no
+      GET exemption, so a Free PAT cannot make a single REST call, yet it can
+      still open a socket and READ the whole vault. Gating the join on it was
+      tried and reverted: `sync_channel_test.exs` and the tracing tests
+      actively assert Free API keys CAN join, so that is a contract change,
+      not a bug fix — it needs a product decision, not a security patch.
+      Writes are blocked regardless (above). Tracked in #1433.
     * `EnforceSearchCap`, `DeviceFingerprint`, `PreAuthRateLimit` — no channel
       equivalent; `PreAuthRateLimit` notably means there is **no join rate
       limiter** at all.
@@ -81,6 +83,8 @@ defmodule EngramWeb.ChannelGate do
   """
 
   alias Engram.Accounts
+  alias Engram.Billing
+  alias Engram.Crypto.RotationGate
   alias Engram.Onboarding
   alias Engram.UsageMeters
 
@@ -103,8 +107,16 @@ defmodule EngramWeb.ChannelGate do
         {:error, %{reason: "account_deleted"}}
 
       fresh ->
-        with :ok <- lifecycle(fresh),
-             :ok <- onboarding(fresh) do
+        # Precedence mirrors `:authed_api` exactly (router.ex:52-56):
+        # AccountDeleted -> RotationLockCheck -> RequireOnboarding ->
+        # RequireActiveSubscription. Suspension therefore comes AFTER
+        # onboarding, so an account suspended mid-signup reports the same
+        # reason on both transports. Rotation reuses the row already loaded
+        # here via `check_user/1`, so it costs no extra query.
+        with :ok <- deleted(fresh),
+             :ok <- rotation(fresh),
+             :ok <- onboarding(fresh),
+             :ok <- suspended(fresh) do
           # Liveness, mirroring `EngramWeb.Plugs.BumpActivity` — see the
           # `## Activity` note above. Only on a PASS: a refused client
           # retrying forever must not keep its own account looking alive.
@@ -113,19 +125,61 @@ defmodule EngramWeb.ChannelGate do
     end
   end
 
-  # Deleted takes precedence over suspended, mirroring
-  # `EngramWeb.Plugs.AccountLifecycle`.
-  defp lifecycle(%{deleted_at: %DateTime{}}), do: {:error, %{reason: "account_deleted"}}
-  defp lifecycle(%{suspended_at: %DateTime{}}), do: {:error, %{reason: "account_suspended"}}
+  @doc """
+  Deletion-only check, for `user:`.
 
-  # Strictly `nil, nil` rather than a `_user` catch-all. A catch-all is
-  # fail-OPEN keyed on field presence: rename either column, narrow the read
-  # to a projection, or change the type away from `:utc_datetime_usec`, and
-  # both guard clauses above stop matching while every account silently
-  # passes the lifecycle gate — no compile error, no test failure. This is
-  # the same argument `Onboarding.derive_gate/3` makes about its own
-  # destructuring. A missing field should crash, not pass.
-  defp lifecycle(%{deleted_at: nil, suspended_at: nil}), do: :ok
+  `user:` is exempt from suspension and onboarding on purpose (see the
+  moduledoc) but NOT from deletion: `AccountDeleted`'s clause runs ahead of
+  the suspension allowlist and HTTP is terminal for a deleted account —
+  "410 Gone on every endpoint, no exemptions". A purged row counts as deleted.
+  """
+  @spec check_not_deleted(Engram.Accounts.User.t()) :: :ok | {:error, map()}
+  def check_not_deleted(%Engram.Accounts.User{id: user_id}) do
+    case Accounts.get_user(user_id) do
+      nil -> {:error, %{reason: "account_deleted"}}
+      %{deleted_at: %DateTime{}} -> {:error, %{reason: "account_deleted"}}
+      %{deleted_at: nil} -> :ok
+    end
+  end
+
+  # Each of these matches STRICTLY on the field it gates rather than falling
+  # through a `_user` catch-all. A catch-all is fail-OPEN keyed on field
+  # presence: rename the column, narrow the read to a projection, or change
+  # the type away from `:utc_datetime_usec`, and the guard stops matching
+  # while every account silently passes — no compile error, no test failure.
+  # Same argument `Onboarding.derive_gate/3` makes about its destructuring.
+  # A missing field should crash, not pass.
+  defp deleted(%{deleted_at: %DateTime{}}), do: {:error, %{reason: "account_deleted"}}
+  defp deleted(%{deleted_at: nil}), do: :ok
+
+  defp suspended(%{suspended_at: %DateTime{}}), do: {:error, %{reason: "account_suspended"}}
+  defp suspended(%{suspended_at: nil}), do: :ok
+
+  @doc """
+  Pricing v2 §G write half, mirroring `EngramWeb.Plugs.RequireApiWriteEnabled`
+  (#1433). True when this socket's caller may not issue write frames.
+
+  JWT callers are exempt (the web UI hides write affordances for tiers that
+  lack the feature), matching the plug. Evaluated once at join and stashed in
+  assigns so the per-frame check is a pattern match, not a query — an
+  entitlement change takes effect on the next join, same as `plan_state`.
+  """
+  @spec api_write_blocked?(Engram.Accounts.User.t(), term()) :: boolean()
+  def api_write_blocked?(_user, nil), do: false
+
+  def api_write_blocked?(user, _api_key) do
+    Billing.check_feature(user, :api_write_enabled) != :ok
+  end
+
+  # `check_user/1`, not `check/1` — the row is already loaded, so this costs
+  # no query. `CrdtChannel` used to open-code `RotationGate.check/1`, which
+  # re-read the same row; `SyncChannel` had no check at all (#1434).
+  defp rotation(user) do
+    case RotationGate.check_user(user) do
+      :ok -> :ok
+      {:error, :rotation_in_progress} -> {:error, %{reason: "rotation_in_progress"}}
+    end
+  end
 
   defp onboarding(user) do
     case Onboarding.gate(user, fresh: true) do

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -47,12 +47,18 @@ defmodule EngramWeb.ChannelGate do
   from `join/3` (always carries a `:reason`).
   """
   @spec check(Engram.Accounts.User.t()) :: :ok | {:error, map()}
-  def check(%{id: user_id} = user) do
+  def check(%{id: user_id}) do
     # One read, shared by both checks — `gate/2` is told not to re-read.
-    fresh = Accounts.get_user(user_id) || user
-
-    with :ok <- lifecycle(fresh) do
-      onboarding(fresh)
+    #
+    # No `|| socket_user` fallback: `Accounts.Lifecycle.hard_delete/2` removes
+    # the row outright, and falling back to the socket's frozen `current_user`
+    # would be fail-OPEN — that struct predates the deletion and carries no
+    # `deleted_at`, so a purged account with a still-valid JWT would keep
+    # syncing. HTTP fails closed here (`Plugs.Auth` cannot resolve a missing
+    # user and 401s); the socket must not be more permissive.
+    case Accounts.get_user(user_id) do
+      nil -> {:error, %{reason: "account_deleted"}}
+      fresh -> with :ok <- lifecycle(fresh), do: onboarding(fresh)
     end
   end
 

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -1,0 +1,74 @@
+defmodule EngramWeb.ChannelGate do
+  @moduledoc """
+  The socket-side equivalent of the vault-scoped router pipeline's access
+  gates. Both `EngramWeb.SyncChannel` and `EngramWeb.CrdtChannel` call
+  `check/1` from `join/3`.
+
+  A Plug takes a `conn` and never runs on a socket, so every rule the pipeline
+  enforces has to be re-expressed here or it silently does not apply to sync.
+  The pipeline runs three (`router.ex`):
+
+    * `AccountLifecycle`        → 410 `account_deleted` / 403 `account_suspended`
+    * `RequireOnboarding`       → 403 `onboarding_required`
+    * `RequireActiveSubscription` → 402 `account_suspended`
+
+  #1426 ported only the middle one; #1429 ported the rest. `RequireActiveSubscription`
+  collapses into the suspended check — since 2026-06-07 it passes every tier
+  (Free counts as active) and only rejects `suspended_at`.
+
+  **Adding a gate to the vault pipeline does not add it here.** If you add a
+  plug to `router.ex`, decide explicitly whether sync needs it and add it to
+  `check/1`.
+
+  ## Why `user:` is not gated
+
+  `EngramWeb.UserChannel` deliberately does NOT call this. It carries
+  `vault_created` / `vault_populated` (the FTUX vault screen blocks on them)
+  and `subscription_activated`. `AccountLifecycle` exempts `/api/billing/*` so
+  a suspended user can pay their way out; `user:` is the socket equivalent of
+  that exemption. Gating it would strand exactly the users who are trying to
+  fix their state. It carries no note content — only ids, names, and plan
+  metadata.
+
+  ## Freshness
+
+  Lifecycle is read from a **fresh row on every join**, never from the socket's
+  `current_user` (frozen at `connect/3`) and never from `Onboarding.GateCache`
+  (a 60s PASS cache). An admin suspension must bite on the very next join:
+  `SessionInvalidator` kills the live socket, but the JWT stays valid and the
+  client reconnects within seconds.
+  """
+
+  alias Engram.Accounts
+  alias Engram.Onboarding
+
+  @doc """
+  `:ok`, or `{:error, payload}` where `payload` is the map to return straight
+  from `join/3` (always carries a `:reason`).
+  """
+  @spec check(Engram.Accounts.User.t()) :: :ok | {:error, map()}
+  def check(%{id: user_id} = user) do
+    # One read, shared by both checks — `gate/2` is told not to re-read.
+    fresh = Accounts.get_user(user_id) || user
+
+    with :ok <- lifecycle(fresh) do
+      onboarding(fresh)
+    end
+  end
+
+  # Deleted takes precedence over suspended, mirroring
+  # `EngramWeb.Plugs.AccountLifecycle`.
+  defp lifecycle(%{deleted_at: %DateTime{}}), do: {:error, %{reason: "account_deleted"}}
+  defp lifecycle(%{suspended_at: %DateTime{}}), do: {:error, %{reason: "account_suspended"}}
+  defp lifecycle(_user), do: :ok
+
+  defp onboarding(user) do
+    case Onboarding.gate(user, fresh: true) do
+      :ok ->
+        :ok
+
+      {:error, missing, next_step} ->
+        {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
+    end
+  end
+end

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -9,13 +9,13 @@ defmodule EngramWeb.ChannelGate do
   ## What is mirrored, and what is NOT
 
   The vault scope pipes `:authed_api` (`router.ex:49-60`), which runs
-  **eleven** plugs. This module mirrors three of them:
+  **eleven** plugs, in this order. This module mirrors six of them:
 
     * `AccountDeleted`            → 410 `account_deleted` (`deleted_at` only) ✅
     * `RequireOnboarding`         → 403 `onboarding_required` ✅ (#1426)
     * `RequireActiveSubscription` → 402 `account_suspended` ✅ (#1429)
 
-    * `RotationLockCheck`         → 423 `rotation_in_progress` ✅ (#1434)
+    * `RotationLockCheck`         → 503 `rotation_in_progress` ✅ (#1434)
     * `RequireApiRpsBudget`       → `api_access_not_available` at join for a
       key whose tier has `api_rps_cap: 0` ✅ (#1433)
     * `RequireApiWriteEnabled`    → WRITE frames only ✅ (#1433), see
@@ -91,9 +91,12 @@ defmodule EngramWeb.ChannelGate do
   `:ok`, or `{:error, payload}` where `payload` is the map to return straight
   from `join/3` (always carries a `:reason`).
   """
+  # `api_key` is MANDATORY, deliberately. It defaulted to nil, which made the
+  # ungated arity the convenient one: `check(user)` compiled, passed dialyzer
+  # and looked complete while silently skipping both Pricing v2 §G gates —
+  # the identical fail-open shape this module exists to prevent one layer up.
+  # Pass `socket.assigns[:current_api_key]`; nil is the JWT case.
   @spec check(Engram.Accounts.User.t(), term()) :: :ok | {:error, map()}
-  def check(user, api_key \\ nil)
-
   def check(%Engram.Accounts.User{id: user_id}, api_key) do
     # One read, shared by both checks — `gate/2` is told not to re-read.
     #
@@ -117,12 +120,21 @@ defmodule EngramWeb.ChannelGate do
         with :ok <- deleted(fresh),
              :ok <- rotation(fresh),
              :ok <- onboarding(fresh),
-             :ok <- suspended(fresh),
-             :ok <- api_access(fresh, api_key) do
-          # Liveness, mirroring `EngramWeb.Plugs.BumpActivity` — see the
-          # `## Activity` note above. Only on a PASS: a refused client
-          # retrying forever must not keep its own account looking alive.
+             :ok <- suspended(fresh) do
+          # Liveness stamp sits HERE, between the account gates and the API
+          # gates, because that is where `BumpActivity` sits on HTTP
+          # (router.ex:57, ahead of `RequireApiRpsBudget` at :58). A Pro user
+          # with a PAT integration who downgrades to Free is stamped on every
+          # REST call before being refused; stamping after `api_access/2`
+          # would leave the socket silent and let `InactivityCleanup` sweep an
+          # account generating daily traffic on both transports.
+          #
+          # It therefore fires when the ACCOUNT passes, not when the join
+          # ultimately succeeds — a join later refused for `vault_not_found`
+          # still stamps, exactly as an HTTP request to a missing vault does
+          # (BumpActivity runs before VaultPlug).
           stamp_activity(user_id)
+          api_access(fresh, api_key)
         end
     end
   end
@@ -145,12 +157,17 @@ defmodule EngramWeb.ChannelGate do
   end
 
   # Each of these matches STRICTLY on the field it gates rather than falling
-  # through a `_user` catch-all. A catch-all is fail-OPEN keyed on field
-  # presence: rename the column, narrow the read to a projection, or change
-  # the type away from `:utc_datetime_usec`, and the guard stops matching
-  # while every account silently passes — no compile error, no test failure.
-  # Same argument `Onboarding.derive_gate/3` makes about its destructuring.
-  # A missing field should crash, not pass.
+  # through a `_user` catch-all, so a renamed or retyped column CRASHES here
+  # instead of silently passing every account. Same argument
+  # `Onboarding.derive_gate/3` makes about its destructuring.
+  #
+  # This does NOT protect against a narrowed read. Ecto materialises
+  # unselected columns as nil, so a `select:`-projected `get_user/1` yields
+  # `%User{deleted_at: nil, suspended_at: nil}` and both clauses match
+  # cleanly — every suspended and soft-deleted account would pass, with no
+  # crash and no test failure. `check/2` must keep loading the FULL row; if
+  # the join cost ever motivates a narrower query, gate on a column list, not
+  # on these clauses.
   defp deleted(%{deleted_at: %DateTime{}}), do: {:error, %{reason: "account_deleted"}}
   defp deleted(%{deleted_at: nil}), do: :ok
 
@@ -166,11 +183,17 @@ defmodule EngramWeb.ChannelGate do
   assigns so the per-frame check is a pattern match, not a query — an
   entitlement change takes effect on the next join, same as `plan_state`.
   """
-  @spec api_write_blocked?(Engram.Accounts.User.t(), term()) :: boolean()
-  def api_write_blocked?(_user, nil), do: false
+  @spec api_write_blocked?(Ecto.UUID.t(), term()) :: boolean()
+  def api_write_blocked?(_user_id, nil), do: false
 
-  def api_write_blocked?(user, _api_key) do
-    Billing.check_feature(user, :api_write_enabled) != :ok
+  def api_write_blocked?(user_id, _api_key) do
+    # Takes an ID, not a struct, so a caller cannot accidentally hand it the
+    # socket's connect-time `current_user`. `Billing.check_feature/2` reads
+    # `plan_id` straight off whatever struct it is given.
+    case Accounts.get_user(user_id) do
+      nil -> true
+      user -> Billing.check_feature(user, :api_write_enabled) != :ok
+    end
   end
 
   # Best-effort, and deliberately so. This is a DB WRITE on a path that was
@@ -190,11 +213,31 @@ defmodule EngramWeb.ChannelGate do
     UsageMeters.touch_active(user_id)
   rescue
     e ->
+      # `:lifecycle`, not `:database` — `Engram.Logger.Category` has no
+      # `:database`, and `with_category/3` RAISES on an unknown atom, so the
+      # rescue handler itself blew up and killed the join it exists to save.
+      # `:reason` (not `:error`) because only allowlisted metadata keys are
+      # emitted, and `safe_reason/1` because `Exception.message/1` on a
+      # `%Postgrex.Error{}` can carry a row value into the log.
       Logger.error(
         "activity stamp failed",
-        Metadata.with_category(:error, :database,
+        Metadata.with_category(:error, :lifecycle,
           user_id: HMAC.hash_user_id(to_string(user_id)),
-          error: Exception.message(e)
+          reason: Metadata.safe_reason(e)
+        )
+      )
+
+      :ok
+  catch
+    # `rescue` does not catch exits, and a DBConnection checkout timeout exits
+    # rather than raising — the single most likely failure here.
+    kind, reason ->
+      Logger.error(
+        "activity stamp exited",
+        Metadata.with_category(:error, :lifecycle,
+          user_id: HMAC.hash_user_id(to_string(user_id)),
+          reason_label: to_string(kind),
+          reason: inspect(reason)
         )
       )
 

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -2,32 +2,47 @@ defmodule EngramWeb.ChannelGate do
   @moduledoc """
   The socket-side equivalent of the vault-scoped router pipeline's access
   gates. Both `EngramWeb.SyncChannel` and `EngramWeb.CrdtChannel` call
-  `check/1` from `join/3`.
+  `check/2` from `join/3`.
 
   A Plug takes a `conn` and never runs on a socket, so every rule the pipeline
   enforces has to be re-expressed here or it silently does not apply to sync.
+
   ## What is mirrored, and what is NOT
 
   The vault scope pipes `:authed_api` (`router.ex:49-60`), which runs
-  **eleven** plugs, in this order. This module mirrors six of them:
+  **eleven** plugs — not three, and not the shorter list an earlier version of
+  this doc claimed. Below in PIPELINE order, which is also the order `check/2`
+  applies them; derive one from the other only in that order.
 
-    * `AccountDeleted`            → 410 `account_deleted` (`deleted_at` only) ✅
-    * `RequireOnboarding`         → 403 `onboarding_required` ✅ (#1426)
-    * `RequireActiveSubscription` → 402 `account_suspended` ✅ (#1429)
+  Mirrored:
 
-    * `RotationLockCheck`         → 503 `rotation_in_progress` ✅ (#1434)
-    * `RequireApiRpsBudget`       → `api_access_not_available` at join for a
-      key whose tier has `api_rps_cap: 0` ✅ (#1433)
-    * `RequireApiWriteEnabled`    → WRITE frames only ✅ (#1433), see
-      `api_write_blocked?/2` and `CrdtChannel`'s `@write_events` clause
-
-  plus `BumpActivity`'s liveness stamp (see `## Activity`).
+    * `AccountDeleted`            → `account_deleted` (`deleted_at` only) ✅ #1429
+    * `RotationLockCheck`         → `rotation_in_progress` ✅ #1434
+    * `RequireOnboarding`         → `onboarding_required` ✅ #1426
+    * `RequireActiveSubscription` → `account_suspended` ✅ #1429
+    * `BumpActivity`              → liveness stamp ✅ #1429 (see `## Activity`)
+    * `RequireApiRpsBudget`       → `api_access_not_available`, but ONLY the
+      `cap == 0` case ✅ #1433
 
   **NOT mirrored — sockets are more permissive than HTTP here:**
 
+    * `RequireApiRpsBudget`'s POSITIVE caps. `CrdtChannel.check_rate/2` is not
+      a substitute: it uses fixed compile-time budgets per device and never
+      reads the plan, so Starter (10 req/s) and Pro (30 req/s) are metered
+      identically and both far above their REST entitlement. #1433.
+    * `RequireApiWriteEnabled`. Attempted and REVERTED: no tier has
+      `api_rps_cap > 0` with `api_write_enabled: false` (Free 0/false,
+      Starter 10/true, Pro 30/true), so it guards only an admin-override
+      state — while screening `crdt_msg` by payload broke reads twice.
+      SyncStep1 is a read, but the server answers it with its own SyncStep1
+      whose protocol-mandated reply is a SyncStep2, so "block SyncStep2"
+      breaks the handshake. Entitlement decided on a wire byte also sits
+      ahead of `ensure_room/3`, i.e. ahead of real side effects. If this is
+      ever wanted, gate it where the write happens, not on the frame. #1433.
     * `EnforceSearchCap`, `DeviceFingerprint`, `PreAuthRateLimit` — no channel
-      equivalent; `PreAuthRateLimit` notably means there is **no join rate
-      limiter** at all.
+      equivalent. `PreAuthRateLimit` notably means there is **no join rate
+      limiter** at all, which is why `check/2` sits behind the free topic
+      ownership match.
 
   `RequireActiveSubscription` collapses into the suspended check — since
   2026-06-07 it passes every tier (Free counts as active) and only rejects
@@ -35,7 +50,7 @@ defmodule EngramWeb.ChannelGate do
   user-scoped and onboarding pipelines, NOT this one.
 
   **Adding a plug to `:authed_api` does not add it here.** Decide explicitly
-  whether sync needs it, then either add it to `check/1` or add it to the NOT
+  whether sync needs it, then either add it to `check/2` or add it to the NOT
   list above with a reason.
 
   ## Why `user:` is not gated
@@ -133,6 +148,14 @@ defmodule EngramWeb.ChannelGate do
           # ultimately succeeds — a join later refused for `vault_not_found`
           # still stamps, exactly as an HTTP request to a missing vault does
           # (BumpActivity runs before VaultPlug).
+          #
+          # KNOWN TRADE-OFF: a Free PAT is refused at `api_access/2` on every
+          # join, so an abandoned install reconnecting in a loop keeps its own
+          # account looking active and `InactivityCleanup` never sweeps it.
+          # HTTP bounds that loop with `PreAuthRateLimit` (plug #1); the socket
+          # has no join limiter. Accepted deliberately: the opposite error is
+          # soft-DELETING a blocked-but-active account, and data loss beats a
+          # stale row. Revisit if a join limiter lands.
           stamp_activity(user_id)
           api_access(fresh, api_key)
         end
@@ -174,51 +197,28 @@ defmodule EngramWeb.ChannelGate do
   defp suspended(%{suspended_at: %DateTime{}}), do: {:error, %{reason: "account_suspended"}}
   defp suspended(%{suspended_at: nil}), do: :ok
 
-  @doc """
-  Pricing v2 §G write half, mirroring `EngramWeb.Plugs.RequireApiWriteEnabled`
-  (#1433). True when this socket's caller may not issue write frames.
-
-  JWT callers are exempt (the web UI hides write affordances for tiers that
-  lack the feature), matching the plug. Evaluated once at join and stashed in
-  assigns so the per-frame check is a pattern match, not a query — an
-  entitlement change takes effect on the next join, same as `plan_state`.
-  """
-  @spec api_write_blocked?(Ecto.UUID.t(), term()) :: boolean()
-  def api_write_blocked?(_user_id, nil), do: false
-
-  def api_write_blocked?(user_id, _api_key) do
-    # Takes an ID, not a struct, so a caller cannot accidentally hand it the
-    # socket's connect-time `current_user`. `Billing.check_feature/2` reads
-    # `plan_id` straight off whatever struct it is given.
-    case Accounts.get_user(user_id) do
-      nil -> true
-      user -> Billing.check_feature(user, :api_write_enabled) != :ok
-    end
-  end
-
   # Best-effort, and deliberately so. This is a DB WRITE on a path that was
   # read-only: an exception here would propagate out of `join/3`, kill the
   # channel process, and hand the client a transport error rather than a gate
   # reason — which it then retries, re-attempting the same write. Refusing to
   # sync because we could not record "you were here" is the wrong coupling.
   #
-  # Logged at :error rather than swallowed, because a persistently failing
-  # stamp is not cosmetic: `InactivityCleanup` reads this column to decide who
-  # gets soft-deleted, so silent failure re-creates the very lockout #1429
-  # exists to prevent. It has to be alertable.
+  # Logged rather than swallowed, because a persistently failing stamp is not
+  # cosmetic: `InactivityCleanup` reads this column to decide who gets
+  # soft-deleted, so silent failure re-creates the very lockout #1429 exists
+  # to prevent. It has to be alertable.
   #
-  # The plug keeps the loud behaviour — a failed write there fails one request,
-  # which is bounded; here it would fail the whole sync session.
+  # `:lifecycle`, not `:database` — there is no `:database` category and
+  # `with_category/3` RAISES on an unknown atom, so the first version of this
+  # handler blew up inside the rescue and killed the join it exists to save.
+  # `:reason`, not `:error`, because only allowlisted metadata keys are
+  # emitted. `safe_reason/1` / `safe_exit_reason/1` because a raw
+  # `%Postgrex.Error{}` renders "Failing row contains (...)" — a row value in
+  # a log line whose user_id is HMAC-hashed precisely to avoid that.
   defp stamp_activity(user_id) do
     UsageMeters.touch_active(user_id)
   rescue
     e ->
-      # `:lifecycle`, not `:database` — `Engram.Logger.Category` has no
-      # `:database`, and `with_category/3` RAISES on an unknown atom, so the
-      # rescue handler itself blew up and killed the join it exists to save.
-      # `:reason` (not `:error`) because only allowlisted metadata keys are
-      # emitted, and `safe_reason/1` because `Exception.message/1` on a
-      # `%Postgrex.Error{}` can carry a row value into the log.
       Logger.error(
         "activity stamp failed",
         Metadata.with_category(:error, :lifecycle,
@@ -237,7 +237,7 @@ defmodule EngramWeb.ChannelGate do
         Metadata.with_category(:error, :lifecycle,
           user_id: HMAC.hash_user_id(to_string(user_id)),
           reason_label: to_string(kind),
-          reason: inspect(reason)
+          reason: Metadata.safe_exit_reason(reason)
         )
       )
 
@@ -255,8 +255,11 @@ defmodule EngramWeb.ChannelGate do
   # `UserSocket.accept/4` ALWAYS sets that key (nil for JWT) — porting the
   # guard literally would gate every web and plugin user on the platform.
   #
-  # Positive caps are metered per-frame by `CrdtChannel.check_rate/2`; this is
-  # the "may you use the API at all" half.
+  # ONLY the `cap == 0` half is mirrored. `CrdtChannel.check_rate/2` is NOT
+  # the socket's `api_rps_cap`: it uses fixed compile-time budgets per device
+  # and never reads the plan, so a Starter key entitled to 10 req/s over REST
+  # sustains far more over the socket, and Starter and Pro are metered
+  # identically. See the NOT-mirrored list above.
   defp api_access(_user, nil), do: :ok
 
   defp api_access(user, _api_key) do

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -35,10 +35,13 @@ defmodule EngramWeb.ChannelGate do
       this note claimed "no tier has `api_rps_cap > 0` with
       `api_write_enabled: false`". That is wrong: `Billing.do_effective_limit/2`
       resolves EACH KEY independently (override → env → plan → tier default),
-      so a single `user_limit_overrides` row raising a Free user's
-      `api_rps_cap` leaves `api_write_enabled` at false. That user is refused
-      every non-GET REST route and, after the revert, writes freely over
-      `crdt_create` / `crdt_delete` / `sync_update`. The mechanism is
+      so raising a Free user's `api_rps_cap` leaves `api_write_enabled` at
+      false. Three layers can do it — the `user_limit_overrides` table, the
+      `:plan_overrides` env config (which opens it for a whole TIER at once),
+      and the plan's own limits JSON. That user is refused
+      every non-GET REST route except `POST /api/search` (exempt as a read)
+      and, after the revert, writes freely over
+      `crdt_create`, `crdt_create_batch`, `crdt_delete`, `sync_update` and `crdt_index_msg`. The mechanism is
       first-class (dedicated table, pg NOTIFY trigger, OverrideCache, expiry
       sweeper), so treat it as reachable in prod.
 
@@ -55,8 +58,9 @@ defmodule EngramWeb.ChannelGate do
     * `DeviceFingerprint` (4) — no equivalent.
     * `EnforceSearchCap` (10) — no equivalent; there is no channel search.
 
-  (`Auth` (2) is not mirrored HERE because `UserSocket.connect/3` already is
-  it — that is the eleventh plug, and the one an 11-vs-10 count trips over.)
+  (`Auth` (2) is not listed above because `UserSocket.connect/3` IS it. That
+  is the plug an 11-vs-10 count trips over — the eleventh in router order is
+  `RequireApiWriteEnabled`, the gap declared open above.)
 
   `RequireActiveSubscription` collapses into the suspended check — since
   2026-06-07 it passes every tier (Free counts as active) and only rejects

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -6,29 +6,70 @@ defmodule EngramWeb.ChannelGate do
 
   A Plug takes a `conn` and never runs on a socket, so every rule the pipeline
   enforces has to be re-expressed here or it silently does not apply to sync.
-  The pipeline runs three (`router.ex`):
+  ## What is mirrored, and what is NOT
 
-    * `AccountLifecycle`        → 410 `account_deleted` / 403 `account_suspended`
-    * `RequireOnboarding`       → 403 `onboarding_required`
-    * `RequireActiveSubscription` → 402 `account_suspended`
+  The vault scope pipes `:authed_api` (`router.ex:49-60`), which runs
+  **eleven** plugs. This module mirrors three of them:
 
-  #1426 ported only the middle one; #1429 ported the rest. `RequireActiveSubscription`
-  collapses into the suspended check — since 2026-06-07 it passes every tier
-  (Free counts as active) and only rejects `suspended_at`.
+    * `AccountDeleted`            → 410 `account_deleted` (`deleted_at` only) ✅
+    * `RequireOnboarding`         → 403 `onboarding_required` ✅ (#1426)
+    * `RequireActiveSubscription` → 402 `account_suspended` ✅ (#1429)
 
-  **Adding a gate to the vault pipeline does not add it here.** If you add a
-  plug to `router.ex`, decide explicitly whether sync needs it and add it to
-  `check/1`.
+  plus `BumpActivity`'s liveness stamp (see `## Activity`), and `CrdtChannel`
+  separately open-codes `RotationGate.check/1`.
+
+  **NOT mirrored — sockets are more permissive than HTTP here:**
+
+    * `RequireApiWriteEnabled` / `RequireApiRpsBudget` — a Free-tier PAT is
+      402'd and 429'd on `POST /api/notes` but writes freely over `crdt_msg`.
+      Tracked in #1433. Port trap: both exempt via
+      `not is_map_key(assigns, :current_api_key)`, and `UserSocket.accept/4`
+      ALWAYS sets that key (nil for JWT), so a literal port gates every JWT
+      socket.
+    * `RotationLockCheck` — `CrdtChannel` has an equivalent, `SyncChannel` has
+      none. Tracked in #1434.
+    * `EnforceSearchCap`, `DeviceFingerprint`, `PreAuthRateLimit` — no channel
+      equivalent; `PreAuthRateLimit` notably means there is **no join rate
+      limiter** at all.
+
+  `RequireActiveSubscription` collapses into the suspended check — since
+  2026-06-07 it passes every tier (Free counts as active) and only rejects
+  `suspended_at`. Note `AccountLifecycle` (a different, richer plug) is on the
+  user-scoped and onboarding pipelines, NOT this one.
+
+  **Adding a plug to `:authed_api` does not add it here.** Decide explicitly
+  whether sync needs it, then either add it to `check/1` or add it to the NOT
+  list above with a reason.
 
   ## Why `user:` is not gated
 
   `EngramWeb.UserChannel` deliberately does NOT call this. It carries
   `vault_created` / `vault_populated` (the FTUX vault screen blocks on them)
-  and `subscription_activated`. `AccountLifecycle` exempts `/api/billing/*` so
-  a suspended user can pay their way out; `user:` is the socket equivalent of
-  that exemption. Gating it would strand exactly the users who are trying to
-  fix their state. It carries no note content — only ids, names, and plan
-  metadata.
+  and `subscription_activated`, and no note content — only ids, names, and
+  plan metadata.
+
+  The justification is **suspension-specific**: a suspended user must be able
+  to pay their way out, which is why `AccountLifecycle` allowlists
+  `/api/billing/*`; `user:` is the socket equivalent. It does NOT extend to
+  deleted accounts, for whom HTTP is terminal with no exemptions — a
+  soft-deleted account can still join `user:` today. That is an open gap, not
+  a decision: tracked in #1435.
+
+  ## Activity
+
+  A passing join also stamps `usage_meters.last_active_at` via
+  `UsageMeters.touch_active/1` (debounced), mirroring
+  `EngramWeb.Plugs.BumpActivity` on the HTTP side.
+
+  This is not incidental — it is load-bearing for the gate above.
+  `Engram.Workers.InactivityCleanup` soft-deletes Free accounts whose stamp
+  has aged past the window, and that stamp was previously written ONLY by the
+  request plug. A plugin user who syncs daily over CRDT and rarely touches
+  REST therefore aged into the sweep while in constant active use. Before
+  lifecycle was enforced here that was invisible (sync kept working); with it
+  enforced, the same user would get a permanent `account_deleted` refusal on a
+  live account. Porting the enforcement half of a pipeline without the
+  liveness half turns a latent mis-classification into user-visible data loss.
 
   ## Freshness
 
@@ -41,13 +82,14 @@ defmodule EngramWeb.ChannelGate do
 
   alias Engram.Accounts
   alias Engram.Onboarding
+  alias Engram.UsageMeters
 
   @doc """
   `:ok`, or `{:error, payload}` where `payload` is the map to return straight
   from `join/3` (always carries a `:reason`).
   """
   @spec check(Engram.Accounts.User.t()) :: :ok | {:error, map()}
-  def check(%{id: user_id}) do
+  def check(%Engram.Accounts.User{id: user_id}) do
     # One read, shared by both checks — `gate/2` is told not to re-read.
     #
     # No `|| socket_user` fallback: `Accounts.Lifecycle.hard_delete/2` removes
@@ -57,8 +99,17 @@ defmodule EngramWeb.ChannelGate do
     # syncing. HTTP fails closed here (`Plugs.Auth` cannot resolve a missing
     # user and 401s); the socket must not be more permissive.
     case Accounts.get_user(user_id) do
-      nil -> {:error, %{reason: "account_deleted"}}
-      fresh -> with :ok <- lifecycle(fresh), do: onboarding(fresh)
+      nil ->
+        {:error, %{reason: "account_deleted"}}
+
+      fresh ->
+        with :ok <- lifecycle(fresh),
+             :ok <- onboarding(fresh) do
+          # Liveness, mirroring `EngramWeb.Plugs.BumpActivity` — see the
+          # `## Activity` note above. Only on a PASS: a refused client
+          # retrying forever must not keep its own account looking alive.
+          UsageMeters.touch_active(user_id)
+        end
     end
   end
 
@@ -66,7 +117,15 @@ defmodule EngramWeb.ChannelGate do
   # `EngramWeb.Plugs.AccountLifecycle`.
   defp lifecycle(%{deleted_at: %DateTime{}}), do: {:error, %{reason: "account_deleted"}}
   defp lifecycle(%{suspended_at: %DateTime{}}), do: {:error, %{reason: "account_suspended"}}
-  defp lifecycle(_user), do: :ok
+
+  # Strictly `nil, nil` rather than a `_user` catch-all. A catch-all is
+  # fail-OPEN keyed on field presence: rename either column, narrow the read
+  # to a projection, or change the type away from `:utc_datetime_usec`, and
+  # both guard clauses above stop matching while every account silently
+  # passes the lifecycle gate — no compile error, no test failure. This is
+  # the same argument `Onboarding.derive_gate/3` makes about its own
+  # destructuring. A missing field should crash, not pass.
+  defp lifecycle(%{deleted_at: nil, suspended_at: nil}), do: :ok
 
   defp onboarding(user) do
     case Onboarding.gate(user, fresh: true) do

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -16,6 +16,8 @@ defmodule EngramWeb.ChannelGate do
     * `RequireActiveSubscription` → 402 `account_suspended` ✅ (#1429)
 
     * `RotationLockCheck`         → 423 `rotation_in_progress` ✅ (#1434)
+    * `RequireApiRpsBudget`       → `api_access_not_available` at join for a
+      key whose tier has `api_rps_cap: 0` ✅ (#1433)
     * `RequireApiWriteEnabled`    → WRITE frames only ✅ (#1433), see
       `api_write_blocked?/2` and `CrdtChannel`'s `@write_events` clause
 
@@ -23,13 +25,6 @@ defmodule EngramWeb.ChannelGate do
 
   **NOT mirrored — sockets are more permissive than HTTP here:**
 
-    * `RequireApiRpsBudget` — Free's `api_rps_cap` is 0 and that plug has no
-      GET exemption, so a Free PAT cannot make a single REST call, yet it can
-      still open a socket and READ the whole vault. Gating the join on it was
-      tried and reverted: `sync_channel_test.exs` and the tracing tests
-      actively assert Free API keys CAN join, so that is a contract change,
-      not a bug fix — it needs a product decision, not a security patch.
-      Writes are blocked regardless (above). Tracked in #1433.
     * `EnforceSearchCap`, `DeviceFingerprint`, `PreAuthRateLimit` — no channel
       equivalent; `PreAuthRateLimit` notably means there is **no join rate
       limiter** at all.
@@ -92,8 +87,10 @@ defmodule EngramWeb.ChannelGate do
   `:ok`, or `{:error, payload}` where `payload` is the map to return straight
   from `join/3` (always carries a `:reason`).
   """
-  @spec check(Engram.Accounts.User.t()) :: :ok | {:error, map()}
-  def check(%Engram.Accounts.User{id: user_id}) do
+  @spec check(Engram.Accounts.User.t(), term()) :: :ok | {:error, map()}
+  def check(user, api_key \\ nil)
+
+  def check(%Engram.Accounts.User{id: user_id}, api_key) do
     # One read, shared by both checks — `gate/2` is told not to re-read.
     #
     # No `|| socket_user` fallback: `Accounts.Lifecycle.hard_delete/2` removes
@@ -116,7 +113,8 @@ defmodule EngramWeb.ChannelGate do
         with :ok <- deleted(fresh),
              :ok <- rotation(fresh),
              :ok <- onboarding(fresh),
-             :ok <- suspended(fresh) do
+             :ok <- suspended(fresh),
+             :ok <- api_access(fresh, api_key) do
           # Liveness, mirroring `EngramWeb.Plugs.BumpActivity` — see the
           # `## Activity` note above. Only on a PASS: a refused client
           # retrying forever must not keep its own account looking alive.
@@ -169,6 +167,28 @@ defmodule EngramWeb.ChannelGate do
 
   def api_write_blocked?(user, _api_key) do
     Billing.check_feature(user, :api_write_enabled) != :ok
+  end
+
+  # Pricing v2 §G, mirroring `RequireApiRpsBudget` (#1433). That plug has no
+  # GET exemption, so for an API-key caller it gates EVERY request — and
+  # Free's `api_rps_cap` default is 0. A Free key therefore cannot make a
+  # single REST call, and must not be able to open a sync socket and read the
+  # whole vault instead.
+  #
+  # The exemption keys on the key being non-nil, NOT on the assign existing.
+  # The plug uses `not is_map_key(assigns, :current_api_key)`, but
+  # `UserSocket.accept/4` ALWAYS sets that key (nil for JWT) — porting the
+  # guard literally would gate every web and plugin user on the platform.
+  #
+  # Positive caps are metered per-frame by `CrdtChannel.check_rate/2`; this is
+  # the "may you use the API at all" half.
+  defp api_access(_user, nil), do: :ok
+
+  defp api_access(user, _api_key) do
+    case Billing.effective_limit(user, :api_rps_cap) do
+      0 -> {:error, %{reason: "api_access_not_available", upgrade_url: "/#settings/billing"}}
+      _ -> :ok
+    end
   end
 
   # `check_user/1`, not `check/1` — the row is already loaded, so this costs

--- a/lib/engram_web/channel_gate.ex
+++ b/lib/engram_web/channel_gate.ex
@@ -79,9 +79,13 @@ defmodule EngramWeb.ChannelGate do
 
   alias Engram.Accounts
   alias Engram.Billing
+  alias Engram.Crypto.HMAC
   alias Engram.Crypto.RotationGate
+  alias Engram.Logger.Metadata
   alias Engram.Onboarding
   alias Engram.UsageMeters
+
+  require Logger
 
   @doc """
   `:ok`, or `{:error, payload}` where `payload` is the map to return straight
@@ -118,7 +122,7 @@ defmodule EngramWeb.ChannelGate do
           # Liveness, mirroring `EngramWeb.Plugs.BumpActivity` — see the
           # `## Activity` note above. Only on a PASS: a refused client
           # retrying forever must not keep its own account looking alive.
-          UsageMeters.touch_active(user_id)
+          stamp_activity(user_id)
         end
     end
   end
@@ -167,6 +171,34 @@ defmodule EngramWeb.ChannelGate do
 
   def api_write_blocked?(user, _api_key) do
     Billing.check_feature(user, :api_write_enabled) != :ok
+  end
+
+  # Best-effort, and deliberately so. This is a DB WRITE on a path that was
+  # read-only: an exception here would propagate out of `join/3`, kill the
+  # channel process, and hand the client a transport error rather than a gate
+  # reason — which it then retries, re-attempting the same write. Refusing to
+  # sync because we could not record "you were here" is the wrong coupling.
+  #
+  # Logged at :error rather than swallowed, because a persistently failing
+  # stamp is not cosmetic: `InactivityCleanup` reads this column to decide who
+  # gets soft-deleted, so silent failure re-creates the very lockout #1429
+  # exists to prevent. It has to be alertable.
+  #
+  # The plug keeps the loud behaviour — a failed write there fails one request,
+  # which is bounded; here it would fail the whole sync session.
+  defp stamp_activity(user_id) do
+    UsageMeters.touch_active(user_id)
+  rescue
+    e ->
+      Logger.error(
+        "activity stamp failed",
+        Metadata.with_category(:error, :database,
+          user_id: HMAC.hash_user_id(to_string(user_id)),
+          error: Exception.message(e)
+        )
+      )
+
+      :ok
   end
 
   # Pricing v2 §G, mirroring `RequireApiRpsBudget` (#1433). That plug has no

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -142,7 +142,7 @@ defmodule EngramWeb.CrdtChannel do
   defp join_vault("crdt:" <> ids, user, user_id_str, socket) do
     case String.split(ids, ":") do
       [^user_id_str, _vid] ->
-        case ChannelGate.check(user) do
+        case ChannelGate.check(user, socket.assigns[:current_api_key]) do
           :ok -> join_gated_vault("crdt:" <> ids, user, user_id_str, socket)
           {:error, payload} -> {:error, payload}
         end

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -19,7 +19,6 @@ defmodule EngramWeb.CrdtChannel do
   use Phoenix.Channel
 
   alias Engram.Crypto.HMAC
-  alias Engram.Crypto.RotationGate
   alias Engram.Logger.Metadata
   alias Engram.{Notes, Repo, Vaults}
   alias Engram.Notes.CrdtBridge
@@ -118,26 +117,15 @@ defmodule EngramWeb.CrdtChannel do
   defp client_type(%{"client_type" => t}) when is_binary(t) and byte_size(t) <= 32, do: t
   defp client_type(_params), do: nil
 
+  # T3.7 (#1092): the crdt: channel is the live write path and must not open
+  # while a DEK rotation holds the user's lock. That check now lives in
+  # `EngramWeb.ChannelGate` (#1434) so `sync:` gets it too — it used to be
+  # open-coded here, and `SyncChannel` had none. In-flight sockets are drained
+  # separately (UserDekRotation).
   defp join_authenticated("crdt:" <> ids, socket) do
     user = socket.assigns.current_user
 
-    user_id_str = to_string(user.id)
-
-    join_rotation_checked(ids, user, user_id_str, socket)
-  end
-
-  defp join_rotation_checked(ids, user, user_id_str, socket) do
-    # T3.7 (#1092): the crdt: channel is the live write path — refuse to open it
-    # while a DEK rotation holds the user's lock. check/1 re-reads the row so a
-    # reconnect mid-rotation is caught even if the socket's user struct predates
-    # the lock. In-flight sockets are drained separately (UserDekRotation).
-    case RotationGate.check(user.id) do
-      {:error, :rotation_in_progress} -> {:error, %{reason: "rotation_in_progress"}}
-      # :ok, or {:error, :user_not_found} — let the downstream path decide.
-      # A missing user now reaches `ChannelGate.check/1`, which refuses with
-      # "account_deleted" (it used to fall through to "unauthorized").
-      _ -> join_vault("crdt:" <> ids, user, user_id_str, socket)
-    end
+    join_vault("crdt:" <> ids, user, to_string(user.id), socket)
   end
 
   # Plugs never run on a socket, so every vault-pipeline access gate is
@@ -213,6 +201,14 @@ defmodule EngramWeb.CrdtChannel do
                        vault: vault,
                        rooms: %{},
                        room_doc: %{},
+                       # Pricing v2 §G write gate (#1433). Resolved once here
+                       # so the per-frame check below is a pattern match, not
+                       # a query. JWT sockets are always false.
+                       api_write_blocked:
+                         ChannelGate.api_write_blocked?(
+                           user,
+                           socket.assigns[:current_api_key]
+                         ),
                        # doc_ids released by an idle drain (#1152), so the
                        # re-spin does not re-announce crdt_doc_ready. See
                        # start_and_observe_room.
@@ -237,6 +233,21 @@ defmodule EngramWeb.CrdtChannel do
   end
 
   @impl true
+  # Pricing v2 §G, mirroring `EngramWeb.Plugs.RequireApiWriteEnabled` (#1433):
+  # an API-key caller whose tier lacks `api_write_enabled` is 402'd on every
+  # non-GET REST route, and must not be able to write through the socket
+  # instead. Reads (`crdt_catchup_since`, inbound fan-out) are deliberately
+  # NOT listed — the plug exempts GET, and a key that may read over REST may
+  # read here. Placed ahead of the write handlers and matched on an assign
+  # resolved at join, so the common path pays nothing.
+  @write_events ~w(crdt_msg crdt_index_msg crdt_create crdt_create_batch crdt_delete)
+
+  def handle_in(event, _payload, %{assigns: %{api_write_blocked: true}} = socket)
+      when event in @write_events do
+    {:reply, {:error, %{reason: "api_write_not_available", upgrade_url: "/#settings/billing"}},
+     socket}
+  end
+
   def handle_in("crdt_msg", %{"doc_id" => doc_id, "b64" => b64}, socket) do
     # Classify (O(1), first 4 b64 chars) BEFORE the rate check so sync
     # handshakes ride their own, larger bucket than edit frames: connect-time

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -204,17 +204,11 @@ defmodule EngramWeb.CrdtChannel do
                        # Pricing v2 §G write gate (#1433). Resolved once here
                        # so the per-frame check below is a pattern match, not
                        # a query. JWT sockets are always false.
-                       # Resolved from a FRESH row, not `socket.assigns
-                       # .current_user` — that struct is frozen at
-                       # `connect/3`, and plugin sockets live for days, so a
-                       # Paddle downgrade or a revoked override would stay
-                       # invisible to this gate while `check/2` on the very
-                       # same join already saw it.
-                       api_write_blocked:
-                         ChannelGate.api_write_blocked?(
-                           user.id,
-                           socket.assigns[:current_api_key]
-                         ),
+                       rooms: %{},
+                       room_doc: %{},
+                       # Pricing v2 §G write gate (#1433). Resolved once here
+                       # so the per-frame check below is a pattern match, not
+                       # a query. JWT sockets are always false.
                        # doc_ids released by an idle drain (#1152), so the
                        # re-spin does not re-announce crdt_doc_ready. See
                        # start_and_observe_room.
@@ -239,27 +233,17 @@ defmodule EngramWeb.CrdtChannel do
   end
 
   @impl true
-  # Pricing v2 §G, mirroring `EngramWeb.Plugs.RequireApiWriteEnabled` (#1433):
-  # an API-key caller whose tier lacks `api_write_enabled` is 402'd on every
-  # non-GET REST route, and must not be able to write through the socket
-  # instead. Reads (`crdt_catchup_since`, inbound fan-out) are deliberately
-  # NOT listed — the plug exempts GET, and a key that may read over REST may
-  # read here. Placed ahead of the write handlers and matched on an assign
-  # resolved at join, so the common path pays nothing.
-  # Unambiguous writes. `crdt_msg`/`crdt_index_msg` are NOT here: they also
-  # carry the Yjs sync handshake, and SyncStep1 (`<<0, 0, _>>`) is a pure
-  # state-vector REQUEST — the frame a client sends to ask for doc state.
-  # Blocking it would leave a read-entitled key joined but permanently deaf
-  # (no room is ever observed, so fan-out never fires either), and the plug
-  # this mirrors opens with `when m in ["GET", "HEAD"], do: conn` under
-  # "Reads are never gated." Those two events are screened by payload below.
-  @write_events ~w(crdt_create crdt_create_batch crdt_delete)
+  # `b64` must be a binary before anything touches it. `decode_frame/1`'s
+  # `when byte_size(b64) > @max_b64_bytes` guard does NOT reject a non-binary
+  # — a failing guard just falls through to the next clause, which calls
+  # `Base.decode64/1` (`when is_binary`) and raises FunctionClauseError,
+  # killing the channel and every room observed on it. Same posture as
+  # `cast_cursor/1`: reply, don't crash.
+  def handle_in("crdt_msg", %{"b64" => b64}, socket) when not is_binary(b64),
+    do: {:reply, {:error, %{reason: "bad_frame"}}, socket}
 
-  def handle_in(event, _payload, %{assigns: %{api_write_blocked: true}} = socket)
-      when event in @write_events do
-    {:reply, {:error, %{reason: "api_write_not_available", upgrade_url: "/#settings/billing"}},
-     socket}
-  end
+  def handle_in("crdt_index_msg", %{"b64" => b64}, socket) when not is_binary(b64),
+    do: {:reply, {:error, %{reason: "bad_frame"}}, socket}
 
   def handle_in("crdt_msg", %{"doc_id" => doc_id, "b64" => b64}, socket) do
     # Classify (O(1), first 4 b64 chars) BEFORE the rate check so sync
@@ -270,8 +254,7 @@ defmodule EngramWeb.CrdtChannel do
     # incident trigger). The full base64 decode runs only AFTER the limiter
     # allows the frame, so an over-budget flood is still rejected at ETS-lookup
     # cost, never at MB-scale decode cost.
-    with :ok <- api_write_ok(socket, b64),
-         :ok <- check_rate(socket, frame_class_b64(b64)),
+    with :ok <- check_rate(socket, frame_class_b64(b64)),
          {:ok, frame} <- decode_frame(b64),
          :ok <- guard_frame(frame),
          {:ok, socket, %{room: room}} <- ensure_room(socket, doc_id, frame_class_b64(b64)),
@@ -283,11 +266,6 @@ defmodule EngramWeb.CrdtChannel do
       # the owner process's mailbox and the room's update_v1 path persists it.
       {:reply, {:ok, %{}}, socket}
     else
-      {:error, :api_write_not_available} ->
-        {:reply,
-         {:error, %{reason: "api_write_not_available", upgrade_url: "/#settings/billing"}},
-         socket}
-
       {:error, :rate_limited} ->
         {:reply, {:error, %{reason: "rate_limited"}}, socket}
 
@@ -365,19 +343,13 @@ defmodule EngramWeb.CrdtChannel do
   # behind the 2026-07-07 cross-file-overwrite incident.
   @impl true
   def handle_in("crdt_index_msg", %{"b64" => b64}, socket) do
-    with :ok <- api_write_ok(socket, b64),
-         :ok <- check_rate(socket, frame_class_b64(b64)),
+    with :ok <- check_rate(socket, frame_class_b64(b64)),
          {:ok, frame} <- decode_frame(b64),
          :ok <- guard_frame(frame),
          {:ok, socket, room} <- ensure_index_room(socket),
          :ok <- relay_frame(room, frame) do
       {:reply, {:ok, %{}}, socket}
     else
-      {:error, :api_write_not_available} ->
-        {:reply,
-         {:error, %{reason: "api_write_not_available", upgrade_url: "/#settings/billing"}},
-         socket}
-
       {:error, :rate_limited} ->
         {:reply, {:error, %{reason: "rate_limited"}}, socket}
 
@@ -1806,25 +1778,6 @@ defmodule EngramWeb.CrdtChannel do
   # edit budget. Without the size gate a client could relabel every edit as
   # STEP2 and mutate at 10x the intended cap.
   @hs_step2_max_b64 4096
-
-  # SyncStep1 only. `<<0, 1, _>>` (SyncStep2) carries the client's updates and
-  # is a write; `frame_class_b64/1` lumps both into `:handshake` because they
-  # share a RATE budget, which is a different question from entitlement.
-  defp read_only_frame?(<<prefix::binary-size(4), _::binary>>) do
-    match?({:ok, <<0, 0, _>>}, Base.decode64(prefix))
-  end
-
-  defp read_only_frame?(_), do: false
-
-  # Entitlement screen for the two events that carry BOTH reads and writes.
-  # SyncStep1 is a state-vector request and passes; SyncStep2 and edits carry
-  # state and are refused. Placed in the handlers' own `with` chains rather
-  # than a guard clause, because the decision needs the payload.
-  defp api_write_ok(%{assigns: %{api_write_blocked: true}}, b64) do
-    if read_only_frame?(b64), do: :ok, else: {:error, :api_write_not_available}
-  end
-
-  defp api_write_ok(_socket, _b64), do: :ok
 
   defp frame_class_b64(<<prefix::binary-size(4), _::binary>> = b64) do
     case Base.decode64(prefix) do

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -133,8 +133,9 @@ defmodule EngramWeb.CrdtChannel do
     # the lock. In-flight sockets are drained separately (UserDekRotation).
     case RotationGate.check(user.id) do
       {:error, :rotation_in_progress} -> {:error, %{reason: "rotation_in_progress"}}
-      # :ok, or {:error, :user_not_found} — let the vault-auth path decide
-      # (a missing user falls through to "unauthorized", not a rotation reason).
+      # :ok, or {:error, :user_not_found} — let the downstream path decide.
+      # A missing user now reaches `ChannelGate.check/1`, which refuses with
+      # "account_deleted" (it used to fall through to "unauthorized").
       _ -> join_vault("crdt:" <> ids, user, user_id_str, socket)
     end
   end

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -225,18 +225,7 @@ defmodule EngramWeb.CrdtChannel do
   end
 
   @impl true
-  # `when is_binary(b64)`: a non-binary must not reach `decode_frame/1`, whose
-  # `when byte_size(b64) > @max_b64_bytes` guard fails silently on one and
-  # falls through to `Base.decode64/1` (`when is_binary`), raising and killing
-  # the channel with every room observed on it.
-  #
-  # Guarding the head rather than adding an early-reply clause is deliberate:
-  # a non-binary now falls to the catch-all at the bottom of this module,
-  # which replies `bad_frame` only AFTER `check_rate/2`. An early clause would
-  # answer at line rate outside any budget — the same unmetered-flood shape
-  # that catch-all's own comment records as the reason it is rate-gated.
-  def handle_in("crdt_msg", %{"doc_id" => doc_id, "b64" => b64}, socket)
-      when is_binary(b64) do
+  def handle_in("crdt_msg", %{"doc_id" => doc_id, "b64" => b64}, socket) do
     # Classify (O(1), first 4 b64 chars) BEFORE the rate check so sync
     # handshakes ride their own, larger bucket than edit frames: connect-time
     # enrollment fires one STEP1 (+ tiny STEP2 echo) per note, so on a
@@ -333,7 +322,7 @@ defmodule EngramWeb.CrdtChannel do
   # lane just moves the starvation risk onto handshakes, which is the shape
   # behind the 2026-07-07 cross-file-overwrite incident.
   @impl true
-  def handle_in("crdt_index_msg", %{"b64" => b64}, socket) when is_binary(b64) do
+  def handle_in("crdt_index_msg", %{"b64" => b64}, socket) do
     with :ok <- check_rate(socket, frame_class_b64(b64)),
          {:ok, frame} <- decode_frame(b64),
          :ok <- guard_frame(frame),
@@ -688,14 +677,9 @@ defmodule EngramWeb.CrdtChannel do
       log_entry_failure(entry, Metadata.safe_reason(e))
   catch
     :exit, reason ->
-      # `safe_exit_reason/1`, not `safe_reason/1` — both redact, but the latter
-      # collapses the two commonest exit shapes to nothing. Its general tuple
-      # clause returns "unknown" unless `elem(0)` is an atom, so a room
-      # crashing mid-batch (`{%RuntimeError{}, stacktrace}`) logged literally
-      # "exited: unknown", and a `GenServer.call` timeout logged ":timeout".
-      # `safe_exit_reason/1` renders those as "runtime error at lib/…:NN" and
-      # "timeout in GenServer.call/3", equally redacted and actually useful.
-      log_entry_failure(entry, "exited: #{Metadata.safe_exit_reason(reason)}")
+      # An exit reason carries the crashed call's arguments, which on this path
+      # are Yjs frames. Kind only.
+      log_entry_failure(entry, "exited: #{Metadata.safe_reason(reason)}")
   end
 
   defp log_entry_failure(entry, reason) do
@@ -771,13 +755,6 @@ defmodule EngramWeb.CrdtChannel do
 
       {:error, :frame_too_large} ->
         {:result, %{doc_id: doc_id, status: "error", reason: "frame_too_large"}}
-
-      # PERMANENT, so it must not fall to `other ->` and report
-      # `create_failed`, which is the TRANSIENT reason (pool timeout, dead
-      # room) the plugin retries — a malformed frame would be re-sent forever.
-      # Same reason the invalid-shape clause below reports.
-      {:error, :bad_base64} ->
-        {:result, %{doc_id: doc_id, status: "error", reason: "bad_frame"}}
 
       other ->
         # Never swallow the reason: this arm is the only thing standing between
@@ -1849,15 +1826,6 @@ defmodule EngramWeb.CrdtChannel do
       {:deny, _} -> {:error, :rate_limited}
     end
   end
-
-  # Non-binary FIRST. `when byte_size(b64) > @max_b64_bytes` does not reject a
-  # non-binary — a failing guard just falls through, and the clause below then
-  # calls `Base.decode64/1` (`when is_binary`) and RAISES. On `crdt_msg` that
-  # killed the channel; inside `crdt_create_batch` it was caught by
-  # `entry_guard` and reported as `create_failed`, the reason reserved for
-  # TRANSIENT failure — so the client re-sent a permanently broken frame
-  # forever. Rejecting here fixes every caller at once.
-  defp decode_frame(b64) when not is_binary(b64), do: {:error, :bad_base64}
 
   defp decode_frame(b64) when byte_size(b64) > @max_b64_bytes, do: {:error, :frame_too_large}
 

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -29,6 +29,7 @@ defmodule EngramWeb.CrdtChannel do
   alias Engram.Notes.CrdtPersistence
   alias Engram.Notes.CrdtRegistry
   alias Engram.Notes.CrdtTransport
+  alias EngramWeb.ChannelGate
   alias Yex.Sync.SharedDoc
 
   require Logger
@@ -138,28 +139,23 @@ defmodule EngramWeb.CrdtChannel do
     end
   end
 
-  # Enforced here, not by a router pipeline: `RequireOnboarding` is a Plug and
-  # Plugs never run on a socket, and this is the live sync write path — an
-  # account that skipped ToS / plan selection reached a full read-write vault
-  # through it while every REST route correctly 403'd. Same verdict function
-  # as the plug (`Engram.Onboarding.gate/1`).
+  # Plugs never run on a socket, so every vault-pipeline access gate is
+  # re-expressed in `EngramWeb.ChannelGate` and applied here. Read that
+  # moduledoc before adding a plug to the vault pipeline.
   #
   # Deliberately positioned AFTER the topic ownership match and after
   # `RotationGate.check/1`: the match is free, so a `crdt:<other-user>:<uuid>`
-  # probe must not buy ~4 DB round-trips (there is no join rate limiter), and
-  # a user mid-DEK-rotation must still get `rotation_in_progress` rather than
-  # this. The plugin's identity self-heal also keys on `unauthorized`
-  # specifically (channel.ts, e2e test_84) — gating ahead of the match would
-  # have replaced that reason and wedged the heal.
+  # probe must not buy the gate's DB round-trips (there is no join rate
+  # limiter), and a user mid-DEK-rotation must still get `rotation_in_progress`
+  # rather than this. The plugin's identity self-heal also keys on
+  # `unauthorized` specifically (channel.ts, e2e test_84) — gating ahead of the
+  # match would have replaced that reason and wedged the heal.
   defp join_vault("crdt:" <> ids, user, user_id_str, socket) do
     case String.split(ids, ":") do
       [^user_id_str, _vid] ->
-        case Engram.Onboarding.gate(user) do
-          :ok ->
-            join_gated_vault("crdt:" <> ids, user, user_id_str, socket)
-
-          {:error, missing, next_step} ->
-            {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
+        case ChannelGate.check(user) do
+          :ok -> join_gated_vault("crdt:" <> ids, user, user_id_str, socket)
+          {:error, payload} -> {:error, payload}
         end
 
       _ ->

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -132,8 +132,8 @@ defmodule EngramWeb.CrdtChannel do
   # re-expressed in `EngramWeb.ChannelGate` and applied here. Read that
   # moduledoc before adding a plug to the vault pipeline.
   #
-  # Deliberately positioned AFTER the topic ownership match and after
-  # `RotationGate.check/1`: the match is free, so a `crdt:<other-user>:<uuid>`
+  # Deliberately positioned AFTER the topic ownership match: the match is
+  # free, so a `crdt:<other-user>:<uuid>`
   # probe must not buy the gate's DB round-trips (there is no join rate
   # limiter), and a user mid-DEK-rotation must still get `rotation_in_progress`
   # rather than this. The plugin's identity self-heal also keys on
@@ -204,9 +204,15 @@ defmodule EngramWeb.CrdtChannel do
                        # Pricing v2 §G write gate (#1433). Resolved once here
                        # so the per-frame check below is a pattern match, not
                        # a query. JWT sockets are always false.
+                       # Resolved from a FRESH row, not `socket.assigns
+                       # .current_user` — that struct is frozen at
+                       # `connect/3`, and plugin sockets live for days, so a
+                       # Paddle downgrade or a revoked override would stay
+                       # invisible to this gate while `check/2` on the very
+                       # same join already saw it.
                        api_write_blocked:
                          ChannelGate.api_write_blocked?(
-                           user,
+                           user.id,
                            socket.assigns[:current_api_key]
                          ),
                        # doc_ids released by an idle drain (#1152), so the
@@ -240,7 +246,14 @@ defmodule EngramWeb.CrdtChannel do
   # NOT listed — the plug exempts GET, and a key that may read over REST may
   # read here. Placed ahead of the write handlers and matched on an assign
   # resolved at join, so the common path pays nothing.
-  @write_events ~w(crdt_msg crdt_index_msg crdt_create crdt_create_batch crdt_delete)
+  # Unambiguous writes. `crdt_msg`/`crdt_index_msg` are NOT here: they also
+  # carry the Yjs sync handshake, and SyncStep1 (`<<0, 0, _>>`) is a pure
+  # state-vector REQUEST — the frame a client sends to ask for doc state.
+  # Blocking it would leave a read-entitled key joined but permanently deaf
+  # (no room is ever observed, so fan-out never fires either), and the plug
+  # this mirrors opens with `when m in ["GET", "HEAD"], do: conn` under
+  # "Reads are never gated." Those two events are screened by payload below.
+  @write_events ~w(crdt_create crdt_create_batch crdt_delete)
 
   def handle_in(event, _payload, %{assigns: %{api_write_blocked: true}} = socket)
       when event in @write_events do
@@ -257,7 +270,8 @@ defmodule EngramWeb.CrdtChannel do
     # incident trigger). The full base64 decode runs only AFTER the limiter
     # allows the frame, so an over-budget flood is still rejected at ETS-lookup
     # cost, never at MB-scale decode cost.
-    with :ok <- check_rate(socket, frame_class_b64(b64)),
+    with :ok <- api_write_ok(socket, b64),
+         :ok <- check_rate(socket, frame_class_b64(b64)),
          {:ok, frame} <- decode_frame(b64),
          :ok <- guard_frame(frame),
          {:ok, socket, %{room: room}} <- ensure_room(socket, doc_id, frame_class_b64(b64)),
@@ -269,6 +283,11 @@ defmodule EngramWeb.CrdtChannel do
       # the owner process's mailbox and the room's update_v1 path persists it.
       {:reply, {:ok, %{}}, socket}
     else
+      {:error, :api_write_not_available} ->
+        {:reply,
+         {:error, %{reason: "api_write_not_available", upgrade_url: "/#settings/billing"}},
+         socket}
+
       {:error, :rate_limited} ->
         {:reply, {:error, %{reason: "rate_limited"}}, socket}
 
@@ -346,13 +365,19 @@ defmodule EngramWeb.CrdtChannel do
   # behind the 2026-07-07 cross-file-overwrite incident.
   @impl true
   def handle_in("crdt_index_msg", %{"b64" => b64}, socket) do
-    with :ok <- check_rate(socket, frame_class_b64(b64)),
+    with :ok <- api_write_ok(socket, b64),
+         :ok <- check_rate(socket, frame_class_b64(b64)),
          {:ok, frame} <- decode_frame(b64),
          :ok <- guard_frame(frame),
          {:ok, socket, room} <- ensure_index_room(socket),
          :ok <- relay_frame(room, frame) do
       {:reply, {:ok, %{}}, socket}
     else
+      {:error, :api_write_not_available} ->
+        {:reply,
+         {:error, %{reason: "api_write_not_available", upgrade_url: "/#settings/billing"}},
+         socket}
+
       {:error, :rate_limited} ->
         {:reply, {:error, %{reason: "rate_limited"}}, socket}
 
@@ -1781,6 +1806,25 @@ defmodule EngramWeb.CrdtChannel do
   # edit budget. Without the size gate a client could relabel every edit as
   # STEP2 and mutate at 10x the intended cap.
   @hs_step2_max_b64 4096
+
+  # SyncStep1 only. `<<0, 1, _>>` (SyncStep2) carries the client's updates and
+  # is a write; `frame_class_b64/1` lumps both into `:handshake` because they
+  # share a RATE budget, which is a different question from entitlement.
+  defp read_only_frame?(<<prefix::binary-size(4), _::binary>>) do
+    match?({:ok, <<0, 0, _>>}, Base.decode64(prefix))
+  end
+
+  defp read_only_frame?(_), do: false
+
+  # Entitlement screen for the two events that carry BOTH reads and writes.
+  # SyncStep1 is a state-vector request and passes; SyncStep2 and edits carry
+  # state and are refused. Placed in the handlers' own `with` chains rather
+  # than a guard clause, because the decision needs the payload.
+  defp api_write_ok(%{assigns: %{api_write_blocked: true}}, b64) do
+    if read_only_frame?(b64), do: :ok, else: {:error, :api_write_not_available}
+  end
+
+  defp api_write_ok(_socket, _b64), do: :ok
 
   defp frame_class_b64(<<prefix::binary-size(4), _::binary>> = b64) do
     case Base.decode64(prefix) do

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -201,14 +201,6 @@ defmodule EngramWeb.CrdtChannel do
                        vault: vault,
                        rooms: %{},
                        room_doc: %{},
-                       # Pricing v2 §G write gate (#1433). Resolved once here
-                       # so the per-frame check below is a pattern match, not
-                       # a query. JWT sockets are always false.
-                       rooms: %{},
-                       room_doc: %{},
-                       # Pricing v2 §G write gate (#1433). Resolved once here
-                       # so the per-frame check below is a pattern match, not
-                       # a query. JWT sockets are always false.
                        # doc_ids released by an idle drain (#1152), so the
                        # re-spin does not re-announce crdt_doc_ready. See
                        # start_and_observe_room.
@@ -233,19 +225,18 @@ defmodule EngramWeb.CrdtChannel do
   end
 
   @impl true
-  # `b64` must be a binary before anything touches it. `decode_frame/1`'s
-  # `when byte_size(b64) > @max_b64_bytes` guard does NOT reject a non-binary
-  # — a failing guard just falls through to the next clause, which calls
-  # `Base.decode64/1` (`when is_binary`) and raises FunctionClauseError,
-  # killing the channel and every room observed on it. Same posture as
-  # `cast_cursor/1`: reply, don't crash.
-  def handle_in("crdt_msg", %{"b64" => b64}, socket) when not is_binary(b64),
-    do: {:reply, {:error, %{reason: "bad_frame"}}, socket}
-
-  def handle_in("crdt_index_msg", %{"b64" => b64}, socket) when not is_binary(b64),
-    do: {:reply, {:error, %{reason: "bad_frame"}}, socket}
-
-  def handle_in("crdt_msg", %{"doc_id" => doc_id, "b64" => b64}, socket) do
+  # `when is_binary(b64)`: a non-binary must not reach `decode_frame/1`, whose
+  # `when byte_size(b64) > @max_b64_bytes` guard fails silently on one and
+  # falls through to `Base.decode64/1` (`when is_binary`), raising and killing
+  # the channel with every room observed on it.
+  #
+  # Guarding the head rather than adding an early-reply clause is deliberate:
+  # a non-binary now falls to the catch-all at the bottom of this module,
+  # which replies `bad_frame` only AFTER `check_rate/2`. An early clause would
+  # answer at line rate outside any budget — the same unmetered-flood shape
+  # that catch-all's own comment records as the reason it is rate-gated.
+  def handle_in("crdt_msg", %{"doc_id" => doc_id, "b64" => b64}, socket)
+      when is_binary(b64) do
     # Classify (O(1), first 4 b64 chars) BEFORE the rate check so sync
     # handshakes ride their own, larger bucket than edit frames: connect-time
     # enrollment fires one STEP1 (+ tiny STEP2 echo) per note, so on a
@@ -342,7 +333,7 @@ defmodule EngramWeb.CrdtChannel do
   # lane just moves the starvation risk onto handshakes, which is the shape
   # behind the 2026-07-07 cross-file-overwrite incident.
   @impl true
-  def handle_in("crdt_index_msg", %{"b64" => b64}, socket) do
+  def handle_in("crdt_index_msg", %{"b64" => b64}, socket) when is_binary(b64) do
     with :ok <- check_rate(socket, frame_class_b64(b64)),
          {:ok, frame} <- decode_frame(b64),
          :ok <- guard_frame(frame),
@@ -697,9 +688,14 @@ defmodule EngramWeb.CrdtChannel do
       log_entry_failure(entry, Metadata.safe_reason(e))
   catch
     :exit, reason ->
-      # An exit reason carries the crashed call's arguments, which on this path
-      # are Yjs frames. Kind only.
-      log_entry_failure(entry, "exited: #{Metadata.safe_reason(reason)}")
+      # `safe_exit_reason/1`, not `safe_reason/1` — both redact, but the latter
+      # collapses the two commonest exit shapes to nothing. Its general tuple
+      # clause returns "unknown" unless `elem(0)` is an atom, so a room
+      # crashing mid-batch (`{%RuntimeError{}, stacktrace}`) logged literally
+      # "exited: unknown", and a `GenServer.call` timeout logged ":timeout".
+      # `safe_exit_reason/1` renders those as "runtime error at lib/…:NN" and
+      # "timeout in GenServer.call/3", equally redacted and actually useful.
+      log_entry_failure(entry, "exited: #{Metadata.safe_exit_reason(reason)}")
   end
 
   defp log_entry_failure(entry, reason) do
@@ -775,6 +771,13 @@ defmodule EngramWeb.CrdtChannel do
 
       {:error, :frame_too_large} ->
         {:result, %{doc_id: doc_id, status: "error", reason: "frame_too_large"}}
+
+      # PERMANENT, so it must not fall to `other ->` and report
+      # `create_failed`, which is the TRANSIENT reason (pool timeout, dead
+      # room) the plugin retries — a malformed frame would be re-sent forever.
+      # Same reason the invalid-shape clause below reports.
+      {:error, :bad_base64} ->
+        {:result, %{doc_id: doc_id, status: "error", reason: "bad_frame"}}
 
       other ->
         # Never swallow the reason: this arm is the only thing standing between
@@ -1846,6 +1849,15 @@ defmodule EngramWeb.CrdtChannel do
       {:deny, _} -> {:error, :rate_limited}
     end
   end
+
+  # Non-binary FIRST. `when byte_size(b64) > @max_b64_bytes` does not reject a
+  # non-binary — a failing guard just falls through, and the clause below then
+  # calls `Base.decode64/1` (`when is_binary`) and RAISES. On `crdt_msg` that
+  # killed the channel; inside `crdt_create_batch` it was caught by
+  # `entry_guard` and reported as `create_failed`, the reason reserved for
+  # TRANSIENT failure — so the client re-sent a permanently broken frame
+  # forever. Rejecting here fixes every caller at once.
+  defp decode_frame(b64) when not is_binary(b64), do: {:error, :bad_base64}
 
   defp decode_frame(b64) when byte_size(b64) > @max_b64_bytes, do: {:error, :frame_too_large}
 

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -17,6 +17,7 @@ defmodule EngramWeb.SyncChannel do
   alias Engram.Crypto.HMAC
   alias Engram.Logger.Metadata
   alias Engram.Vaults
+  alias EngramWeb.ChannelGate
   alias EngramWeb.Presence
 
   require Logger
@@ -44,18 +45,14 @@ defmodule EngramWeb.SyncChannel do
     end
   end
 
-  # Enforced here, not by a router pipeline: `RequireOnboarding` is a Plug and
-  # Plugs never run on a socket. Same verdict function as the plug
-  # (`Engram.Onboarding.gate/1`). Runs AFTER the topic ownership match, which
-  # is free — deriving the verdict costs ~4 DB round-trips and there is no
-  # join rate limiter, so a `sync:<other-user>:<uuid>` probe must not pay it.
+  # Plugs never run on a socket, so every vault-pipeline access gate is
+  # re-expressed in `EngramWeb.ChannelGate`. Runs AFTER the topic ownership
+  # match, which is free — the gate costs DB round-trips and there is no join
+  # rate limiter, so a `sync:<other-user>:<uuid>` probe must not pay for it.
   defp gate_and_join(vault_id_str, params, socket, user) do
-    case Engram.Onboarding.gate(user) do
-      :ok ->
-        resolve_vault_and_join(vault_id_str, params, socket, user)
-
-      {:error, missing, next_step} ->
-        {:error, %{reason: "onboarding_required", missing: missing, next_step: next_step}}
+    case ChannelGate.check(user) do
+      :ok -> resolve_vault_and_join(vault_id_str, params, socket, user)
+      {:error, payload} -> {:error, payload}
     end
   end
 

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -50,7 +50,7 @@ defmodule EngramWeb.SyncChannel do
   # match, which is free — the gate costs DB round-trips and there is no join
   # rate limiter, so a `sync:<other-user>:<uuid>` probe must not pay for it.
   defp gate_and_join(vault_id_str, params, socket, user) do
-    case ChannelGate.check(user) do
+    case ChannelGate.check(user, socket.assigns[:current_api_key]) do
       :ok -> resolve_vault_and_join(vault_id_str, params, socket, user)
       {:error, payload} -> {:error, payload}
     end

--- a/lib/engram_web/channels/user_channel.ex
+++ b/lib/engram_web/channels/user_channel.ex
@@ -12,12 +12,22 @@ defmodule EngramWeb.UserChannel do
 
   use Phoenix.Channel
 
+  alias EngramWeb.ChannelGate
+
   @impl true
   def join("user:" <> user_id_str, _params, socket) do
     user = socket.assigns.current_user
 
     if to_string(user.id) == user_id_str do
-      {:ok, %{plan: Engram.Billing.plan_state(user)}, socket}
+      # Deletion only. Suspension and onboarding are deliberately NOT gated
+      # here — a suspended user needs `subscription_activated` to pay their
+      # way out, and the FTUX vault screen blocks on `vault_created` /
+      # `vault_populated` before onboarding is complete. Deletion has no such
+      # exemption on the HTTP side and gets none here. (#1435)
+      case ChannelGate.check_not_deleted(user) do
+        :ok -> {:ok, %{plan: Engram.Billing.plan_state(user)}, socket}
+        {:error, payload} -> {:error, payload}
+      end
     else
       {:error, %{reason: "unauthorized"}}
     end

--- a/lib/engram_web/plugs/bump_activity.ex
+++ b/lib/engram_web/plugs/bump_activity.ex
@@ -3,49 +3,22 @@ defmodule EngramWeb.Plugs.BumpActivity do
   Stamps `usage_meters.last_active_at` on every authenticated request so the
   inactivity cron (§C) can tell who's actually using Engram.
 
-  Debounced: only writes when the stored value is stale by > 1h, since
-  every API call and SSE keepalive otherwise hammers the meter row.
-
-  An `ActivityCache` (per-node ETS) holds the last-known stamp so that, once
-  warm, a request within the debounce window skips the meter read entirely —
-  the common steady-state path no longer touches the DB at all. On a cache
-  miss we fall back to the authoritative DB read, then warm the cache.
+  The debounce + cache logic lives in `Engram.UsageMeters.touch_active/1`
+  because HTTP is not the only transport a user can be active on — the
+  `sync:`/`crdt:` channel joins call it too via `EngramWeb.ChannelGate`.
+  Stamping on requests alone let a plugin user who syncs daily over WebSocket
+  and rarely touches REST age into the 90-day soft-delete sweep while in
+  constant active use.
   """
 
   alias Engram.UsageMeters
-  alias Engram.UsageMeters.ActivityCache
 
   def init(opts), do: opts
 
   def call(%Plug.Conn{assigns: %{current_user: %{id: user_id}}} = conn, _opts) do
-    case ActivityCache.get(user_id) do
-      {:ok, ts} ->
-        if needs_bump?(ts), do: bump(user_id)
-
-      :miss ->
-        last = UsageMeters.last_active_at(user_id)
-
-        if needs_bump?(last) do
-          bump(user_id)
-        else
-          ActivityCache.put(user_id, last)
-        end
-    end
-
+    :ok = UsageMeters.touch_active(user_id)
     conn
   end
 
   def call(conn, _opts), do: conn
-
-  defp bump(user_id) do
-    now = DateTime.utc_now()
-    UsageMeters.bump_last_active(user_id)
-    ActivityCache.put(user_id, now)
-  end
-
-  defp needs_bump?(nil), do: true
-
-  defp needs_bump?(%DateTime{} = ts) do
-    DateTime.diff(DateTime.utc_now(), ts, :second) > ActivityCache.debounce_seconds()
-  end
 end

--- a/lib/engram_web/plugs/require_onboarding.ex
+++ b/lib/engram_web/plugs/require_onboarding.ex
@@ -13,7 +13,7 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
   on a socket.
 
   Adding a route to the vault pipeline gets you this plug. Adding a *channel*
-  gets you nothing — call `EngramWeb.ChannelGate.check/1` from its `join/3`,
+  gets you nothing — call `EngramWeb.ChannelGate.check/2` from its `join/3`,
   NOT `Onboarding.gate/2` directly. `ChannelGate` composes onboarding with the
   account-lifecycle gates and the liveness stamp; calling `gate/2` alone gives
   you a channel with onboarding enforced and lifecycle silently missing, which

--- a/lib/engram_web/plugs/require_onboarding.ex
+++ b/lib/engram_web/plugs/require_onboarding.ex
@@ -8,10 +8,16 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
   profile + vault.
 
   This is the HTTP half of the gate only. The verdict itself lives in
-  `Engram.Onboarding.gate/1` because the WebSocket sync path (`sync:` /
+  `Engram.Onboarding.gate/2` because the WebSocket sync path (`sync:` /
   `crdt:` channel joins) must enforce the same rule and a Plug never runs
-  on a socket. Adding a route to the vault pipeline gets you this plug;
-  adding a *channel* does not — call `Onboarding.gate/1` from its `join/3`.
+  on a socket.
+
+  Adding a route to the vault pipeline gets you this plug. Adding a *channel*
+  gets you nothing — call `EngramWeb.ChannelGate.check/1` from its `join/3`,
+  NOT `Onboarding.gate/2` directly. `ChannelGate` composes onboarding with the
+  account-lifecycle gates and the liveness stamp; calling `gate/2` alone gives
+  you a channel with onboarding enforced and lifecycle silently missing, which
+  is the exact regression #1429 existed to close.
 
   Accepts the same options as `Engram.Onboarding.gate/2` — notably
   `skip_vault: true`, for routes whose own job is creating the first vault

--- a/test/engram/logger/log_call_compliance_test.exs
+++ b/test/engram/logger/log_call_compliance_test.exs
@@ -42,6 +42,11 @@ defmodule Engram.Logger.LogCallComplianceTest do
   # flags 84 sites to protect 40 gets switched off. Widen this list rather than
   # adding exceptions to it.
   @content_paths [
+    # Logs exception and EXIT reasons from the liveness stamp. A Postgrex
+    # error renders "Failing row contains (...)", so this file can absolutely
+    # reach a row value — it was out-of-scope on the claim that it "never"
+    # can, which its own safe_reason/safe_exit_reason calls disprove.
+    "lib/engram_web/channel_gate.ex",
     "lib/engram/notes.ex",
     "lib/engram/notes/",
     "lib/engram/attachments.ex",
@@ -162,10 +167,6 @@ defmodule Engram.Logger.LogCallComplianceTest do
     "lib/engram/webhooks/",
     "lib/engram_web.ex",
     "lib/engram_web/api_spec.ex",
-    # Socket-side equivalent of `plugs/` below: account lifecycle, onboarding
-    # and API entitlement verdicts. Sees user ids and plan limits, never note
-    # content, paths, titles or queries.
-    "lib/engram_web/channel_gate.ex",
     "lib/engram_web/controllers/",
     "lib/engram_web/controllers/admin/",
     "lib/engram_web/csp.ex",

--- a/test/engram/logger/log_call_compliance_test.exs
+++ b/test/engram/logger/log_call_compliance_test.exs
@@ -162,6 +162,10 @@ defmodule Engram.Logger.LogCallComplianceTest do
     "lib/engram/webhooks/",
     "lib/engram_web.ex",
     "lib/engram_web/api_spec.ex",
+    # Socket-side equivalent of `plugs/` below: account lifecycle, onboarding
+    # and API entitlement verdicts. Sees user ids and plan limits, never note
+    # content, paths, titles or queries.
+    "lib/engram_web/channel_gate.ex",
     "lib/engram_web/controllers/",
     "lib/engram_web/controllers/admin/",
     "lib/engram_web/csp.ex",

--- a/test/engram/onboarding_gate_test.exs
+++ b/test/engram/onboarding_gate_test.exs
@@ -87,6 +87,25 @@ defmodule Engram.OnboardingGateTest do
     assert :ok = Onboarding.gate(done)
   end
 
+  # Pins the metadata the socket-side liveness rescue emits. That rescue
+  # shipped once with `:database`, which is not a category — and
+  # `with_category/3` RAISES on an unknown atom, so the handler written to
+  # keep a stamp failure from killing the join killed it instead. There is no
+  # seam to force a real meter-write failure in this suite, so pin the part
+  # that was actually wrong: the atoms.
+  test "the activity-stamp failure log is well-formed" do
+    assert Engram.Logger.Category.valid?(:lifecycle)
+
+    meta =
+      Engram.Logger.Metadata.with_category(:error, :lifecycle,
+        user_id: "hashed",
+        reason: "boom",
+        reason_label: "exit"
+      )
+
+    assert Keyword.get(meta, :category) == :lifecycle
+  end
+
   defp onboarded_user(opts \\ []) do
     uses_obsidian = Keyword.get(opts, :uses_obsidian, true)
     user = insert_user(onboarding_profile: %{})

--- a/test/engram/onboarding_gate_test.exs
+++ b/test/engram/onboarding_gate_test.exs
@@ -87,25 +87,6 @@ defmodule Engram.OnboardingGateTest do
     assert :ok = Onboarding.gate(done)
   end
 
-  # Pins the metadata the socket-side liveness rescue emits. That rescue
-  # shipped once with `:database`, which is not a category — and
-  # `with_category/3` RAISES on an unknown atom, so the handler written to
-  # keep a stamp failure from killing the join killed it instead. There is no
-  # seam to force a real meter-write failure in this suite, so pin the part
-  # that was actually wrong: the atoms.
-  test "the activity-stamp failure log is well-formed" do
-    assert Engram.Logger.Category.valid?(:lifecycle)
-
-    meta =
-      Engram.Logger.Metadata.with_category(:error, :lifecycle,
-        user_id: "hashed",
-        reason: "boom",
-        reason_label: "exit"
-      )
-
-    assert Keyword.get(meta, :category) == :lifecycle
-  end
-
   defp onboarded_user(opts \\ []) do
     uses_obsidian = Keyword.get(opts, :uses_obsidian, true)
     user = insert_user(onboarding_profile: %{})

--- a/test/engram_web/channels/crdt_channel_tracing_test.exs
+++ b/test/engram_web/channels/crdt_channel_tracing_test.exs
@@ -20,6 +20,7 @@ defmodule EngramWeb.CrdtChannelTracingTest do
     user = insert(:user)
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     vault = insert(:vault, user: user, is_default: true)
+    grant_api_write!(user)
     {:ok, token, _} = Engram.Accounts.create_api_key(user, "crdt-tracing-test")
     topic = "crdt:#{user.id}:#{vault.id}"
     %{user: user, vault: vault, token: token, topic: topic}

--- a/test/engram_web/channels/sync_channel_test.exs
+++ b/test/engram_web/channels/sync_channel_test.exs
@@ -20,6 +20,7 @@ defmodule EngramWeb.SyncChannelTest do
   describe "connect/3" do
     test "accepts valid API key" do
       user = insert(:user)
+      grant_api_write!(user)
       {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test")
 
       assert {:ok, socket} =
@@ -94,6 +95,7 @@ defmodule EngramWeb.SyncChannelTest do
 
   describe "join/3 with restricted API key" do
     test "restricted key can join its authorized vault", %{user: user, vault: vault} do
+      grant_api_write!(user)
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-chan")
 
       Engram.Repo.insert_all("api_key_vaults", [
@@ -107,6 +109,7 @@ defmodule EngramWeb.SyncChannelTest do
     test "restricted key cannot join unauthorized vault", %{user: user, vault: vault} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
       {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Vault B"})
+      grant_api_write!(user)
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-chan2")
 
       # Only grant access to vault_b — NOT the default vault
@@ -126,6 +129,7 @@ defmodule EngramWeb.SyncChannelTest do
     end
 
     test "restricted key on topic without vault_id gets invalid_topic", %{user: user} do
+      grant_api_write!(user)
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-compat")
       socket = user_socket(user, api_key_record)
 
@@ -137,6 +141,7 @@ defmodule EngramWeb.SyncChannelTest do
       user: user,
       vault: vault
     } do
+      grant_api_write!(user)
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "unrestricted-chan")
 
       socket = user_socket(user, api_key_record)

--- a/test/engram_web/channels/sync_channel_tracing_test.exs
+++ b/test/engram_web/channels/sync_channel_tracing_test.exs
@@ -20,6 +20,7 @@ defmodule EngramWeb.SyncChannelTracingTest do
     user = insert(:user)
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     vault = insert(:vault, user: user, is_default: true)
+    grant_api_write!(user)
     {:ok, token, _} = Engram.Accounts.create_api_key(user, "tracing-test")
     topic = "sync:#{user.id}:#{vault.id}"
     %{user: user, vault: vault, token: token, topic: topic}

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -14,6 +14,8 @@ defmodule EngramWeb.LifecycleGateChannelTest do
   alias Engram.Onboarding
   alias Engram.Onboarding.GateCache
   alias Engram.Repo
+  alias Engram.UsageMeters
+  alias Engram.UsageMeters.ActivityCache
   alias Engram.Vaults
 
   setup do
@@ -64,8 +66,13 @@ defmodule EngramWeb.LifecycleGateChannelTest do
       |> Ecto.Changeset.change([{field, DateTime.utc_now()}])
       |> Repo.update()
 
-    # The gate caches PASS verdicts; a suspension must not be masked by one.
-    GateCache.evict_all()
+    # Deliberately NOT evicting GateCache here. Lifecycle is never cached by
+    # design, so eviction is not needed for these tests to pass — but a warm
+    # PASS entry (left by an earlier successful join in the same test) is the
+    # ONLY signal that catches someone "optimizing" the double read by putting
+    # lifecycle behind the cache. Evicting threw that detector away: the
+    # review proved a `GateCache.passed?` short-circuit in `check/1` left all
+    # 22 tests across both gate files green.
     user
   end
 
@@ -101,7 +108,14 @@ defmodule EngramWeb.LifecycleGateChannelTest do
       assert {:ok, _, joined} = join_crdt(user, vault)
       Sandbox.allow(Repo, self(), joined.channel_pid)
 
-      user = mark!(user, :suspended_at)
+      _suspended = mark!(user, :suspended_at)
+
+      # Rejoin on a socket built from the PRE-suspension struct — that is the
+      # real shape: `UserSocket` freezes `current_user` at `connect/3`, so the
+      # reconnecting client's socket predates the suspension. Passing the
+      # already-mutated struct (as this test used to) would keep passing even
+      # if `check/1` read `socket.assigns.current_user` instead of the DB,
+      # which is exactly the invariant the extra read exists to hold.
       assert {:error, %{reason: "account_suspended"}} = join_crdt(user, vault)
     end
 
@@ -118,7 +132,9 @@ defmodule EngramWeb.LifecycleGateChannelTest do
 
   describe "soft-deleted accounts" do
     test "crdt: join is refused", %{user: user, vault: vault} do
-      user = mark!(user, :deleted_at)
+      # `user` stays the PRE-deletion struct on purpose — see the suspension
+      # test above. The gate must read the row, not the socket.
+      _deleted = mark!(user, :deleted_at)
       assert {:error, %{reason: "account_deleted"}} = join_crdt(user, vault)
     end
 
@@ -166,6 +182,52 @@ defmodule EngramWeb.LifecycleGateChannelTest do
                  EngramWeb.SyncChannel,
                  "sync:#{user.id}:#{vault.id}"
                )
+    end
+  end
+
+  describe "liveness (the half that decides when deleted_at gets set)" do
+    # `EngramWeb.Plugs.BumpActivity` stamps `usage_meters.last_active_at` and
+    # runs ONLY on `:authed_api`. `InactivityCleanup.sweep_soft_delete/0`
+    # soft-deletes Free accounts whose stamp has aged past the window.
+    #
+    # So a plugin user who syncs daily over CRDT and rarely touches REST ages
+    # into that sweep while in constant active use. Before the lifecycle gate
+    # that was invisible — sync kept working. WITH the gate it becomes a
+    # permanent `account_deleted` refusal on a live account whose Qdrant points
+    # and S3 attachments the sweep already dropped.
+    #
+    # Porting the enforcement half of the pipeline without the liveness half
+    # is what turns a latent mis-classification into user-visible data loss.
+    test "a crdt: join stamps last_active_at", %{user: user, vault: vault} do
+      ActivityCache.clear_local()
+
+      assert {:ok, _, joined} = join_crdt(user, vault)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      assert %DateTime{} = UsageMeters.last_active_at(user.id)
+    end
+
+    test "a sync: join stamps last_active_at", %{user: user, vault: vault} do
+      ActivityCache.clear_local()
+
+      assert {:ok, _, _} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+
+      assert %DateTime{} = UsageMeters.last_active_at(user.id)
+    end
+
+    # A refused join is not activity — a suspended or un-onboarded client
+    # retrying forever must not keep its own account looking alive.
+    test "a REFUSED join does not stamp", %{user: user, vault: vault} do
+      ActivityCache.clear_local()
+      user = mark!(user, :suspended_at)
+
+      assert {:error, %{reason: "account_suspended"}} = join_crdt(user, vault)
+      assert is_nil(UsageMeters.last_active_at(user.id))
     end
   end
 

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -319,67 +319,6 @@ defmodule EngramWeb.LifecycleGateChannelTest do
     end
   end
 
-  # A non-binary `b64` reaches `Base.decode64/1` (which is `when is_binary`)
-  # because `decode_frame/1`'s `when byte_size(b64) > @max_b64_bytes` guard
-  # silently fails to match on a non-binary rather than raising there. The
-  # channel dies, every observed room is lost, and the client must rejoin and
-  # re-handshake every note. This file is defensive about exactly this class
-  # elsewhere (`cast_cursor/1`: "rather than raising into a FunctionClauseError
-  # that would crash the whole channel").
-  describe "malformed frames do not kill the channel" do
-    # `assert_reply`, not a monitor + `refute_receive`: the reply contract is
-    # what the client depends on, and a `{:noreply, socket}` regression leaves
-    # a monitor-based test green while every malformed push hangs until its
-    # client-side timeout — the "SPA re-handshook every open note every ~3.5s
-    # forever" shape the ACK comment in crdt_channel.ex records. It is also
-    # deterministic; `refute_receive ..., 300` passes on broken code whenever
-    # the mailbox is behind other work.
-    test "a non-binary b64 replies bad_frame instead of raising", %{user: user, vault: vault} do
-      {:ok, _, joined} = join_crdt(user, vault)
-      Sandbox.allow(Repo, self(), joined.channel_pid)
-
-      ref = push(joined, "crdt_msg", %{"doc_id" => Ecto.UUID.generate(), "b64" => 123})
-
-      assert_reply ref, :error, %{reason: "bad_frame"}
-      assert Process.alive?(joined.channel_pid)
-    end
-
-    # A malformed BATCH entry has all three required keys, so it matches
-    # `prepare_create/4`'s first clause, raises inside `Base.decode64/2`, and
-    # `entry_guard`'s rescue maps it onto `create_failed` — the reason
-    # reserved for TRANSIENT server failure, which the plugin retries. A
-    # permanently-malformed frame therefore gets re-sent forever.
-    # `crdt_channel_test.exs` already pins `bad_frame` for a malformed entry.
-    test "a non-binary b64 in a batch entry is permanent, not retryable", %{
-      user: user,
-      vault: vault
-    } do
-      {:ok, _, joined} = join_crdt(user, vault)
-      Sandbox.allow(Repo, self(), joined.channel_pid)
-
-      ref =
-        push(joined, "crdt_create_batch", %{
-          "creates" => [%{"doc_id" => Ecto.UUID.generate(), "path" => "Bad.md", "b64" => 123}]
-        })
-
-      assert_reply ref, :ok, %{results: [%{status: "error", reason: reason}]}
-      assert reason == "bad_frame", "expected a permanent reason, got #{reason}"
-    end
-
-    test "a non-binary index b64 replies bad_frame instead of raising", %{
-      user: user,
-      vault: vault
-    } do
-      {:ok, _, joined} = join_crdt(user, vault)
-      Sandbox.allow(Repo, self(), joined.channel_pid)
-
-      ref = push(joined, "crdt_index_msg", %{"b64" => %{"not" => "a binary"}})
-
-      assert_reply ref, :error, %{reason: "bad_frame"}
-      assert Process.alive?(joined.channel_pid)
-    end
-  end
-
   # Pins `api_access/2`, which the #1433 revert did NOT touch. These were
   # collateral of deleting the whole entitlement describe block: afterwards
   # the only `api_access_not_available` assertion in the repo was on

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -141,6 +141,34 @@ defmodule EngramWeb.LifecycleGateChannelTest do
     end
   end
 
+  describe "purged accounts (row gone)" do
+    # `Accounts.Lifecycle.hard_delete/2` removes the row outright, so the
+    # re-read returns nil. Falling back to the socket's frozen `current_user`
+    # there is fail-OPEN: that struct predates the deletion and carries no
+    # `deleted_at`, so lifecycle would pass and a purged account with a
+    # still-valid JWT would keep syncing. HTTP fails closed on this path —
+    # `Plugs.Auth` cannot resolve a missing user and 401s — so the socket must
+    # not be more permissive than the pipeline it is mirroring.
+    test "crdt: join is refused once the row is gone", %{user: user, vault: vault} do
+      Repo.delete!(user)
+      GateCache.evict_all()
+
+      assert {:error, %{reason: "account_deleted"}} = join_crdt(user, vault)
+    end
+
+    test "sync: join is refused once the row is gone", %{user: user, vault: vault} do
+      Repo.delete!(user)
+      GateCache.evict_all()
+
+      assert {:error, %{reason: "account_deleted"}} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+    end
+  end
+
   describe "healthy accounts" do
     test "still join normally", %{user: user, vault: vault} do
       assert {:ok, _, joined} = join_crdt(user, vault)

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -240,14 +240,35 @@ defmodule EngramWeb.LifecycleGateChannelTest do
       assert %DateTime{} = UsageMeters.last_active_at(user.id)
     end
 
-    # A refused join is not activity — a suspended or un-onboarded client
+    # An ACCOUNT-refused join is not activity: a suspended or deleted client
     # retrying forever must not keep its own account looking alive.
-    test "a REFUSED join does not stamp", %{user: user, vault: vault} do
+    test "an account-gate refusal does not stamp", %{user: user, vault: vault} do
       ActivityCache.clear_local()
       user = mark!(user, :suspended_at)
 
       assert {:error, %{reason: "account_suspended"}} = join_crdt(user, vault)
       assert is_nil(UsageMeters.last_active_at(user.id))
+    end
+
+    # An ENTITLEMENT refusal is the opposite, and deliberately so: the account
+    # is healthy, only its API plan is not. HTTP stamps here too — BumpActivity
+    # is router.ex:57, RequireApiRpsBudget is :58 — so a Pro user with a PAT
+    # integration who downgrades to Free stays visibly alive on both
+    # transports. Stamping after the entitlement gate instead would let
+    # InactivityCleanup soft-delete an account generating daily traffic.
+    test "an ENTITLEMENT refusal still stamps", %{user: user, vault: vault} do
+      ActivityCache.clear_local()
+      {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "no-entitlement")
+
+      assert {:error, %{reason: "api_access_not_available"}} =
+               subscribe_and_join(
+                 user_socket(user, api_key),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      assert %DateTime{} = UsageMeters.last_active_at(user.id)
     end
   end
 

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -1,0 +1,150 @@
+defmodule EngramWeb.LifecycleGateChannelTest do
+  @moduledoc """
+  #1426 ported ONE of the three vault-pipeline gates to the sockets. These pin
+  the other two: `AccountLifecycle` (410 deleted / 403 suspended) and
+  `RequireActiveSubscription` (402 suspended). Without them an admin could
+  suspend an abusive account, `SessionInvalidator` would kill its sockets, and
+  the still-valid JWT would reconnect seconds later into full read/write CRDT
+  sync while every REST call returned 402/410.
+  """
+  use EngramWeb.ChannelCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Engram.LegalFixtures
+  alias Engram.Onboarding
+  alias Engram.Onboarding.GateCache
+  alias Engram.Repo
+  alias Engram.Vaults
+
+  setup do
+    prev = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+
+    # Seed + accept an explicit version rather than relying on "no versions
+    # exist". VersionCache is node-local ETS and is NOT sandboxed, so a
+    # concurrent case seeding a material version leaks a terms floor in here
+    # and every test fails on missing: ["terms"] instead of the lifecycle
+    # reason it is actually asserting (see #1427).
+    LegalFixtures.insert_version(
+      document: "terms_of_service",
+      version: "2026-05-15",
+      content_hash: "canonical",
+      material: true,
+      effective_date: nil
+    )
+
+    # reset_version_cache/0, not invalidate_all/0 — it adds the :sys.get_state
+    # barrier so the async invalidation cannot land mid-test.
+    LegalFixtures.reset_version_cache()
+    GateCache.evict_all()
+
+    on_exit(fn ->
+      Application.put_env(:engram, :billing_enabled, prev)
+      LegalFixtures.reset_version_cache()
+      GateCache.evict_all()
+    end)
+
+    user = insert_user(onboarding_profile: %{})
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, vault} = Vaults.create_vault(user, %{name: "Lifecycle"})
+
+    # Fully onboarded on purpose: these tests must fail for LIFECYCLE reasons,
+    # not because the onboarding gate happened to catch them first.
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    {:ok, _} = Onboarding.accept_free_tier(user)
+    {:ok, user} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+    GateCache.evict_all()
+
+    {:ok, user: user, vault: vault}
+  end
+
+  defp mark!(user, field) do
+    {:ok, user} =
+      user
+      |> Ecto.Changeset.change([{field, DateTime.utc_now()}])
+      |> Repo.update()
+
+    # The gate caches PASS verdicts; a suspension must not be masked by one.
+    GateCache.evict_all()
+    user
+  end
+
+  defp join_crdt(user, vault) do
+    subscribe_and_join(
+      user_socket(user),
+      EngramWeb.CrdtChannel,
+      "crdt:#{user.id}:#{vault.id}",
+      %{"crdt_proto" => 2}
+    )
+  end
+
+  describe "suspended accounts" do
+    test "crdt: join is refused", %{user: user, vault: vault} do
+      user = mark!(user, :suspended_at)
+      assert {:error, %{reason: "account_suspended"}} = join_crdt(user, vault)
+    end
+
+    test "sync: join is refused", %{user: user, vault: vault} do
+      user = mark!(user, :suspended_at)
+
+      assert {:error, %{reason: "account_suspended"}} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+    end
+
+    # The reconnect path is the whole point: SessionInvalidator kills the live
+    # socket, but the JWT is still valid and the client comes straight back.
+    test "a fresh socket after suspension is still refused", %{user: user, vault: vault} do
+      assert {:ok, _, joined} = join_crdt(user, vault)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      user = mark!(user, :suspended_at)
+      assert {:error, %{reason: "account_suspended"}} = join_crdt(user, vault)
+    end
+
+    # AccountLifecycle exempts /api/billing/* so a suspended user can pay their
+    # way out. `user:` is the socket equivalent — it carries
+    # `subscription_activated`, so gating it would strand them.
+    test "user: stays joinable so they can self-reactivate", %{user: user} do
+      user = mark!(user, :suspended_at)
+
+      assert {:ok, _, _} =
+               subscribe_and_join(user_socket(user), EngramWeb.UserChannel, "user:#{user.id}")
+    end
+  end
+
+  describe "soft-deleted accounts" do
+    test "crdt: join is refused", %{user: user, vault: vault} do
+      user = mark!(user, :deleted_at)
+      assert {:error, %{reason: "account_deleted"}} = join_crdt(user, vault)
+    end
+
+    test "sync: join is refused", %{user: user, vault: vault} do
+      user = mark!(user, :deleted_at)
+
+      assert {:error, %{reason: "account_deleted"}} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+    end
+
+    # Deleted takes precedence over suspended (mirrors the plug).
+    test "deleted outranks suspended", %{user: user, vault: vault} do
+      user = mark!(user, :suspended_at)
+      user = mark!(user, :deleted_at)
+      assert {:error, %{reason: "account_deleted"}} = join_crdt(user, vault)
+    end
+  end
+
+  describe "healthy accounts" do
+    test "still join normally", %{user: user, vault: vault} do
+      assert {:ok, _, joined} = join_crdt(user, vault)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+    end
+  end
+end

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -327,27 +327,103 @@ defmodule EngramWeb.LifecycleGateChannelTest do
   # elsewhere (`cast_cursor/1`: "rather than raising into a FunctionClauseError
   # that would crash the whole channel").
   describe "malformed frames do not kill the channel" do
-    test "a non-binary b64 is rejected, not raised", %{user: user, vault: vault} do
-      {:ok, note} = Engram.Notes.upsert_note(user, vault, %{"path" => "r.md", "content" => "hi"})
+    # `assert_reply`, not a monitor + `refute_receive`: the reply contract is
+    # what the client depends on, and a `{:noreply, socket}` regression leaves
+    # a monitor-based test green while every malformed push hangs until its
+    # client-side timeout — the "SPA re-handshook every open note every ~3.5s
+    # forever" shape the ACK comment in crdt_channel.ex records. It is also
+    # deterministic; `refute_receive ..., 300` passes on broken code whenever
+    # the mailbox is behind other work.
+    test "a non-binary b64 replies bad_frame instead of raising", %{user: user, vault: vault} do
       {:ok, _, joined} = join_crdt(user, vault)
       Sandbox.allow(Repo, self(), joined.channel_pid)
-      ref_mon = Process.monitor(joined.channel_pid)
 
-      push(joined, "crdt_msg", %{"doc_id" => note.id, "b64" => 123})
+      ref = push(joined, "crdt_msg", %{"doc_id" => Ecto.UUID.generate(), "b64" => 123})
 
-      refute_receive {:DOWN, ^ref_mon, :process, _, _}, 300
+      assert_reply ref, :error, %{reason: "bad_frame"}
       assert Process.alive?(joined.channel_pid)
     end
 
-    test "a non-binary index b64 is rejected, not raised", %{user: user, vault: vault} do
+    # A malformed BATCH entry has all three required keys, so it matches
+    # `prepare_create/4`'s first clause, raises inside `Base.decode64/2`, and
+    # `entry_guard`'s rescue maps it onto `create_failed` — the reason
+    # reserved for TRANSIENT server failure, which the plugin retries. A
+    # permanently-malformed frame therefore gets re-sent forever.
+    # `crdt_channel_test.exs` already pins `bad_frame` for a malformed entry.
+    test "a non-binary b64 in a batch entry is permanent, not retryable", %{
+      user: user,
+      vault: vault
+    } do
       {:ok, _, joined} = join_crdt(user, vault)
       Sandbox.allow(Repo, self(), joined.channel_pid)
-      ref_mon = Process.monitor(joined.channel_pid)
 
-      push(joined, "crdt_index_msg", %{"b64" => %{"not" => "a binary"}})
+      ref =
+        push(joined, "crdt_create_batch", %{
+          "creates" => [%{"doc_id" => Ecto.UUID.generate(), "path" => "Bad.md", "b64" => 123}]
+        })
 
-      refute_receive {:DOWN, ^ref_mon, :process, _, _}, 300
+      assert_reply ref, :ok, %{results: [%{status: "error", reason: reason}]}
+      assert reason == "bad_frame", "expected a permanent reason, got #{reason}"
+    end
+
+    test "a non-binary index b64 replies bad_frame instead of raising", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, _, joined} = join_crdt(user, vault)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      ref = push(joined, "crdt_index_msg", %{"b64" => %{"not" => "a binary"}})
+
+      assert_reply ref, :error, %{reason: "bad_frame"}
       assert Process.alive?(joined.channel_pid)
+    end
+  end
+
+  # Pins `api_access/2`, which the #1433 revert did NOT touch. These were
+  # collateral of deleting the whole entitlement describe block: afterwards
+  # the only `api_access_not_available` assertion in the repo was on
+  # CrdtChannel, leaving the SyncChannel gate and the JWT exemption unpinned
+  # — and `sync:` grants Presence + note_changed fan-out.
+  describe "API-key join entitlement (#1433 join half, NOT reverted)" do
+    setup %{user: user} do
+      {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "join-gate")
+      {:ok, api_key: api_key}
+    end
+
+    test "a Free PAT cannot join sync:", %{user: user, vault: vault, api_key: api_key} do
+      assert {:error, %{reason: "api_access_not_available"}} =
+               subscribe_and_join(
+                 user_socket(user, api_key),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+    end
+
+    test "a Free PAT cannot join crdt:", %{user: user, vault: vault, api_key: api_key} do
+      assert {:error, %{reason: "api_access_not_available"}} =
+               subscribe_and_join(
+                 user_socket(user, api_key),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+    end
+
+    # The exemption keys on the key being non-nil, NOT on the assign existing:
+    # `UserSocket.accept/4` ALWAYS sets :current_api_key (nil for JWT), so a
+    # literal port of the plug's `not is_map_key/2` guard would gate every web
+    # and plugin user on the platform.
+    test "the SAME user on a JWT socket joins both channels", %{user: user, vault: vault} do
+      assert {:ok, _, joined} = join_crdt(user, vault)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      assert {:ok, _, _} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
     end
   end
 

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -303,9 +303,10 @@ defmodule EngramWeb.LifecycleGateChannelTest do
   # able to write through the socket instead. Reads stay open: the plug
   # exempts GET, and existing tests assert Free API keys can join and read.
   describe "API-key entitlements (#1433)" do
-    setup %{user: user} do
+    setup %{user: user, vault: vault} do
       {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "entitlement-gate")
-      {:ok, api_key: api_key}
+      {:ok, note} = Engram.Notes.upsert_note(user, vault, %{"path" => "r.md", "content" => "hi"})
+      {:ok, api_key: api_key, note: note}
     end
 
     # Free's `api_rps_cap` is 0 and `RequireApiRpsBudget` has no GET
@@ -346,7 +347,6 @@ defmodule EngramWeb.LifecycleGateChannelTest do
     } do
       # rps only — `api_write_enabled` stays at the Free default (false).
       grant_api_read!(user)
-      Engram.Billing.OverrideCache.clear_local()
 
       assert {:ok, _, joined} =
                subscribe_and_join(
@@ -360,6 +360,37 @@ defmodule EngramWeb.LifecycleGateChannelTest do
 
       ref = push(joined, "crdt_create", %{"doc_id" => Ecto.UUID.generate(), "path" => "n.md"})
       assert_reply ref, :error, %{reason: "api_write_not_available"}
+    end
+
+    # `crdt_msg` is not "the write frame" — it carries the Yjs sync handshake
+    # too. SyncStep1 (`<<0, 0, _>>`) is a pure state-vector REQUEST: it is how
+    # a client asks for doc state. Blocking it means a read-entitled key joins
+    # successfully and then receives nothing, forever — no room is ever
+    # observed, so fan-out never fires either. The plug this mirrors opens
+    # with `when m in ["GET", "HEAD"], do: conn` under "Reads are never
+    # gated"; this is that clause.
+    test "a write-blocked PAT can still send SyncStep1 and read", %{
+      user: user,
+      vault: vault,
+      api_key: api_key,
+      note: note
+    } do
+      grant_api_read!(user)
+
+      {:ok, _, joined} =
+        subscribe_and_join(
+          user_socket(user, api_key),
+          EngramWeb.CrdtChannel,
+          "crdt:#{user.id}:#{vault.id}",
+          %{"crdt_proto" => 2}
+        )
+
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      # SyncStep1 for an empty local state = read the whole doc.
+      step1 = Base.encode64(<<0, 0, 1, 0>>)
+      ref = push(joined, "crdt_msg", %{"doc_id" => note.id, "b64" => step1})
+      assert_reply ref, :ok, %{}
     end
 
     test "a JWT socket writes normally", %{user: user, vault: vault} do
@@ -377,7 +408,6 @@ defmodule EngramWeb.LifecycleGateChannelTest do
       api_key: api_key
     } do
       grant_api_write!(user)
-      Engram.Billing.OverrideCache.clear_local()
 
       assert {:ok, _, joined} =
                subscribe_and_join(

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -319,130 +319,35 @@ defmodule EngramWeb.LifecycleGateChannelTest do
     end
   end
 
-  # Pricing v2 §G write half (#1433). Free's `api_write_enabled` is false, so
-  # an API-key caller is 402'd on every non-GET REST route — and must not be
-  # able to write through the socket instead. Reads stay open: the plug
-  # exempts GET, and existing tests assert Free API keys can join and read.
-  describe "API-key entitlements (#1433)" do
-    setup %{user: user, vault: vault} do
-      {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "entitlement-gate")
+  # A non-binary `b64` reaches `Base.decode64/1` (which is `when is_binary`)
+  # because `decode_frame/1`'s `when byte_size(b64) > @max_b64_bytes` guard
+  # silently fails to match on a non-binary rather than raising there. The
+  # channel dies, every observed room is lost, and the client must rejoin and
+  # re-handshake every note. This file is defensive about exactly this class
+  # elsewhere (`cast_cursor/1`: "rather than raising into a FunctionClauseError
+  # that would crash the whole channel").
+  describe "malformed frames do not kill the channel" do
+    test "a non-binary b64 is rejected, not raised", %{user: user, vault: vault} do
       {:ok, note} = Engram.Notes.upsert_note(user, vault, %{"path" => "r.md", "content" => "hi"})
-      {:ok, api_key: api_key, note: note}
-    end
-
-    # Free's `api_rps_cap` is 0 and `RequireApiRpsBudget` has no GET
-    # exemption, so a Free key cannot make a single REST call. It must not be
-    # able to open a socket and read the whole vault instead.
-    test "a Free PAT cannot join at all", %{user: user, vault: vault, api_key: api_key} do
-      assert {:error, %{reason: "api_access_not_available"}} =
-               subscribe_and_join(
-                 user_socket(user, api_key),
-                 EngramWeb.CrdtChannel,
-                 "crdt:#{user.id}:#{vault.id}",
-                 %{"crdt_proto" => 2}
-               )
-    end
-
-    test "a Free PAT cannot join sync: either", %{user: user, vault: vault, api_key: api_key} do
-      assert {:error, %{reason: "api_access_not_available"}} =
-               subscribe_and_join(
-                 user_socket(user, api_key),
-                 EngramWeb.SyncChannel,
-                 "sync:#{user.id}:#{vault.id}"
-               )
-    end
-
-    # The exemption must key on the api_key being non-nil, NOT on the assign
-    # existing: `UserSocket.accept/4` ALWAYS sets :current_api_key (nil for
-    # JWT), so a literal port of the plug's `not is_map_key/2` guard would
-    # gate every web and plugin user on the platform.
-    test "the SAME user on a JWT socket is unaffected", %{user: user, vault: vault} do
-      assert {:ok, _, joined} = join_crdt(user, vault)
+      {:ok, _, joined} = join_crdt(user, vault)
       Sandbox.allow(Repo, self(), joined.channel_pid)
+      ref_mon = Process.monitor(joined.channel_pid)
+
+      push(joined, "crdt_msg", %{"doc_id" => note.id, "b64" => 123})
+
+      refute_receive {:DOWN, ^ref_mon, :process, _, _}, 300
+      assert Process.alive?(joined.channel_pid)
     end
 
-    test "a read-entitled PAT can join but still cannot write", %{
-      user: user,
-      vault: vault,
-      api_key: api_key
-    } do
-      # rps only — `api_write_enabled` stays at the Free default (false).
-      grant_api_read!(user)
-
-      assert {:ok, _, joined} =
-               subscribe_and_join(
-                 user_socket(user, api_key),
-                 EngramWeb.CrdtChannel,
-                 "crdt:#{user.id}:#{vault.id}",
-                 %{"crdt_proto" => 2}
-               )
-
+    test "a non-binary index b64 is rejected, not raised", %{user: user, vault: vault} do
+      {:ok, _, joined} = join_crdt(user, vault)
       Sandbox.allow(Repo, self(), joined.channel_pid)
+      ref_mon = Process.monitor(joined.channel_pid)
 
-      ref = push(joined, "crdt_create", %{"doc_id" => Ecto.UUID.generate(), "path" => "n.md"})
-      assert_reply ref, :error, %{reason: "api_write_not_available"}
-    end
+      push(joined, "crdt_index_msg", %{"b64" => %{"not" => "a binary"}})
 
-    # `crdt_msg` is not "the write frame" — it carries the Yjs sync handshake
-    # too. SyncStep1 (`<<0, 0, _>>`) is a pure state-vector REQUEST: it is how
-    # a client asks for doc state. Blocking it means a read-entitled key joins
-    # successfully and then receives nothing, forever — no room is ever
-    # observed, so fan-out never fires either. The plug this mirrors opens
-    # with `when m in ["GET", "HEAD"], do: conn` under "Reads are never
-    # gated"; this is that clause.
-    test "a write-blocked PAT can still send SyncStep1 and read", %{
-      user: user,
-      vault: vault,
-      api_key: api_key,
-      note: note
-    } do
-      grant_api_read!(user)
-
-      {:ok, _, joined} =
-        subscribe_and_join(
-          user_socket(user, api_key),
-          EngramWeb.CrdtChannel,
-          "crdt:#{user.id}:#{vault.id}",
-          %{"crdt_proto" => 2}
-        )
-
-      Sandbox.allow(Repo, self(), joined.channel_pid)
-
-      # SyncStep1 for an empty local state = read the whole doc.
-      step1 = Base.encode64(<<0, 0, 1, 0>>)
-      ref = push(joined, "crdt_msg", %{"doc_id" => note.id, "b64" => step1})
-      assert_reply ref, :ok, %{}
-    end
-
-    test "a JWT socket writes normally", %{user: user, vault: vault} do
-      assert {:ok, _, joined} = join_crdt(user, vault)
-      Sandbox.allow(Repo, self(), joined.channel_pid)
-
-      id = Ecto.UUID.generate()
-      ref = push(joined, "crdt_create", %{"doc_id" => id, "path" => "n.md"})
-      assert_reply ref, :ok, %{doc_id: ^id}
-    end
-
-    test "a PAT with api_write_enabled granted can write", %{
-      user: user,
-      vault: vault,
-      api_key: api_key
-    } do
-      grant_api_write!(user)
-
-      assert {:ok, _, joined} =
-               subscribe_and_join(
-                 user_socket(user, api_key),
-                 EngramWeb.CrdtChannel,
-                 "crdt:#{user.id}:#{vault.id}",
-                 %{"crdt_proto" => 2}
-               )
-
-      Sandbox.allow(Repo, self(), joined.channel_pid)
-
-      id = Ecto.UUID.generate()
-      ref = push(joined, "crdt_create", %{"doc_id" => id, "path" => "n2.md"})
-      assert_reply ref, :ok, %{doc_id: ^id}
+      refute_receive {:DOWN, ^ref_mon, :process, _, _}, 300
+      assert Process.alive?(joined.channel_pid)
     end
   end
 

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -130,6 +130,26 @@ defmodule EngramWeb.LifecycleGateChannelTest do
     end
   end
 
+  # The `user:` carve-out is SUSPENSION-specific: it mirrors AccountLifecycle
+  # allowlisting `/api/billing/*` so a suspended user can pay their way out.
+  # Deletion has no such exemption — the deleted clause runs ahead of the
+  # allowlist and HTTP is terminal, "410 on every endpoint, no exemptions".
+  describe "user: channel vs deletion (#1435)" do
+    test "a deleted account cannot join user:", %{user: user} do
+      _deleted = mark!(user, :deleted_at)
+
+      assert {:error, %{reason: "account_deleted"}} =
+               subscribe_and_join(user_socket(user), EngramWeb.UserChannel, "user:#{user.id}")
+    end
+
+    test "an un-onboarded account CAN still join user: — the wizard needs it", %{vault: _v} do
+      fresh = insert_user(onboarding_profile: %{})
+
+      assert {:ok, _, _} =
+               subscribe_and_join(user_socket(fresh), EngramWeb.UserChannel, "user:#{fresh.id}")
+    end
+  end
+
   describe "soft-deleted accounts" do
     test "crdt: join is refused", %{user: user, vault: vault} do
       # `user` stays the PRE-deletion struct on purpose — see the suspension
@@ -228,6 +248,115 @@ defmodule EngramWeb.LifecycleGateChannelTest do
 
       assert {:error, %{reason: "account_suspended"}} = join_crdt(user, vault)
       assert is_nil(UsageMeters.last_active_at(user.id))
+    end
+  end
+
+  # `RotationLockCheck` runs on :authed_api and its moduledoc is explicit that
+  # "Read AND write paths block" — rotated rows reference a dek_version whose
+  # master mapping has not flipped yet, so any decrypt with the old DEK fails
+  # until the rotation completes. CrdtChannel open-coded a check; SyncChannel
+  # had none, so a mid-rotation user was blocked on every HTTP route and on
+  # `crdt:` but received Presence + note_changed on `sync:` for the whole
+  # rotation window. (#1434)
+  describe "DEK rotation (#1434)" do
+    setup %{user: user} do
+      {:ok, _} =
+        user
+        |> Ecto.Changeset.change(dek_rotation_locked_at: DateTime.utc_now())
+        |> Repo.update()
+
+      :ok
+    end
+
+    test "sync: join is refused mid-rotation", %{user: user, vault: vault} do
+      assert {:error, %{reason: "rotation_in_progress"}} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+    end
+
+    test "crdt: still reports rotation_in_progress, not a lifecycle reason", %{
+      user: user,
+      vault: vault
+    } do
+      assert {:error, %{reason: "rotation_in_progress"}} = join_crdt(user, vault)
+    end
+
+    # Rotation must outrank lifecycle: it is transient and self-clears, and
+    # the client backs off on it. Reporting account_suspended for a suspended
+    # user mid-rotation would be correct too, but the ordering has to be
+    # DECIDED rather than incidental — HTTP runs AccountDeleted (52) before
+    # RotationLockCheck (54), so deleted wins there and must here.
+    test "a DELETED account mid-rotation still reports account_deleted", %{
+      user: user,
+      vault: vault
+    } do
+      _deleted = mark!(user, :deleted_at)
+      assert {:error, %{reason: "account_deleted"}} = join_crdt(user, vault)
+    end
+  end
+
+  # Pricing v2 §G write half (#1433). Free's `api_write_enabled` is false, so
+  # an API-key caller is 402'd on every non-GET REST route — and must not be
+  # able to write through the socket instead. Reads stay open: the plug
+  # exempts GET, and existing tests assert Free API keys can join and read.
+  describe "API-key write entitlement (#1433)" do
+    setup %{user: user} do
+      {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "write-gate")
+      {:ok, api_key: api_key}
+    end
+
+    test "a Free PAT can join and read but cannot write", %{
+      user: user,
+      vault: vault,
+      api_key: api_key
+    } do
+      assert {:ok, _, joined} =
+               subscribe_and_join(
+                 user_socket(user, api_key),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      ref = push(joined, "crdt_create", %{"doc_id" => Ecto.UUID.generate(), "path" => "n.md"})
+      assert_reply ref, :error, %{reason: "api_write_not_available"}
+    end
+
+    test "the SAME user on a JWT socket writes normally", %{user: user, vault: vault} do
+      assert {:ok, _, joined} = join_crdt(user, vault)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      id = Ecto.UUID.generate()
+      ref = push(joined, "crdt_create", %{"doc_id" => id, "path" => "n.md"})
+      assert_reply ref, :ok, %{doc_id: ^id}
+    end
+
+    test "a PAT with api_write_enabled granted can write", %{
+      user: user,
+      vault: vault,
+      api_key: api_key
+    } do
+      insert(:user_limit_override, user: user, key: "api_write_enabled", value: %{"v" => true})
+      Engram.Billing.OverrideCache.clear_local()
+
+      assert {:ok, _, joined} =
+               subscribe_and_join(
+                 user_socket(user, api_key),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+
+      id = Ecto.UUID.generate()
+      ref = push(joined, "crdt_create", %{"doc_id" => id, "path" => "n2.md"})
+      assert_reply ref, :ok, %{doc_id: ^id}
     end
   end
 

--- a/test/engram_web/lifecycle_gate_channel_test.exs
+++ b/test/engram_web/lifecycle_gate_channel_test.exs
@@ -302,17 +302,52 @@ defmodule EngramWeb.LifecycleGateChannelTest do
   # an API-key caller is 402'd on every non-GET REST route — and must not be
   # able to write through the socket instead. Reads stay open: the plug
   # exempts GET, and existing tests assert Free API keys can join and read.
-  describe "API-key write entitlement (#1433)" do
+  describe "API-key entitlements (#1433)" do
     setup %{user: user} do
-      {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "write-gate")
+      {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "entitlement-gate")
       {:ok, api_key: api_key}
     end
 
-    test "a Free PAT can join and read but cannot write", %{
+    # Free's `api_rps_cap` is 0 and `RequireApiRpsBudget` has no GET
+    # exemption, so a Free key cannot make a single REST call. It must not be
+    # able to open a socket and read the whole vault instead.
+    test "a Free PAT cannot join at all", %{user: user, vault: vault, api_key: api_key} do
+      assert {:error, %{reason: "api_access_not_available"}} =
+               subscribe_and_join(
+                 user_socket(user, api_key),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+    end
+
+    test "a Free PAT cannot join sync: either", %{user: user, vault: vault, api_key: api_key} do
+      assert {:error, %{reason: "api_access_not_available"}} =
+               subscribe_and_join(
+                 user_socket(user, api_key),
+                 EngramWeb.SyncChannel,
+                 "sync:#{user.id}:#{vault.id}"
+               )
+    end
+
+    # The exemption must key on the api_key being non-nil, NOT on the assign
+    # existing: `UserSocket.accept/4` ALWAYS sets :current_api_key (nil for
+    # JWT), so a literal port of the plug's `not is_map_key/2` guard would
+    # gate every web and plugin user on the platform.
+    test "the SAME user on a JWT socket is unaffected", %{user: user, vault: vault} do
+      assert {:ok, _, joined} = join_crdt(user, vault)
+      Sandbox.allow(Repo, self(), joined.channel_pid)
+    end
+
+    test "a read-entitled PAT can join but still cannot write", %{
       user: user,
       vault: vault,
       api_key: api_key
     } do
+      # rps only — `api_write_enabled` stays at the Free default (false).
+      grant_api_read!(user)
+      Engram.Billing.OverrideCache.clear_local()
+
       assert {:ok, _, joined} =
                subscribe_and_join(
                  user_socket(user, api_key),
@@ -327,7 +362,7 @@ defmodule EngramWeb.LifecycleGateChannelTest do
       assert_reply ref, :error, %{reason: "api_write_not_available"}
     end
 
-    test "the SAME user on a JWT socket writes normally", %{user: user, vault: vault} do
+    test "a JWT socket writes normally", %{user: user, vault: vault} do
       assert {:ok, _, joined} = join_crdt(user, vault)
       Sandbox.allow(Repo, self(), joined.channel_pid)
 
@@ -341,7 +376,7 @@ defmodule EngramWeb.LifecycleGateChannelTest do
       vault: vault,
       api_key: api_key
     } do
-      insert(:user_limit_override, user: user, key: "api_write_enabled", value: %{"v" => true})
+      grant_api_write!(user)
       Engram.Billing.OverrideCache.clear_local()
 
       assert {:ok, _, joined} =

--- a/test/engram_web/onboarding_gate_channel_test.exs
+++ b/test/engram_web/onboarding_gate_channel_test.exs
@@ -157,7 +157,7 @@ defmodule EngramWeb.OnboardingGateChannelTest do
     end
 
     # T3.7: a user mid-DEK-rotation must hear rotation_in_progress. Gating
-    # ahead of RotationGate.check/1 would have swallowed it.
+    # ahead of the rotation check (now in ChannelGate) would have swallowed it.
     test "rotation_in_progress outranks onboarding_required", %{user: user, vault: vault} do
       {:ok, _} =
         user

--- a/test/support/api_entitlement_helpers.ex
+++ b/test/support/api_entitlement_helpers.ex
@@ -1,0 +1,48 @@
+defmodule Engram.ApiEntitlementHelpers do
+  @moduledoc """
+  Grants paid-tier API entitlements via `user_limit_overrides`.
+
+  Pricing v2 §G gives Free `api_write_enabled: false` and `api_rps_cap: 0`,
+  and `RequireApiRpsBudget` has no GET exemption — so a Free API key cannot
+  make a single REST call, and (since #1433) cannot open a `sync:`/`crdt:`
+  socket either.
+
+  That means **any test that mints an API key to exercise something else** —
+  vault restriction, join tracing, channel logging — has to represent a paid
+  user, or it fails on entitlement before reaching what it is actually
+  testing. Shared by `ConnCase` and `ChannelCase` so the two cannot drift.
+
+  JWT-authed sockets and requests are exempt from both gates, so tests that
+  do not mint a key need none of this.
+  """
+
+  @doc """
+  Grants `api_write_enabled=true` and a generous `api_rps_cap=1000`.
+  Idempotent. Returns `user` for pipe-friendliness.
+  """
+  def grant_api_write!(%Engram.Accounts.User{} = user) do
+    upsert_override!(user, "api_write_enabled", true)
+    upsert_override!(user, "api_rps_cap", 1_000)
+    user
+  end
+
+  @doc """
+  Grants read-level API access only (`api_rps_cap`), leaving
+  `api_write_enabled` at the tier default. Use when the test needs an API key
+  to CONNECT but is asserting that writes are refused.
+  """
+  def grant_api_read!(%Engram.Accounts.User{} = user) do
+    upsert_override!(user, "api_rps_cap", 1_000)
+    user
+  end
+
+  defp upsert_override!(user, key, value) do
+    case Engram.Repo.get_by(Engram.Billing.UserLimitOverride, user_id: user.id, key: key) do
+      nil ->
+        Engram.Factory.insert(:user_limit_override, user: user, key: key, value: %{"v" => value})
+
+      _existing ->
+        :noop
+    end
+  end
+end

--- a/test/support/api_entitlement_helpers.ex
+++ b/test/support/api_entitlement_helpers.ex
@@ -26,16 +26,6 @@ defmodule Engram.ApiEntitlementHelpers do
     user
   end
 
-  @doc """
-  Grants read-level API access only (`api_rps_cap`), leaving
-  `api_write_enabled` at the tier default. Use when the test needs an API key
-  to CONNECT but is asserting that writes are refused.
-  """
-  def grant_api_read!(%Engram.Accounts.User{} = user) do
-    upsert_override!(user, "api_rps_cap", 1_000)
-    user
-  end
-
   # Writes the row, then evicts `Engram.Billing.OverrideCache` for this user.
   #
   # The eviction is NOT optional. That cache is node-global ETS with a 60s TTL

--- a/test/support/api_entitlement_helpers.ex
+++ b/test/support/api_entitlement_helpers.ex
@@ -36,13 +36,32 @@ defmodule Engram.ApiEntitlementHelpers do
     user
   end
 
+  # Writes the row, then evicts `Engram.Billing.OverrideCache` for this user.
+  #
+  # The eviction is NOT optional. That cache is node-global ETS with a 60s TTL
+  # and it caches MISSES as well as hits; the pg NOTIFY trigger that normally
+  # evicts it can never fire under the Ecto sandbox, because `pg_notify` only
+  # delivers on COMMIT and the sandbox always rolls back. So if anything in a
+  # setup resolves a limit for this user BEFORE the grant, the miss is cached
+  # and the grant has no effect for 60s — presenting as an order-dependent
+  # flake in a suite where the failure ("api_access_not_available") has
+  # nothing to do with the assertion.
+  #
+  # `evict/1` is per-user; `clear_local/0` is a node-global wipe and is wrong
+  # in an async suite.
   defp upsert_override!(user, key, value) do
     case Engram.Repo.get_by(Engram.Billing.UserLimitOverride, user_id: user.id, key: key) do
       nil ->
         Engram.Factory.insert(:user_limit_override, user: user, key: key, value: %{"v" => value})
 
-      _existing ->
-        :noop
+      existing ->
+        # Was `:noop`, which quietly broke the documented idempotency: a second
+        # grant with a different value left the first one in place.
+        existing
+        |> Ecto.Changeset.change(value: %{"v" => value})
+        |> Engram.Repo.update!()
     end
+
+    Engram.Billing.OverrideCache.evict(user.id)
   end
 end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -9,6 +9,7 @@ defmodule EngramWeb.ChannelCase do
   using do
     quote do
       import Phoenix.ChannelTest
+      import Engram.ApiEntitlementHelpers
       import Engram.Factory
 
       @endpoint EngramWeb.Endpoint

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -37,21 +37,8 @@ defmodule EngramWeb.ConnCase do
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 
-  @doc """
-  Grants the user paid-tier API access via `user_limit_overrides` rows:
-  `api_write_enabled=true` and a generous `api_rps_cap=1000`. Use in
-  setup blocks for tests that exercise API-key write paths — pricing v2
-  §G gates non-GET requests on the write flag AND every API-key request
-  on the RPS cap when authed via API key, so any test minting a key for
-  controller use must represent a paid user.
-
-  Returns `user` unchanged for pipe-friendliness.
-  """
-  def grant_api_write!(%Engram.Accounts.User{} = user) do
-    upsert_override!(user, "api_write_enabled", true)
-    upsert_override!(user, "api_rps_cap", 1_000)
-    user
-  end
+  defdelegate grant_api_write!(user), to: Engram.ApiEntitlementHelpers
+  defdelegate grant_api_read!(user), to: Engram.ApiEntitlementHelpers
 
   @doc """
   Test `setup` callback that builds an API-key-authenticated connection:
@@ -94,17 +81,4 @@ defmodule EngramWeb.ConnCase do
 
   # Idempotent insert — the helper may be called multiple times against the
   # same user when a test exercises more than one `create_api_key` flow.
-  defp upsert_override!(user, key, value) do
-    case Engram.Repo.get_by(Engram.Billing.UserLimitOverride, user_id: user.id, key: key) do
-      nil ->
-        Engram.Factory.insert(:user_limit_override,
-          user: user,
-          key: key,
-          value: %{"v" => value}
-        )
-
-      _existing ->
-        :noop
-    end
-  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -38,7 +38,6 @@ defmodule EngramWeb.ConnCase do
   end
 
   defdelegate grant_api_write!(user), to: Engram.ApiEntitlementHelpers
-  defdelegate grant_api_read!(user), to: Engram.ApiEntitlementHelpers
 
   @doc """
   Test `setup` callback that builds an API-key-authenticated connection:


### PR DESCRIPTION
Closes #1429. Follow-on to #1426.

## The hole

#1426 ported **one** of the vault pipeline's three access gates to the sockets:

| `router.ex:52-56` | HTTP | Socket before this PR |
|---|---|---|
| `AccountLifecycle` | 410 `account_deleted` / 403 `account_suspended` | ❌ |
| `RequireOnboarding` | 403 `onboarding_required` | ✅ #1426 |
| `RequireActiveSubscription` | 402 `account_suspended` | ❌ |

`join/3` asked `Onboarding.gate/1` and nothing else. That function never reads `suspended_at`/`deleted_at`, and `Auth.TokenResolver.resolve/1` → `Accounts.get_user/1` has no lifecycle filter.

**Failure scenario:** an admin suspends an abusive account. `SessionInvalidator` kills the live sockets. The JWT is still valid, the client reconnects seconds later, and CRDT read/write sync resumes — while every REST call returns 402/410.

## The fix

Rather than bolt a second inline check into both channels, the access rules now live in **`EngramWeb.ChannelGate`**, which both `join/3`s call.

#1426's review flagged the copy-pasted guard as *"the same omission class that caused the bug"* — a rule living in one transport's plumbing. `ChannelGate` gives it one home, and its moduledoc says the thing that was never written down: **adding a plug to the vault pipeline does not add it to sockets.**

`RequireActiveSubscription` collapses into the suspended check — since 2026-06-07 it passes every tier (Free counts as active) and only rejects `suspended_at`.

### Freshness

Lifecycle is read from a **fresh row on every join** — never from the socket's `current_user` (frozen at `connect/3`) and never through `GateCache`, whose 60s PASS cache would leave a suspended account syncing for up to a minute per node. `Onboarding.gate/2` grew a `fresh: true` option so the shared read isn't paid twice.

### `user:` stays ungated — now for a second reason

`AccountLifecycle` exempts `/api/billing/*` so a suspended user can pay their way out. `user:` carries `subscription_activated`, so it's the socket equivalent of that exemption — gating it strands exactly the users trying to fix their state. It carries no note content (ids, names, plan metadata only). There's a test pinning it joinable while suspended.

## Verification

- New `test/engram_web/lifecycle_gate_channel_test.exs` — 8 tests: suspended and deleted refused on both channels with distinct reasons, deleted outranks suspended, the **reconnect-after-suspension** path (the actual attack), `user:` still joinable, healthy accounts unaffected.
- **Mutation-checked:** deleting the two `lifecycle/1` clauses turns 6 of the 8 red. The tests can fail.
- Setup seeds and accepts an explicit terms version rather than relying on "no versions exist", and uses `LegalFixtures.reset_version_cache/0` (which has the `:sys.get_state` barrier) — `VersionCache` is node-local ETS and isn't sandboxed, so a concurrent case leaks a terms floor and every assertion fails on `missing: ["terms"]` instead of the lifecycle reason. See #1427.
- 392 targeted tests green; `mix format`, `mix credo --strict`, `mix dialyzer` all exit 0.

## Still open after this

- #1430 — the SPA silently drops creates/deletes when a join is permanently refused. **This PR makes that reachable for suspended users**, so it moves up.
- Engram-obsidian#455 — the plugin degrades to a dead-and-gated REST path with no recovery.
- #1427 — `billing_enabled` is clobbered false suite-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DhZTrvajwXLrxpSkq1XAp
