### PR TITLE
refactor(vaults): one path to create a vault

### DIFF
--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -1,5 +1,5 @@
 Config.CSP: Missing Content-Security-Policy,lib/engram_web/router.ex:173,43202C
-Config.CSRFRoute: CSRF via Action Reuse,lib/engram_web/router.ex:586,342E9AB
+Config.CSRFRoute: CSRF via Action Reuse,lib/engram_web/router.ex:585,41B0634
 Config.CSWH: Cross-Site Websocket Hijacking,lib/engram_web/endpoint.ex:9,68D560D
 Config.CSWH: Cross-Site Websocket Hijacking,lib/engram_web/endpoint.ex:30,6F8AC00
 Config.CSWH: Cross-Site Websocket Hijacking,lib/engram_web/endpoint.ex:45,6EA19F5

--- a/e2e/helpers/api.py
+++ b/e2e/helpers/api.py
@@ -272,15 +272,8 @@ class ApiClient:
         self._log_error_response(resp)
         return resp.json() if resp.status_code in (200, 201) else {}, resp.status_code
 
-    def create_vault(self, name: str) -> tuple[dict, int]:
-        """POST /vaults. Returns (response_json, status_code)."""
-        resp = self.session.post(
-            f"{self.base_url}/vaults",
-            json={"name": name},
-            timeout=10,
-        )
-        self._log_error_response(resp)
-        return resp.json() if resp.status_code in (200, 201) else {}, resp.status_code
+    # `create_vault` (POST /vaults) is gone — it made a new vault per call, so a
+    # retry produced a duplicate. Use `register_vault` with a stable client_id.
 
     def get_vault(self, vault_id: str) -> tuple[dict | None, int]:
         """GET /vaults/:id. Returns (vault_dict or None, status_code)."""

--- a/e2e/tests/api_only/conftest.py
+++ b/e2e/tests/api_only/conftest.py
@@ -13,8 +13,8 @@ import pytest
 @pytest.fixture(scope="session", autouse=True)
 def ensure_vaults(api_sync, api_iso):
     """Create default vaults so vault-scoped endpoints don't 404."""
-    api_sync.create_vault("e2e-api-only")
-    api_iso.create_vault("e2e-api-only-iso")
+    api_sync.register_vault("e2e-api-only", "e2e-api-only-client")
+    api_iso.register_vault("e2e-api-only-iso", "e2e-api-only-iso-client")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/e2e/tests/api_only/test_71_connections.py
+++ b/e2e/tests/api_only/test_71_connections.py
@@ -531,19 +531,20 @@ def device_token_poll(device_code: str, *, max_attempts: int = 10) -> dict:
 
 
 def create_vault(jwt_token: str, name: str) -> int:
-    """POST /api/vaults — create a vault. Returns vault_id (int).
+    """POST /api/vaults/register: create a vault. Returns vault_id.
 
-    The controller wraps the row under a "vault" key — see
-    EngramWeb.VaultsController.create/2 returning %{vault: vault_json(...)}.
+    The only create endpoint, idempotent by client_id, and it responds with
+    the vault flat (no "vault" wrapper). The name is already unique per call
+    here, so it doubles as the idempotency key.
     """
     resp = requests.post(
-        f"{API_URL}/vaults",
-        json={"name": name},
+        f"{API_URL}/vaults/register",
+        json={"name": name, "client_id": name},
         headers={"Authorization": f"Bearer {jwt_token}"},
         timeout=10,
     )
     resp.raise_for_status()
-    return resp.json()["vault"]["id"]
+    return resp.json()["id"]
 
 
 def revoke_device(jwt_token: str, family_id: str) -> int:

--- a/e2e/tests/api_only/test_72_free_signup_to_vault.py
+++ b/e2e/tests/api_only/test_72_free_signup_to_vault.py
@@ -10,7 +10,7 @@ Covers the happy path a Free user walks from "just signed up" to
      (Phase 2 endpoint, gates RequireOnboarding's :subscription_ok lane
      when SaaS billing_enabled is true). Asserted both first-call (200
      with next_step shape) and idempotent second-call.
-  3. POST /api/vaults — create the user's first (and only, on Free) vault.
+  3. POST /api/vaults/register — create the user's first (and only, on Free) vault.
   4. POST /api/notes — create hello.md under that vault.
   5. GET /api/sync/manifest — verify the note appears in the manifest, and
      that the retired GET /api/notes/changes feed answers 410 Gone.
@@ -109,12 +109,12 @@ def test_free_signup_to_first_note():
     )
 
     # ── 3. Create first vault ────────────────────────────────────────────
-    vault_resp, vault_status = api.create_vault(f"hello-vault-{_ts()}")
+    vault_resp, vault_status = api.register_vault(f"hello-vault-{_ts()}", f"hello-client-{_ts()}")
     assert vault_status in (200, 201), (
-        f"POST /api/vaults should succeed for Free user with 0 vaults; "
+        f"POST /api/vaults/register should succeed for Free user with 0 vaults; "
         f"got {vault_status}: {vault_resp}"
     )
-    vault_id = (vault_resp.get("vault") or {}).get("id")
+    vault_id = vault_resp.get("id")
     assert vault_id, f"vault response missing id: {vault_resp}"
 
     api_v = api.with_vault(vault_id)

--- a/e2e/tests/api_only/test_73_free_attachment_402.py
+++ b/e2e/tests/api_only/test_73_free_attachment_402.py
@@ -93,11 +93,11 @@ def test_free_attachment_blocked_note_passes():
     )
 
     # Create the user's one Free-tier vault.
-    vault_resp, vault_status = api.create_vault(f"att-vault-{_ts()}")
+    vault_resp, vault_status = api.register_vault(f"att-vault-{_ts()}", f"att-client-{_ts()}")
     assert vault_status in (200, 201), (
         f"vault create should succeed; got {vault_status}: {vault_resp}"
     )
-    vault_id = (vault_resp.get("vault") or {}).get("id")
+    vault_id = vault_resp.get("id")
     assert vault_id, f"vault response missing id: {vault_resp}"
     api_v = api.with_vault(vault_id)
 

--- a/e2e/tests/api_only/test_74_cancel_to_free_overlimit.py
+++ b/e2e/tests/api_only/test_74_cancel_to_free_overlimit.py
@@ -202,11 +202,11 @@ def test_cancel_pro_to_free_over_limit():
     _set_notes_count(user_id, SEED_NOTES_COUNT)
 
     # Create a vault so vault-scoped endpoints don't 404.
-    vault_resp, vault_status = api.create_vault(f"cancel-vault-{_ts()}")
+    vault_resp, vault_status = api.register_vault(f"cancel-vault-{_ts()}", f"cancel-client-{_ts()}")
     assert vault_status in (200, 201), (
         f"vault create should succeed for Pro user; got {vault_status}: {vault_resp}"
     )
-    vault_id = (vault_resp.get("vault") or {}).get("id")
+    vault_id = vault_resp.get("id")
     assert vault_id, f"vault response missing id: {vault_resp}"
     api_v = api.with_vault(vault_id)
 

--- a/frontend/e2e/dark-mode.spec.ts
+++ b/frontend/e2e/dark-mode.spec.ts
@@ -24,10 +24,10 @@ async function registerUser(baseURL: string, email: string) {
 	if (!prof.ok) {
 		throw new Error(`onboarding PATCH failed: ${prof.status} ${await prof.text()}`);
 	}
-	const vault = await fetch(`${baseURL}/api/vaults`, {
+	const vault = await fetch(`${baseURL}/api/vaults/register`, {
 		method: "POST",
 		headers: auth,
-		body: JSON.stringify({ name: "E2E Vault" }),
+		body: JSON.stringify({ name: "E2E Vault", client_id: crypto.randomUUID() }),
 	});
 	if (!vault.ok) {
 		throw new Error(`vault POST failed: ${vault.status} ${await vault.text()}`);

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -62,10 +62,10 @@ async function preCompleteOnboarding(userId: string, secretKey: string): Promise
 	// dashboard, breaking sign-out / theme / mobile / note tests. The FTUX
 	// modal-specific tests use idempotent "skip if absent" checks, so seeding
 	// here doesn't regress that coverage.
-	const vaultResp = await fetch(`${CLERK_API_BASE}/vaults`, {
+	const vaultResp = await fetch(`${CLERK_API_BASE}/vaults/register`, {
 		method: "POST",
 		headers: { Authorization: `Bearer ${jwt}`, "Content-Type": "application/json" },
-		body: JSON.stringify({ name: "E2E Default Vault" }),
+		body: JSON.stringify({ name: "E2E Default Vault", client_id: crypto.randomUUID() }),
 	});
 	if (!vaultResp.ok) {
 		throw new Error(`Vault POST failed: ${vaultResp.status} ${await vaultResp.text()}`);

--- a/frontend/e2e/local-auth.spec.ts
+++ b/frontend/e2e/local-auth.spec.ts
@@ -29,10 +29,10 @@ async function registerUser(baseURL: string, email: string) {
 	if (!prof.ok) {
 		throw new Error(`Onboarding profile PATCH failed: ${prof.status} ${await prof.text()}`);
 	}
-	const vault = await fetch(`${baseURL}/api/vaults`, {
+	const vault = await fetch(`${baseURL}/api/vaults/register`, {
 		method: "POST",
 		headers: auth,
-		body: JSON.stringify({ name: "E2E Vault" }),
+		body: JSON.stringify({ name: "E2E Vault", client_id: crypto.randomUUID() }),
 	});
 	if (!vault.ok) {
 		throw new Error(`Vault POST failed: ${vault.status} ${await vault.text()}`);

--- a/frontend/e2e/mobile.spec.ts
+++ b/frontend/e2e/mobile.spec.ts
@@ -24,10 +24,10 @@ async function registerUser(baseURL: string, email: string) {
 	if (!prof.ok) {
 		throw new Error(`onboarding PATCH failed: ${prof.status} ${await prof.text()}`);
 	}
-	const vault = await fetch(`${baseURL}/api/vaults`, {
+	const vault = await fetch(`${baseURL}/api/vaults/register`, {
 		method: "POST",
 		headers: auth,
-		body: JSON.stringify({ name: "E2E Vault" }),
+		body: JSON.stringify({ name: "E2E Vault", client_id: crypto.randomUUID() }),
 	});
 	if (!vault.ok) {
 		throw new Error(`vault POST failed: ${vault.status} ${await vault.text()}`);

--- a/frontend/e2e/note-properties.spec.ts
+++ b/frontend/e2e/note-properties.spec.ts
@@ -56,16 +56,16 @@ interface Vault {
 }
 
 async function createVault(baseURL: string, token: string, name: string): Promise<Vault> {
-	const res = await fetch(`${baseURL}/api/vaults`, {
+	const res = await fetch(`${baseURL}/api/vaults/register`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-		body: JSON.stringify({ name }),
+		body: JSON.stringify({ name, client_id: crypto.randomUUID() }),
 	});
 	if (!res.ok) {
 		throw new Error(`vault create failed: ${res.status} ${await res.text()}`);
 	}
-	const { vault } = (await res.json()) as { vault: Vault };
-	return vault;
+	// /vaults/register answers with the vault flat, not wrapped in { vault }.
+	return (await res.json()) as Vault;
 }
 
 async function upsertNote(

--- a/frontend/e2e/support/api.ts
+++ b/frontend/e2e/support/api.ts
@@ -40,16 +40,16 @@ export async function createVault(
 	token: string,
 	name: string,
 ): Promise<{ id: number; name: string }> {
-	const res = await fetch(`${baseURL}/api/vaults`, {
+	const res = await fetch(`${baseURL}/api/vaults/register`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-		body: JSON.stringify({ name }),
+		body: JSON.stringify({ name, client_id: crypto.randomUUID() }),
 	});
 	if (!res.ok) {
 		throw new Error(`vault create failed: ${res.status} ${await res.text()}`);
 	}
-	const { vault } = (await res.json()) as { vault: { id: number; name: string } };
-	return vault;
+	// /vaults/register answers with the vault flat, not wrapped in { vault }.
+	return (await res.json()) as { id: number; name: string };
 }
 
 export async function upsertNote(

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -58,7 +58,7 @@ describe("api client 402 handling", () => {
 			),
 		);
 
-		await expect(api.post("/vaults", {})).rejects.toBeInstanceOf(LimitExceededError);
+		await expect(api.post("/vaults/register", {})).rejects.toBeInstanceOf(LimitExceededError);
 	});
 
 	it("LimitExceededError carries null fields when body is empty", async () => {

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1671,11 +1671,18 @@ export function useUpdateVault() {
 export function useCreateVault() {
 	const qc = useQueryClient();
 	return useMutation({
-		mutationFn: (attrs: { name: string; description?: string }) =>
-			api.post<{ vault: Vault }>("/vaults", attrs),
+		// POST /vaults/register is the only create endpoint, and it is
+		// idempotent by client_id: a retry after a timeout or a double submit
+		// resolves to the vault the first attempt already created instead of
+		// minting a second one. Callers must therefore hold `client_id` STABLE
+		// across retries of one user intent — mint it when the form mounts, not
+		// per submit, or the idempotency is a no-op. Responds with the vault
+		// flat (plus `status`), not wrapped in `{ vault }`.
+		mutationFn: (attrs: { name: string; client_id: string }) =>
+			api.post<Vault>("/vaults/register", attrs),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["vaults"] });
-			// Backend records `first_vault_created` in Vaults.create_vault/2;
+			// Backend records `first_vault_created` in Vaults.register_vault/4;
 			// refresh /status so the onboarding checklist ticks immediately.
 			qc.invalidateQueries({ queryKey: ["onboarding", "status"] });
 		},

--- a/frontend/src/components/vault-create-form.test.tsx
+++ b/frontend/src/components/vault-create-form.test.tsx
@@ -39,3 +39,47 @@ describe("VaultCreateForm onError", () => {
 		expect(toastError).not.toHaveBeenCalled();
 	});
 });
+
+describe("VaultCreateForm idempotency key", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	function submit(name: string) {
+		fireEvent.change(screen.getByLabelText(/vault name/iu), { target: { value: name } });
+		fireEvent.click(screen.getByRole("button", { name: /create/iu }));
+	}
+
+	it("reuses one client_id across retries of the same failed create", () => {
+		mutate.mockImplementation((_attrs, opts) => opts?.onError?.(new Error("boom")));
+		render(<VaultCreateForm />);
+
+		submit("A");
+		submit("A");
+
+		// Retrying a create that may already have landed server-side MUST carry
+		// the same key, or the retry mints a second vault.
+		expect(mutate.mock.calls[0]![0].client_id).toBe(mutate.mock.calls[1]![0].client_id);
+	});
+
+	it("mints a fresh client_id after a success, since that is a new intent", () => {
+		mutate.mockImplementation((_attrs, opts) =>
+			opts?.onSuccess?.({ id: "v1", slug: "a", name: "A" }),
+		);
+		render(<VaultCreateForm />);
+
+		submit("A");
+		submit("B");
+
+		expect(mutate.mock.calls[0]![0].client_id).not.toBe(mutate.mock.calls[1]![0].client_id);
+	});
+
+	it("hands onCreated the flat vault that /vaults/register returns", () => {
+		const vault = { id: "v1", slug: "archive", name: "Archive" };
+		mutate.mockImplementation((_attrs, opts) => opts?.onSuccess?.(vault));
+		const onCreated = vi.fn();
+		render(<VaultCreateForm onCreated={onCreated} />);
+
+		submit("Archive");
+
+		expect(onCreated).toHaveBeenCalledWith(vault);
+	});
+});

--- a/frontend/src/components/vault-create-form.tsx
+++ b/frontend/src/components/vault-create-form.tsx
@@ -26,6 +26,10 @@ export function VaultCreateForm({
 }: Props) {
 	const create = useCreateVault();
 	const [name, setName] = useState("");
+	// Stable across retries of ONE create intent so a double submit or a retry
+	// after a timeout resolves to the same vault instead of making a second.
+	// Re-minted on success, since the next create is a new intent.
+	const [clientId, setClientId] = useState(() => crypto.randomUUID());
 	const nameRef = useAutofocus<HTMLInputElement>(autoFocus);
 
 	function submit(e: React.FormEvent) {
@@ -35,12 +39,13 @@ export function VaultCreateForm({
 			return;
 		}
 		create.mutate(
-			{ name: next },
+			{ name: next, client_id: clientId },
 			{
-				onSuccess: (res) => {
+				onSuccess: (vault) => {
 					toast.success("Vault created");
 					setName("");
-					onCreated?.(res.vault);
+					setClientId(crypto.randomUUID());
+					onCreated?.(vault);
 				},
 				onError: (err) => {
 					// 402 cap errors are already surfaced by UpgradeDialogProvider via

--- a/frontend/src/layout/vault-switcher.test.tsx
+++ b/frontend/src/layout/vault-switcher.test.tsx
@@ -116,13 +116,12 @@ describe("VaultSwitcher", () => {
 		fireEvent.submit(input.closest("form")!);
 
 		expect(createMutate).toHaveBeenCalledWith(
-			{ name: "Archive" },
+			{ name: "Archive", client_id: expect.any(String) },
 			expect.objectContaining({ onSuccess: expect.any(Function) }),
 		);
-		// Land in the vault that was just created, by slug.
-		createMutate.mock.calls[0]![1].onSuccess({
-			vault: { id: "id-c", slug: "archive", name: "Archive" },
-		});
+		// Land in the vault that was just created, by slug. /vaults/register
+		// answers with the vault flat, NOT wrapped in { vault }.
+		createMutate.mock.calls[0]![1].onSuccess({ id: "id-c", slug: "archive", name: "Archive" });
 		expect(navigate).toHaveBeenCalledWith("/archive");
 	});
 });

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -46,6 +46,10 @@ function VaultStep({
 	const [source, setSource] = useState<Source>(
 		profileSaved ? (savedUsesObsidian ? "obsidian" : "fresh") : null,
 	);
+	// Idempotency key for this user's FIRST vault, stable for the lifetime of
+	// the step. Without it a retry after a slow or failed create leaves the
+	// user with two vaults and their content split across them.
+	const [vaultClientId] = useState(() => crypto.randomUUID());
 	// Track whether we've eager-committed `uses_obsidian: true` so the plugin's
 	// first sync isn't blocked by RequireOnboarding. The gate skips the vault
 	// check when uses_obsidian is true — without this, /api/notes 403s mid-sync
@@ -83,7 +87,10 @@ function VaultStep({
 	async function commitFresh(name: string) {
 		await setProfile.mutateAsync({ uses_obsidian: false });
 		const trimmed = name.trim() || "My Vault";
-		const { vault } = await createVault.mutateAsync({ name: trimmed });
+		const vault = await createVault.mutateAsync({
+			name: trimmed,
+			client_id: vaultClientId,
+		});
 		setActiveVaultId(vault.id);
 		try {
 			await updateNote.mutateAsync({

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -199,7 +199,16 @@ defmodule Engram.Vaults do
           })
           |> inject_name_phase_b(user, vault_id)
 
-        case Repo.insert(Vault.changeset(%Vault{id: vault_id}, attrs)) do
+        # `mode: :savepoint` is load-bearing, not defensive. The lookup above is
+        # a read-then-insert, so two concurrent registers of the same client_id
+        # both see `nil` and both insert. The partial unique index on
+        # (user_id, client_id) correctly rejects the loser — but a constraint
+        # violation ABORTS the surrounding transaction, and without a savepoint
+        # to roll back to, `with_tenant`'s role reset then dies with 25P02
+        # `in_failed_sql_transaction` and the caller gets a 500. The savepoint
+        # keeps the transaction usable so we can turn the loss into the right
+        # answer below.
+        case Repo.insert(Vault.changeset(%Vault{id: vault_id}, attrs), mode: :savepoint) do
           {:ok, vault} ->
             emit_vault_count(user.id, :created)
             _ = Engram.Onboarding.record_action(user.id, :first_vault_created)
@@ -208,7 +217,16 @@ defmodule Engram.Vaults do
             {:ok, decrypted, :created}
 
           {:error, cs} ->
-            {:error, cs}
+            # Losing the race is not an error: idempotency means resolving to
+            # whichever vault won. Re-read rather than inspecting the changeset
+            # errors, because BOTH unique constraints here (user_id+client_id
+            # and user_id+slug) report on `:user_id`, so the error key cannot
+            # tell them apart. A genuine validation failure (blank name) finds
+            # nothing and still surfaces as the changeset.
+            case find_by_client_id(user.id, client_id) do
+              %Vault{} = vault -> {:ok, decrypt_vault_if_needed(vault, user), :existing}
+              nil -> {:error, cs}
+            end
         end
     end
   end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -30,66 +30,6 @@ defmodule Engram.Vaults do
   @spec deleted(Ecto.Queryable.t()) :: Ecto.Query.t()
   def deleted(query), do: from(v in query, where: not is_nil(v.deleted_at))
 
-  # ── Create ─────────────────────────────────────────────────────────────────
-
-  @doc """
-  Creates a new vault for a user.
-
-  - Enforces billing limit (max_vaults).
-  - First vault is automatically set as default.
-  - Generates a unique slug from the name.
-
-  Returns {:ok, vault} or {:error, {:vault_limit_reached, limit, current}}
-  or {:error, changeset}.
-  """
-  def create_vault(user, attrs) do
-    # Ensure user has a DEK before Phase B injection
-    with {:ok, user} <- Engram.Crypto.ensure_user_dek(user) do
-      Repo.with_tenant(user.id, fn ->
-        current_count = count_vaults(user.id)
-
-        case Billing.check_limit(user, :vaults_cap, current_count) do
-          {:error, :limit_reached} ->
-            # Free-tier launch §4.5 — carry the resolved limit + current
-            # count back to the controller so the 402 body can populate
-            # them. The resolver call here is the same one check_limit
-            # already made internally; a second call is cheaper than
-            # threading the value out of check_limit (no hot path).
-            limit = Billing.effective_limit(user, :vaults_cap)
-            {:error, {:vault_limit_reached, limit, current_count}}
-
-          :ok ->
-            is_default = current_count == 0
-            name = attrs[:name] || attrs["name"] || ""
-            slug = unique_slug(user.id, slugify(name))
-            vault_id = Ecto.UUID.generate()
-
-            vault_attrs =
-              attrs
-              |> atomize_keys()
-              |> inject_name_phase_b(user, vault_id)
-              |> Map.merge(%{slug: slug, user_id: user.id, is_default: is_default})
-
-            %Vault{id: vault_id}
-            |> Vault.changeset(vault_attrs)
-            |> Repo.insert()
-            |> case do
-              {:ok, v} ->
-                emit_vault_count(user.id, :created)
-                _ = Engram.Onboarding.record_action(user.id, :first_vault_created)
-                decrypted = decrypt_vault_if_needed(v, user)
-                broadcast_vault_created(user.id, decrypted)
-                {:ok, decrypted}
-
-              other ->
-                other
-            end
-        end
-      end)
-      |> unwrap_transaction()
-    end
-  end
-
   # FTUX vault page subscribes to user channel and waits for this event so
   # it can auto-transition to the dashboard once a vault appears (e.g. the
   # Obsidian plugin creates one via its OAuth flow). Fire-and-forget; if
@@ -170,22 +110,37 @@ defmodule Engram.Vaults do
     seq
   end
 
-  # ── Register (idempotent) ───────────────────────────────────────────────────
+  # ── Create (single path) ────────────────────────────────────────────────────
 
   @doc """
-  Registers a vault by client_id. Idempotent: returns the existing vault if
-  a non-deleted vault with this client_id already exists for the user.
+  Creates a vault, keyed by `client_id`. **This is the only way a vault is
+  created** — every caller (HTTP, device link, tests) comes through here, so
+  the billing check, slug allocation, default-vault rule, encryption
+  injection, telemetry, onboarding action and `vault_created` broadcast can
+  only be applied one way.
+
+  Idempotent: returns the existing vault if a non-deleted vault with this
+  `client_id` already exists for the user. That is the whole point of the
+  key — a caller that retries after a timeout resolves to the vault its first
+  attempt may already have created, instead of minting a second one.
+
+  `extra_attrs` carries optional columns (e.g. `:description`); `:name`,
+  `:client_id`, `:slug`, `:user_id` and `:is_default` are computed here and
+  cannot be overridden.
 
   Returns:
     {:ok, vault, :created}   — new vault was inserted
     {:ok, vault, :existing}  — matched an existing vault
     {:error, :invalid_client_id}  — client_id is not a non-blank string
     {:error, {:vault_limit_reached, limit, current}}
+    {:error, changeset}
   """
-  def register_vault(_user, _name, client_id) when not is_binary(client_id),
+  def register_vault(user, name, client_id, extra_attrs \\ %{})
+
+  def register_vault(_user, _name, client_id, _extra_attrs) when not is_binary(client_id),
     do: {:error, :invalid_client_id}
 
-  def register_vault(user, name, client_id) do
+  def register_vault(user, name, client_id, extra_attrs) do
     # A blank client_id cannot serve as this function's idempotency key, and
     # fails in the worst direction: `Vault.changeset/2` casts `:client_id`, so
     # Ecto's default `:empty_values` drops "" and the row stores NULL — which
@@ -196,57 +151,65 @@ defmodule Engram.Vaults do
     if String.trim(client_id) == "" do
       {:error, :invalid_client_id}
     else
-      do_register_vault(user, name, client_id)
+      do_register_vault(user, name, client_id, atomize_keys(extra_attrs))
     end
   end
 
-  defp do_register_vault(user, name, client_id) do
+  defp do_register_vault(user, name, client_id, extra_attrs) do
     # Ensure user has a DEK before Phase B injection
     with {:ok, user} <- Engram.Crypto.ensure_user_dek(user) do
-      result =
-        Repo.with_tenant(user.id, fn ->
-          existing = find_by_client_id(user.id, client_id)
+      Repo.with_tenant(user.id, fn ->
+        case find_by_client_id(user.id, client_id) do
+          %Vault{} = vault ->
+            {:ok, decrypt_vault_if_needed(vault, user), :existing}
 
-          case existing do
-            %Vault{} = vault ->
-              {:ok, decrypt_vault_if_needed(vault, user), :existing}
+          nil ->
+            insert_vault(user, name, client_id, extra_attrs)
+        end
+      end)
+      |> unwrap_register_transaction()
+    end
+  end
 
-            nil ->
-              current_count = count_vaults(user.id)
+  # Runs inside the caller's `Repo.with_tenant/2` transaction.
+  defp insert_vault(user, name, client_id, extra_attrs) do
+    current_count = count_vaults(user.id)
 
-              case Billing.check_limit(user, :vaults_cap, current_count) do
-                {:error, :limit_reached} ->
-                  limit = Billing.effective_limit(user, :vaults_cap)
-                  {:error, {:vault_limit_reached, limit, current_count}}
+    case Billing.check_limit(user, :vaults_cap, current_count) do
+      {:error, :limit_reached} ->
+        # Free-tier launch §4.5 — carry the resolved limit + current count back
+        # to the controller so the 402 body can populate them. The resolver
+        # call here is the same one check_limit already made internally; a
+        # second call is cheaper than threading the value out of check_limit
+        # (no hot path).
+        limit = Billing.effective_limit(user, :vaults_cap)
+        {:error, {:vault_limit_reached, limit, current_count}}
 
-                :ok ->
-                  is_default = current_count == 0
-                  slug = unique_slug(user.id, slugify(name))
-                  vault_id = Ecto.UUID.generate()
+      :ok ->
+        vault_id = Ecto.UUID.generate()
 
-                  attrs = %{
-                    name: name,
-                    client_id: client_id,
-                    slug: slug,
-                    user_id: user.id,
-                    is_default: is_default
-                  }
+        attrs =
+          extra_attrs
+          |> Map.merge(%{
+            name: name,
+            client_id: client_id,
+            slug: unique_slug(user.id, slugify(name)),
+            user_id: user.id,
+            is_default: current_count == 0
+          })
+          |> inject_name_phase_b(user, vault_id)
 
-                  attrs = inject_name_phase_b(attrs, user, vault_id)
+        case Repo.insert(Vault.changeset(%Vault{id: vault_id}, attrs)) do
+          {:ok, vault} ->
+            emit_vault_count(user.id, :created)
+            _ = Engram.Onboarding.record_action(user.id, :first_vault_created)
+            decrypted = decrypt_vault_if_needed(vault, user)
+            broadcast_vault_created(user.id, decrypted)
+            {:ok, decrypted, :created}
 
-                  case Repo.insert(Vault.changeset(%Vault{id: vault_id}, attrs)) do
-                    {:ok, vault} ->
-                      emit_vault_count(user.id, :created)
-                      {:ok, decrypt_vault_if_needed(vault, user), :created}
-
-                    {:error, cs} ->
-                      {:error, cs}
-                  end
-              end
-          end
-        end)
-
-      unwrap_register_transaction(result)
+          {:error, cs} ->
+            {:error, cs}
+        end
     end
   end
 

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -49,8 +49,11 @@ defmodule EngramWeb.DeviceAuthController do
   def authorize(conn, %{"user_code" => user_code, "vault_id" => "new", "vault_name" => vault_name}) do
     user = conn.assigns.current_user
 
-    case Vaults.create_vault(user, %{name: vault_name}) do
-      {:ok, vault} ->
+    # `user_code` identifies THIS link attempt, so it doubles as the
+    # idempotency key for the vault it creates: a double-tapped Authorize
+    # resolves to the vault the first tap made instead of minting a second.
+    case Vaults.register_vault(user, vault_name, "device-link:" <> user_code) do
+      {:ok, vault, _status} ->
         do_authorize(conn, user_code, user, vault.id)
 
       {:error, {:vault_limit_reached, limit, current}} ->

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -86,47 +86,11 @@ defmodule EngramWeb.VaultsController do
     %{vaults: Enum.map(vaults, &vault_json(&1, Map.get(counts, &1.id, @zero_counts)))}
   end
 
-  # ── create ─────────────────────────────────────────────────────────────────
-
-  operation(:create,
-    operation_id: "vaults-create",
-    summary: "Create a vault",
-    description:
-      "Creates a new vault for the user and returns it with zeroed content counts. Returns 402 " <>
-        "when the plan's vault cap is reached and 422 on validation errors.",
-    tags: ["Vaults"],
-    request_body:
-      {"Vault attributes", "application/json", Schemas.CreateVaultRequest, required: true},
-    responses: [
-      created: {"Created", "application/json", Schemas.VaultResponse},
-      payment_required: {"Vault cap reached", "application/json", Schemas.LimitError},
-      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
-    ]
-  )
-
-  def create(conn, params) do
-    user = conn.assigns.current_user
-
-    case Vaults.create_vault(user, params) do
-      {:ok, vault} ->
-        conn
-        |> put_status(201)
-        |> json(%{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
-
-      {:error, {:vault_limit_reached, limit, current}} ->
-        # Free-tier launch §4.5 — standardized 402 shape via LimitResponse.
-        EngramWeb.LimitResponse.halt(
-          conn,
-          "vaults_cap_exceeded",
-          :vaults_cap,
-          limit,
-          current
-        )
-
-      {:error, %Ecto.Changeset{}} = error ->
-        error
-    end
-  end
+  # `POST /vaults` used to live here. It created a vault per call with no
+  # idempotency key, so a client that retried a slow or failed request got a
+  # SECOND vault — which is how one Obsidian first-sync produced two vaults and
+  # orphaned 292 uploads into the abandoned one. `POST /vaults/register` (the
+  # `:register` action below) is now the only create endpoint.
 
   # ── show ───────────────────────────────────────────────────────────────────
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -358,7 +358,6 @@ defmodule EngramWeb.Router do
     # Vault management (user-level, not vault-scoped)
     get "/vaults", VaultsController, :index
     post "/vaults/register", VaultsController, :register
-    post "/vaults", VaultsController, :create
     get "/vaults/:id", VaultsController, :show
     patch "/vaults/:id", VaultsController, :update
     delete "/vaults/:id", VaultsController, :delete

--- a/lib/engram_web/schemas/vaults.ex
+++ b/lib/engram_web/schemas/vaults.ex
@@ -72,28 +72,6 @@ defmodule EngramWeb.Schemas.VaultsResponse do
   })
 end
 
-defmodule EngramWeb.Schemas.CreateVaultRequest do
-  @moduledoc false
-  alias OpenApiSpex.Schema
-  require OpenApiSpex
-
-  OpenApiSpex.schema(%{
-    title: "CreateVaultRequest",
-    type: :object,
-    properties: %{
-      name: %Schema{type: :string},
-      description: %Schema{type: :string, nullable: true},
-      is_default: %Schema{type: :boolean}
-    },
-    required: [:name],
-    example: %{
-      "name" => "Research",
-      "description" => "Papers and reading notes.",
-      "is_default" => false
-    }
-  })
-end
-
 defmodule EngramWeb.Schemas.UpdateVaultRequest do
   @moduledoc "Partial update — only supplied fields change."
   alias OpenApiSpex.Schema

--- a/openapi.json
+++ b/openapi.json
@@ -2151,38 +2151,6 @@
         "x-struct": "Elixir.EngramWeb.Schemas.AttachmentsResponse",
         "x-validate": null
       },
-      "CreateVaultRequest": {
-        "example": {
-          "description": "Papers and reading notes.",
-          "is_default": false,
-          "name": "Research"
-        },
-        "properties": {
-          "description": {
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "is_default": {
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": [
-          "name"
-        ],
-        "title": "CreateVaultRequest",
-        "type": "object",
-        "x-struct": "Elixir.EngramWeb.Schemas.CreateVaultRequest",
-        "x-validate": null
-      },
       "AttachmentWithContent": {
         "properties": {
           "content_base64": {
@@ -4083,59 +4051,6 @@
           }
         },
         "summary": "List vaults",
-        "tags": [
-          "Vaults"
-        ]
-      },
-      "post": {
-        "callbacks": {},
-        "description": "Creates a new vault for the user and returns it with zeroed content counts. Returns 402 when the plan's vault cap is reached and 422 on validation errors.",
-        "operationId": "vaults-create",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateVaultRequest"
-              }
-            }
-          },
-          "description": "Vault attributes",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VaultResponse"
-                }
-              }
-            },
-            "description": "Created"
-          },
-          "402": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LimitError"
-                }
-              }
-            },
-            "description": "Vault cap reached"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Validation error"
-          }
-        },
-        "summary": "Create a vault",
         "tags": [
           "Vaults"
         ]

--- a/test/engram/attachments_seq_feed_test.exs
+++ b/test/engram/attachments_seq_feed_test.exs
@@ -7,7 +7,7 @@ defmodule Engram.AttachmentsSeqFeedTest do
     user = insert_user()
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/attachments_seq_test.exs
+++ b/test/engram/attachments_seq_test.exs
@@ -7,7 +7,7 @@ defmodule Engram.AttachmentsSeqTest do
     user = insert_user()
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/backfill/tenant_scan_test.exs
+++ b/test/engram/backfill/tenant_scan_test.exs
@@ -31,7 +31,7 @@ defmodule Engram.Backfill.TenantScanTest do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "TenantScan"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "TenantScan", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/connections_test.exs
+++ b/test/engram/connections_test.exs
@@ -376,10 +376,10 @@ defmodule Engram.ConnectionsTest do
 
     test "vault_name resolves to the decrypted vault name" do
       user = insert_user()
-      # create_vault drives the real encryption pipeline so list_vaults/1 can
+      # register_vault drives the real encryption pipeline so list_vaults/1 can
       # decrypt the name back. The factory-built :vault has random ciphertext
       # which would decrypt to nil, that's the "vault gone" path tested below.
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Personal"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "Personal", Ecto.UUID.generate())
       client = insert(:oauth_client, kind: "mcp")
 
       insert(:oauth_refresh_token,

--- a/test/engram/content_hash/backfill_test.exs
+++ b/test/engram/content_hash/backfill_test.exs
@@ -27,7 +27,9 @@ defmodule Engram.ContentHash.BackfillTest do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "ContentHashBackfill"})
+
+    {:ok, vault, _} =
+      Engram.Vaults.register_vault(user, "ContentHashBackfill", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/crdt_sync_handoff_test.exs
+++ b/test/engram/crdt_sync_handoff_test.exs
@@ -26,7 +26,7 @@ defmodule Engram.CrdtSyncHandoffTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtSyncHandoffTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtSyncHandoffTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "base"})
 
     socket = user_socket(user)

--- a/test/engram/crypto/aad_rebind_test.exs
+++ b/test/engram/crypto/aad_rebind_test.exs
@@ -20,7 +20,7 @@ defmodule Engram.Crypto.AadRebindTest do
       # Use the real Vaults context so the vault is born AAD-bound (dek_version=2).
       # The rebind would otherwise pick it up and fail on the random-bytes
       # ciphertext the test factory writes.
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Rebind Vault"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "Rebind Vault", Ecto.UUID.generate())
       {:ok, dek} = Crypto.get_dek(user)
 
       # Hand-build a legacy note: every ciphertext column written with
@@ -139,7 +139,8 @@ defmodule Engram.Crypto.AadRebindTest do
       # from "1000 users had nothing to do." Fix: track whether the wrap was
       # changed AND whether any rows were rewritten. If neither, return
       # :skipped so re-runs are honest.
-      {:ok, _vault} = Engram.Vaults.create_vault(user, %{name: "Idempotence Vault"})
+      {:ok, _vault, _} =
+        Engram.Vaults.register_vault(user, "Idempotence Vault", Ecto.UUID.generate())
 
       # First run: DEK wrap upgrades v1→v2 + Idempotence Vault was just
       # created (post-T3.6 already at v2 if factories track it; the rewrap
@@ -167,7 +168,8 @@ defmodule Engram.Crypto.AadRebindTest do
       # Use the real Vaults context so the vault is born AAD-bound; we want
       # to isolate this test to the attachment rebind signal, not vault
       # legacy decrypt.
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Attachment Vault"})
+      {:ok, vault, _} =
+        Engram.Vaults.register_vault(user, "Attachment Vault", Ecto.UUID.generate())
 
       _att1 = insert(:attachment, user: user, vault: vault, dek_version: legacy_version)
       _att2 = insert(:attachment, user: user, vault: vault, dek_version: legacy_version)

--- a/test/engram/crypto/aad_tamper_test.exs
+++ b/test/engram/crypto/aad_tamper_test.exs
@@ -16,7 +16,7 @@ defmodule Engram.Crypto.AadTamperTest do
     DekCache.invalidate_all()
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Tamper Vault"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Tamper Vault", Ecto.UUID.generate())
     {:ok, user: user, vault: vault}
   end
 
@@ -58,7 +58,7 @@ defmodule Engram.Crypto.AadTamperTest do
        %{user: user_a, vault: vault_a} do
     user_b = insert(:user)
     {:ok, user_b} = Crypto.ensure_user_dek(user_b)
-    {:ok, vault_b} = Engram.Vaults.create_vault(user_b, %{name: "B Vault"})
+    {:ok, vault_b, _} = Engram.Vaults.register_vault(user_b, "B Vault", Ecto.UUID.generate())
 
     {:ok, note_a} = Notes.upsert_note(user_a, vault_a, %{path: "a.md", content: "user-a-secret"})
     {:ok, note_b} = Notes.upsert_note(user_b, vault_b, %{path: "b.md", content: "user-b-secret"})

--- a/test/engram/crypto/user_dek_rotation_test.exs
+++ b/test/engram/crypto/user_dek_rotation_test.exs
@@ -50,7 +50,9 @@ defmodule Engram.Crypto.UserDekRotationTest do
   # once it is retired — long after the rotation reported success.
   describe "rotate_user/1 — vault index snapshot (#1151)" do
     setup %{user: user} do
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "RotationIndexVault"})
+      {:ok, vault, _} =
+        Engram.Vaults.register_vault(user, "RotationIndexVault", Ecto.UUID.generate())
+
       %{vault: vault}
     end
 
@@ -990,9 +992,9 @@ defmodule Engram.Crypto.UserDekRotationTest do
 
   describe "rotate_user/1 — production-path bug regression" do
     setup %{user: user} do
-      # Grant unlimited vaults so create_vault doesn't hit the billing limit.
+      # Grant unlimited vaults so register_vault doesn't hit the billing limit.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "ProdVault"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "ProdVault", Ecto.UUID.generate())
       {:ok, user: user, vault: vault}
     end
 

--- a/test/engram/keyword_index/stats_cache_test.exs
+++ b/test/engram/keyword_index/stats_cache_test.exs
@@ -15,7 +15,7 @@ defmodule Engram.KeywordIndex.StatsCacheTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/mcp/handlers_broadcast_test.exs
+++ b/test/engram/mcp/handlers_broadcast_test.exs
@@ -14,7 +14,7 @@ defmodule Engram.MCP.HandlersBroadcastTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
     %{user: user, vault: vault}
   end

--- a/test/engram/mcp/handlers_get_note_utf8_test.exs
+++ b/test/engram/mcp/handlers_get_note_utf8_test.exs
@@ -21,7 +21,7 @@ defmodule Engram.MCP.HandlersGetNoteUtf8Test do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/checkpoint_interleave_test.exs
+++ b/test/engram/notes/checkpoint_interleave_test.exs
@@ -41,7 +41,7 @@ defmodule Engram.Notes.CheckpointInterleaveTest do
     user = insert(:user, id: user_id, email: email)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "CpInterleave"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "CpInterleave", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/notes/crdt_checkpoint_backpressure_test.exs
+++ b/test/engram/notes/crdt_checkpoint_backpressure_test.exs
@@ -20,7 +20,7 @@ defmodule Engram.Notes.CrdtCheckpointBackpressureTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "BackpressureTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "BackpressureTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before"})
     %{user: user, vault: vault, note: note}
   end

--- a/test/engram/notes/crdt_checkpoint_legacy_row_test.exs
+++ b/test/engram/notes/crdt_checkpoint_legacy_row_test.exs
@@ -31,7 +31,7 @@ defmodule Engram.Notes.CrdtCheckpointLegacyRowTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "LegacyRow"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "LegacyRow", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/crdt_checkpoint_rotation_fence_test.exs
+++ b/test/engram/notes/crdt_checkpoint_rotation_fence_test.exs
@@ -36,7 +36,7 @@ defmodule Engram.Notes.CrdtCheckpointRotationFenceTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "RotationFence"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "RotationFence", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -12,7 +12,7 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtCheckpointTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtCheckpointTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before"})
     %{user: user, vault: vault, note: note}
   end

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -17,7 +17,7 @@ defmodule Engram.Notes.CrdtDeliverTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "DeliverTest"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "DeliverTest", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/crdt_doc_test.exs
+++ b/test/engram/notes/crdt_doc_test.exs
@@ -8,7 +8,7 @@ defmodule Engram.Notes.CrdtDocTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtDocTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtDocTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before"})
     %{user: user, vault: vault, note: note}
   end

--- a/test/engram/notes/crdt_e2e_test.exs
+++ b/test/engram/notes/crdt_e2e_test.exs
@@ -33,7 +33,7 @@ defmodule Engram.Notes.CrdtE2ETest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtE2E"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtE2E", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "e2e.md", "content" => "base"})
     doc_id = note.id
     topic = "crdt:#{user.id}:#{vault.id}"

--- a/test/engram/notes/crdt_embed_coalescing_test.exs
+++ b/test/engram/notes/crdt_embed_coalescing_test.exs
@@ -17,7 +17,7 @@ defmodule Engram.Notes.CrdtEmbedCoalescingTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtEmbedCoalescingTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtEmbedCoalescingTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "coalesce.md", "content" => "base"})
     %{user: user, vault: vault, note: note}
   end

--- a/test/engram/notes/crdt_head_property_test.exs
+++ b/test/engram/notes/crdt_head_property_test.exs
@@ -59,7 +59,7 @@ defmodule Engram.Notes.CrdtHeadPropertyTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "HeadProperty"})
+    {:ok, vault, _} = Vaults.register_vault(user, "HeadProperty", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/crdt_index_chaos_test.exs
+++ b/test/engram/notes/crdt_index_chaos_test.exs
@@ -38,7 +38,7 @@ defmodule Engram.Notes.CrdtIndexChaosTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "IndexChaos"})
+    {:ok, vault, _} = Vaults.register_vault(user, "IndexChaos", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/crdt_index_persistence_test.exs
+++ b/test/engram/notes/crdt_index_persistence_test.exs
@@ -41,7 +41,7 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "IndexPersistenceTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "IndexPersistenceTest", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end
@@ -633,7 +633,7 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
 
   describe "isolation and binding" do
     test "one vault's index never bleeds into another's", ctx do
-      {:ok, other} = Vaults.create_vault(ctx.user, %{name: "OtherVault"})
+      {:ok, other, _} = Vaults.register_vault(ctx.user, "OtherVault", Ecto.UUID.generate())
 
       room = start_index_room(ctx)
       put_entry(room, "mine.md", "note-mine")
@@ -661,7 +661,7 @@ defmodule Engram.Notes.CrdtIndexPersistenceTest do
     # it lives in, so a blob moved between vaults fails to decrypt rather than
     # silently handing one vault another's index.
     test "a snapshot moved to another vault's row will not decrypt", ctx do
-      {:ok, other} = Vaults.create_vault(ctx.user, %{name: "AadVault"})
+      {:ok, other, _} = Vaults.register_vault(ctx.user, "AadVault", Ecto.UUID.generate())
 
       room = start_index_room(ctx)
       put_entry(room, "bound.md", "note-bound")

--- a/test/engram/notes/crdt_index_room_test.exs
+++ b/test/engram/notes/crdt_index_room_test.exs
@@ -30,8 +30,8 @@ defmodule Engram.Notes.CrdtIndexRoomTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "IndexRoomTest"})
-    {:ok, other} = Vaults.create_vault(user, %{name: "IndexRoomTestOther"})
+    {:ok, vault, _} = Vaults.register_vault(user, "IndexRoomTest", Ecto.UUID.generate())
+    {:ok, other, _} = Vaults.register_vault(user, "IndexRoomTestOther", Ecto.UUID.generate())
 
     %{user: user, vault: vault, other_vault: other}
   end

--- a/test/engram/notes/crdt_merge_path_test.exs
+++ b/test/engram/notes/crdt_merge_path_test.exs
@@ -10,7 +10,7 @@ defmodule Engram.Notes.CrdtMergePathTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtMerge"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtMerge", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 
@@ -391,7 +391,7 @@ defmodule Engram.Notes.CrdtMergePathTest do
   # green without ever exercising it.
   test "a tail row stamped with another vault is not folded into this vault's doc", ctx do
     %{user: user, vault: vault} = ctx
-    {:ok, other_vault} = Vaults.create_vault(user, %{name: "OtherVault"})
+    {:ok, other_vault, _} = Vaults.register_vault(user, "OtherVault", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "scoped.md", "content" => "MINE"})
 
     {:ok, {ct, nonce}} = Crypto.encrypt_crdt_state("foreign_update", user, note.id)

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -11,7 +11,7 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtPersist"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtPersist", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "base"})
     %{user: user, vault: vault, note: note}
   end

--- a/test/engram/notes/crdt_registry_test.exs
+++ b/test/engram/notes/crdt_registry_test.exs
@@ -9,7 +9,7 @@ defmodule Engram.Notes.CrdtRegistryTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtRegistryTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtRegistryTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "r.md", "content" => "base"})
     %{user: user, vault: vault, note: note}
   end

--- a/test/engram/notes/crdt_room_idle_exit_test.exs
+++ b/test/engram/notes/crdt_room_idle_exit_test.exs
@@ -68,7 +68,7 @@ defmodule Engram.Notes.CrdtRoomIdleExitTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "IdleExitTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "IdleExitTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before"})
 
     %{user: user, vault: vault, note: note}

--- a/test/engram/notes/crdt_transport_test.exs
+++ b/test/engram/notes/crdt_transport_test.exs
@@ -10,7 +10,7 @@ defmodule Engram.Notes.CrdtTransportTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "TransportTest"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "TransportTest", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/fanout_pacer_wiring_test.exs
+++ b/test/engram/notes/fanout_pacer_wiring_test.exs
@@ -7,7 +7,7 @@ defmodule Engram.Notes.FanoutPacerWiringTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/feed_interleave_test.exs
+++ b/test/engram/notes/feed_interleave_test.exs
@@ -42,7 +42,7 @@ defmodule Engram.Notes.FeedInterleaveTest do
     user = insert(:user, id: user_id, email: email)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "FeedInterleave"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "FeedInterleave", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/notes/folder_marker_race_test.exs
+++ b/test/engram/notes/folder_marker_race_test.exs
@@ -30,7 +30,7 @@ defmodule Engram.Notes.FolderMarkerRaceTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/genesis_crdt_note_test.exs
+++ b/test/engram/notes/genesis_crdt_note_test.exs
@@ -6,7 +6,7 @@ defmodule Engram.Notes.GenesisCrdtNoteTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "GenesisTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "GenesisTest", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 
@@ -237,7 +237,7 @@ defmodule Engram.Notes.GenesisCrdtNoteTest do
   end
 
   test "an id owned by ANOTHER vault is re-minted, not dropped", %{user: user, vault: vault} do
-    {:ok, other} = Vaults.create_vault(user, %{name: "GenesisTestB"})
+    {:ok, other, _} = Vaults.register_vault(user, "GenesisTestB", Ecto.UUID.generate())
 
     {:ok, in_a} =
       Notes.upsert_note(user, vault, %{"path" => "Notes/copied.md", "content" => "vault A"})
@@ -265,7 +265,7 @@ defmodule Engram.Notes.GenesisCrdtNoteTest do
     # no-op on the PK -- and, with it, a crdt merge, an encrypt, and a vault seq
     # consumed by a row that never lands. remint_own_id still backstops the REST
     # leg; this pins that the socket leg no longer needs it.
-    {:ok, other} = Vaults.create_vault(user, %{name: "GenesisSeqB"})
+    {:ok, other, _} = Vaults.register_vault(user, "GenesisSeqB", Ecto.UUID.generate())
     {:ok, foreign} = Notes.upsert_note(user, other, %{"path" => "Notes/f.md", "content" => "x"})
 
     {:ok, base} = Notes.upsert_note(user, vault, %{"path" => "Notes/base.md", "content" => "b"})

--- a/test/engram/notes/identity_test.exs
+++ b/test/engram/notes/identity_test.exs
@@ -27,7 +27,7 @@ defmodule Engram.Notes.IdentityTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "IdentityTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "IdentityTest", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/notes/materialization_test.exs
+++ b/test/engram/notes/materialization_test.exs
@@ -8,7 +8,7 @@ defmodule Engram.Notes.MaterializationTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/notes/note_upsert_race_test.exs
+++ b/test/engram/notes/note_upsert_race_test.exs
@@ -37,7 +37,7 @@ defmodule Engram.Notes.NoteUpsertRaceTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes/rest_write_interleave_test.exs
+++ b/test/engram/notes/rest_write_interleave_test.exs
@@ -57,7 +57,7 @@ defmodule Engram.Notes.RestWriteInterleaveTest do
     user = insert(:user, id: user_id, email: email)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Interleave"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Interleave", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/notes/utf8_backfill_test.exs
+++ b/test/engram/notes/utf8_backfill_test.exs
@@ -13,7 +13,7 @@ defmodule Engram.Notes.Utf8BackfillTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_batch_test.exs
+++ b/test/engram/notes_batch_test.exs
@@ -13,8 +13,8 @@ defmodule Engram.NotesBatchTest do
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     {:ok, other_user} = Engram.Crypto.ensure_user_dek(other_user)
 
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
-    {:ok, other_vault} = Engram.Vaults.create_vault(other_user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
+    {:ok, other_vault, _} = Engram.Vaults.register_vault(other_user, "Test", Ecto.UUID.generate())
 
     %{user: user, other_user: other_user, vault: vault, other_vault: other_vault}
   end
@@ -535,7 +535,7 @@ defmodule Engram.NotesBatchSetBasedTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_batch_upsert_test.exs
+++ b/test/engram/notes_batch_upsert_test.exs
@@ -11,7 +11,7 @@ defmodule Engram.NotesBatchUpsertTest do
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
 
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/notes_broadcast_test.exs
+++ b/test/engram/notes_broadcast_test.exs
@@ -7,7 +7,7 @@ defmodule Engram.NotesBroadcastTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_cap_test.exs
+++ b/test/engram/notes_cap_test.exs
@@ -13,7 +13,7 @@ defmodule Engram.NotesCapTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_content_for_read_test.exs
+++ b/test/engram/notes_content_for_read_test.exs
@@ -25,7 +25,7 @@ defmodule Engram.NotesContentForReadTest do
   setup do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "ContentForRead"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "ContentForRead", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_delete_tombstone_test.exs
+++ b/test/engram/notes_delete_tombstone_test.exs
@@ -14,7 +14,7 @@ defmodule Engram.NotesDeleteTombstoneTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_display_fields_meta_test.exs
+++ b/test/engram/notes_display_fields_meta_test.exs
@@ -17,7 +17,7 @@ defmodule Engram.NotesDisplayFieldsMetaTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_folder_marker_test.exs
+++ b/test/engram/notes_folder_marker_test.exs
@@ -7,7 +7,7 @@ defmodule Engram.NotesFolderMarkerTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_folder_rename_crypto_test.exs
+++ b/test/engram/notes_folder_rename_crypto_test.exs
@@ -18,7 +18,7 @@ defmodule Engram.NotesFolderRenameCryptoTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_idempotent_upsert_test.exs
+++ b/test/engram/notes_idempotent_upsert_test.exs
@@ -14,7 +14,7 @@ defmodule Engram.NotesIdempotentUpsertTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_okf_write_test.exs
+++ b/test/engram/notes_okf_write_test.exs
@@ -21,7 +21,7 @@ defmodule Engram.NotesOkfWriteTest do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Vaults.create_vault(user, %{"name" => "okf-test"})
+    {:ok, vault, _} = Vaults.register_vault(user, "okf-test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_seq_feed_byte_budget_test.exs
+++ b/test/engram/notes_seq_feed_byte_budget_test.exs
@@ -24,7 +24,7 @@ defmodule Engram.NotesSeqFeedByteBudgetTest do
     user = insert_user()
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+    {:ok, vault, _} = Vaults.register_vault(user, "T", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_seq_feed_test.exs
+++ b/test/engram/notes_seq_feed_test.exs
@@ -6,7 +6,7 @@ defmodule Engram.NotesSeqFeedTest do
     user = insert_user()
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+    {:ok, vault, _} = Vaults.register_vault(user, "T", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_seq_test.exs
+++ b/test/engram/notes_seq_test.exs
@@ -9,7 +9,7 @@ defmodule Engram.NotesSeqTest do
     user = insert_user()
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -9,7 +9,7 @@ defmodule Engram.NotesTest do
     user = insert(:user)
     other_user = insert(:user)
 
-    # Allow unlimited vaults so create_vault doesn't hit the billing limit
+    # Allow unlimited vaults so register_vault doesn't hit the billing limit
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     insert(:user_limit_override, user: other_user, key: "vaults_cap", value: %{"v" => -1})
 
@@ -18,8 +18,8 @@ defmodule Engram.NotesTest do
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     {:ok, other_user} = Engram.Crypto.ensure_user_dek(other_user)
 
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
-    {:ok, other_vault} = Engram.Vaults.create_vault(other_user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
+    {:ok, other_vault, _} = Engram.Vaults.register_vault(other_user, "Test", Ecto.UUID.generate())
 
     %{user: user, other_user: other_user, vault: vault, other_vault: other_vault}
   end

--- a/test/engram/observability/emitters_test.exs
+++ b/test/engram/observability/emitters_test.exs
@@ -68,7 +68,7 @@ defmodule Engram.Observability.EmittersTest do
   describe "note_created" do
     test "fires on new note insert with vault_id property", %{bypass: bypass} do
       user = user_with_clerk_id()
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
       expect_capture(bypass)
 
       assert {:ok, _note} =
@@ -87,7 +87,7 @@ defmodule Engram.Observability.EmittersTest do
     test "does NOT fire on an update to an existing note (idempotent re-push)",
          %{bypass: bypass} do
       user = user_with_clerk_id()
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
 
       # First insert — burn the single Bypass expectation so a second emit
       # would fail the test (Bypass.expect_once raises on extra calls).
@@ -122,7 +122,7 @@ defmodule Engram.Observability.EmittersTest do
     test "fires after Qdrant returns with result_count + latency_ms",
          %{bypass: bypass} do
       user = user_with_clerk_id()
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
 
       # Re-route Qdrant to the same Bypass under a distinct path so we can
       # serve the search response inline.
@@ -162,7 +162,7 @@ defmodule Engram.Observability.EmittersTest do
   describe "vault_opened" do
     test "fires on GET /vaults/:id success", %{conn: conn, bypass: bypass} do
       user = user_with_clerk_id()
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
       expect_capture(bypass)
 
       conn = conn |> authenticate(user) |> get("/api/vaults/#{vault.id}")

--- a/test/engram/onboarding/backfill_test.exs
+++ b/test/engram/onboarding/backfill_test.exs
@@ -12,7 +12,7 @@ defmodule Engram.Onboarding.BackfillTest do
   test "records first_vault_created for every user holding a vault, and no one else" do
     user_with = insert_user()
     user_without = insert_user()
-    {:ok, _} = Vaults.create_vault(user_with, %{name: "Main"})
+    {:ok, _, _} = Vaults.register_vault(user_with, "Main", Ecto.UUID.generate())
 
     # Clear the row the T5 hook creates so this exercises pure backfill.
     # Cross-tenant test cleanup — onboarding_actions is a tenant table (#788).
@@ -26,7 +26,7 @@ defmodule Engram.Onboarding.BackfillTest do
 
   test "is idempotent — a second run inserts nothing" do
     user = insert_user()
-    {:ok, _} = Vaults.create_vault(user, %{name: "Main"})
+    {:ok, _, _} = Vaults.register_vault(user, "Main", Ecto.UUID.generate())
     Repo.delete_all(Action, skip_tenant_check: true)
 
     assert Backfill.first_vault_created() == 1

--- a/test/engram/onboarding/gate_cache_test.exs
+++ b/test/engram/onboarding/gate_cache_test.exs
@@ -75,7 +75,7 @@ defmodule Engram.Onboarding.GateCacheTest do
 
     test "delete_vault evicts the user's verdict" do
       user = insert(:user)
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "V"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "V", Ecto.UUID.generate())
       :ok = GateCache.mark_passed(user.id)
 
       {:ok, _} = Engram.Vaults.delete_vault(user, vault.id)

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -651,7 +651,7 @@ defmodule Engram.OnboardingTest do
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
       insert(:subscription, user: user, status: "active")
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
-      {:ok, _} = Engram.Vaults.create_vault(user, %{name: "My Vault"})
+      {:ok, _, _} = Engram.Vaults.register_vault(user, "My Vault", Ecto.UUID.generate())
 
       assert %{has_vault: true, next_step: :done} = Onboarding.status(user)
     end

--- a/test/engram/request_path_tenant_scope_test.exs
+++ b/test/engram/request_path_tenant_scope_test.exs
@@ -32,7 +32,7 @@ defmodule Engram.RequestPathTenantScopeTest do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Vaults.create_vault(user, %{name: "RequestScope"})
+    {:ok, vault, _} = Vaults.register_vault(user, "RequestScope", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/search_integration_test.exs
+++ b/test/engram/search_integration_test.exs
@@ -10,7 +10,9 @@ defmodule Engram.SearchIntegrationTest do
     user = insert(:user)
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "SearchIntegration"})
+
+    {:ok, vault, _} =
+      Engram.Vaults.register_vault(user, "SearchIntegration", Ecto.UUID.generate())
 
     # Use a test-isolated Qdrant collection so we can drop it after.
     col = "engram_test_#{System.unique_integer([:positive])}"

--- a/test/engram/vault_isolation_test.exs
+++ b/test/engram/vault_isolation_test.exs
@@ -14,8 +14,8 @@ defmodule Engram.VaultIsolationTest do
     # Phase B reads derive a filter key from the user's DEK — provision upfront.
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
 
-    {:ok, vault_a} = Vaults.create_vault(user, %{name: "Personal"})
-    {:ok, vault_b} = Vaults.create_vault(user, %{name: "Work"})
+    {:ok, vault_a, _} = Vaults.register_vault(user, "Personal", Ecto.UUID.generate())
+    {:ok, vault_b, _} = Vaults.register_vault(user, "Work", Ecto.UUID.generate())
 
     %{user: user, vault_a: vault_a, vault_b: vault_b}
   end

--- a/test/engram/vaults_seq_test.exs
+++ b/test/engram/vaults_seq_test.exs
@@ -7,7 +7,7 @@ defmodule Engram.VaultsSeqTest do
     user = insert_user()
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Vaults.register_vault(user, "Test", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 
@@ -26,7 +26,7 @@ defmodule Engram.VaultsSeqTest do
   end
 
   test "next_seq! is isolated per vault", %{user: user, vault: vault_a} do
-    {:ok, vault_b} = Vaults.create_vault(user, %{name: "B"})
+    {:ok, vault_b, _} = Vaults.register_vault(user, "B", Ecto.UUID.generate())
     {:ok, a1} = Repo.with_tenant(user.id, fn -> Vaults.next_seq!(vault_a.id) end)
     {:ok, b1} = Repo.with_tenant(user.id, fn -> Vaults.next_seq!(vault_b.id) end)
     {:ok, a2} = Repo.with_tenant(user.id, fn -> Vaults.next_seq!(vault_a.id) end)

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -17,32 +17,36 @@ defmodule Engram.VaultsTest do
   # only path to a vault name now, exercised throughout the rest of the suite.
 
   # ---------------------------------------------------------------------------
-  # create_vault/2
+  # register_vault/4
   # ---------------------------------------------------------------------------
 
-  describe "create_vault/2" do
+  describe "register_vault/4" do
     test "creates a vault with generated slug", %{user: user} do
-      assert {:ok, vault} = Vaults.create_vault(user, %{name: "My Notes"})
+      assert {:ok, vault, _} = Vaults.register_vault(user, "My Notes", Ecto.UUID.generate())
       assert vault.name == "My Notes"
       assert vault.slug == "my-notes"
       assert vault.user_id == user.id
     end
 
     test "first vault is set as default", %{user: user} do
-      assert {:ok, vault} = Vaults.create_vault(user, %{name: "First"})
+      assert {:ok, vault, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
       assert vault.is_default == true
     end
 
     test "ignores unknown string keys instead of crashing", %{user: user} do
-      # Controller feeds raw params straight in; an attacker-supplied key that
-      # is not an existing atom must not raise (String.to_existing_atom).
-      attrs = %{"name" => "Notes", "__definitely_not_a_field__" => "x"}
-      assert {:ok, vault} = Vaults.create_vault(user, attrs)
+      # `extra_attrs` may carry raw params; an attacker-supplied key that is
+      # not an existing atom must not raise (String.to_existing_atom).
+      extra = %{"description" => "Notes", "__definitely_not_a_field__" => "x"}
+
+      assert {:ok, vault, _} =
+               Vaults.register_vault(user, "Notes", Ecto.UUID.generate(), extra)
+
       assert vault.name == "Notes"
+      assert vault.description == "Notes"
     end
 
     test "second vault is not default", %{user: user} do
-      {:ok, _} = Vaults.create_vault(user, %{name: "First"})
+      {:ok, _, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
 
       # Give the second user unlimited vaults via user_overrides or just test default (1) blocks
       # Override the limit so we can insert a second vault. The first create
@@ -51,55 +55,55 @@ defmodule Engram.VaultsTest do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
       :ok = OverrideCache.evict(user.id)
 
-      assert {:ok, vault2} = Vaults.create_vault(user, %{name: "Second"})
+      assert {:ok, vault2, _} = Vaults.register_vault(user, "Second", Ecto.UUID.generate())
       assert vault2.is_default == false
     end
 
     test "enforces default billing limit of 1", %{user: user} do
-      {:ok, _} = Vaults.create_vault(user, %{name: "First"})
+      {:ok, _, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
 
       assert {:error, {:vault_limit_reached, 1, 1}} =
-               Vaults.create_vault(user, %{name: "Second"})
+               Vaults.register_vault(user, "Second", Ecto.UUID.generate())
     end
 
     test "unlimited override (-1) allows any number of vaults", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
 
-      {:ok, _} = Vaults.create_vault(user, %{name: "First"})
-      {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
-      {:ok, _} = Vaults.create_vault(user, %{name: "Third"})
+      {:ok, _, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
+      {:ok, _, _} = Vaults.register_vault(user, "Second", Ecto.UUID.generate())
+      {:ok, _, _} = Vaults.register_vault(user, "Third", Ecto.UUID.generate())
     end
 
     test "specific override enforces that exact limit", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 2})
 
-      {:ok, _} = Vaults.create_vault(user, %{name: "First"})
-      {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
+      {:ok, _, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
+      {:ok, _, _} = Vaults.register_vault(user, "Second", Ecto.UUID.generate())
 
       assert {:error, {:vault_limit_reached, 2, 2}} =
-               Vaults.create_vault(user, %{name: "Third"})
+               Vaults.register_vault(user, "Third", Ecto.UUID.generate())
     end
 
     test "override upgrade: blocked by default, then lifted", %{user: user} do
-      {:ok, _} = Vaults.create_vault(user, %{name: "First"})
+      {:ok, _, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
 
       assert {:error, {:vault_limit_reached, 1, 1}} =
-               Vaults.create_vault(user, %{name: "Second"})
+               Vaults.register_vault(user, "Second", Ecto.UUID.generate())
 
       # Lift the limit via per-user override. Earlier creates cached the
       # override MISS — evict so the grant is visible immediately.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
       :ok = OverrideCache.evict(user.id)
 
-      {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
-      {:ok, _} = Vaults.create_vault(user, %{name: "Third"})
+      {:ok, _, _} = Vaults.register_vault(user, "Second", Ecto.UUID.generate())
+      {:ok, _, _} = Vaults.register_vault(user, "Third", Ecto.UUID.generate())
     end
 
     test "deduplicates slug collision with numeric suffix", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "Notes"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "Notes"})
+      {:ok, v1, _} = Vaults.register_vault(user, "Notes", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "Notes", Ecto.UUID.generate())
 
       assert v1.slug == "notes"
       assert v2.slug == "notes-2"
@@ -108,9 +112,9 @@ defmodule Engram.VaultsTest do
     test "slug with triple collision gets -3 suffix", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, _} = Vaults.create_vault(user, %{name: "Notes"})
-      {:ok, _} = Vaults.create_vault(user, %{name: "Notes"})
-      {:ok, v3} = Vaults.create_vault(user, %{name: "Notes"})
+      {:ok, _, _} = Vaults.register_vault(user, "Notes", Ecto.UUID.generate())
+      {:ok, _, _} = Vaults.register_vault(user, "Notes", Ecto.UUID.generate())
+      {:ok, v3, _} = Vaults.register_vault(user, "Notes", Ecto.UUID.generate())
 
       assert v3.slug == "notes-3"
     end
@@ -123,49 +127,66 @@ defmodule Engram.VaultsTest do
       # rejection here would be a dead end: "Settings" always slugifies to
       # "settings" and the user has no field to fix. Route reserved words
       # through the same dedup path as a taken slug.
-      assert {:ok, vault} = Vaults.create_vault(user, %{name: "Settings"})
+      assert {:ok, vault, _} = Vaults.register_vault(user, "Settings", Ecto.UUID.generate())
       assert vault.slug == "settings-2"
     end
 
     test "slug strips special characters", %{user: user} do
-      assert {:ok, vault} = Vaults.create_vault(user, %{name: "My Vault!"})
+      assert {:ok, vault, _} = Vaults.register_vault(user, "My Vault!", Ecto.UUID.generate())
       assert vault.slug == "my-vault"
     end
 
     test "empty slug falls back to 'vault'", %{user: user} do
-      assert {:ok, vault} = Vaults.create_vault(user, %{name: "!!!"})
+      assert {:ok, vault, _} = Vaults.register_vault(user, "!!!", Ecto.UUID.generate())
       assert vault.slug == "vault"
     end
 
-    test "description and client_id are optional", %{user: user} do
-      assert {:ok, vault} =
-               Vaults.create_vault(user, %{
-                 name: "Work",
-                 description: "Work notes",
-                 client_id: "client-abc"
-               })
+    test "description rides along in extra_attrs", %{user: user} do
+      assert {:ok, vault, _} =
+               Vaults.register_vault(user, "Work", "client-abc", %{description: "Work notes"})
 
       assert vault.description == "Work notes"
       assert vault.client_id == "client-abc"
+    end
+
+    test "extra_attrs cannot override the computed columns", %{user: user} do
+      # name/client_id/slug/user_id/is_default are derived, not caller input —
+      # a caller that smuggles them through extra_attrs must not win.
+      other = insert(:user)
+
+      assert {:ok, vault, _} =
+               Vaults.register_vault(user, "Real", "cid-real", %{
+                 name: "Spoofed",
+                 client_id: "cid-spoofed",
+                 slug: "spoofed",
+                 user_id: other.id,
+                 is_default: false
+               })
+
+      assert vault.name == "Real"
+      assert vault.client_id == "cid-real"
+      assert vault.slug == "real"
+      assert vault.user_id == user.id
+      assert vault.is_default == true
     end
 
     test "requires a name", %{user: user} do
       # Phase B.3: name is virtual — a missing name means the encrypted trio
       # never gets injected, and the changeset surfaces that on the public
       # `name` field (never the internal ciphertext/nonce/hmac column names).
-      assert {:error, changeset} = Vaults.create_vault(user, %{})
+      assert {:error, changeset} = Vaults.register_vault(user, "", Ecto.UUID.generate())
       errors = errors_on(changeset)
       assert errors[:name] == ["can't be blank"]
       refute Map.has_key?(errors, :name_ciphertext)
     end
 
     test "rejects a blank name", %{user: user} do
-      assert {:error, changeset} = Vaults.create_vault(user, %{name: "   "})
+      assert {:error, changeset} = Vaults.register_vault(user, "   ", Ecto.UUID.generate())
       assert errors_on(changeset)[:name] == ["can't be blank"]
     end
 
     test "update_vault rejects a blank name without touching the slug", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Keep Me"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Keep Me", Ecto.UUID.generate())
 
       assert {:error, changeset} = Vaults.update_vault(user, vault.id, %{name: ""})
       assert errors_on(changeset)[:name] == ["can't be blank"]
@@ -183,8 +204,8 @@ defmodule Engram.VaultsTest do
   describe "content_counts_for/2 and content_counts/2" do
     setup %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, a} = Vaults.create_vault(user, %{name: "Alpha"})
-      {:ok, b} = Vaults.create_vault(user, %{name: "Beta"})
+      {:ok, a, _} = Vaults.register_vault(user, "Alpha", Ecto.UUID.generate())
+      {:ok, b, _} = Vaults.register_vault(user, "Beta", Ecto.UUID.generate())
       %{a: a, b: b}
     end
 
@@ -310,8 +331,8 @@ defmodule Engram.VaultsTest do
     test "returns all non-deleted vaults for user", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "A"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "B"})
+      {:ok, v1, _} = Vaults.register_vault(user, "A", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "B", Ecto.UUID.generate())
 
       vaults = Vaults.list_vaults(user)
       ids = Enum.map(vaults, & &1.id)
@@ -322,8 +343,8 @@ defmodule Engram.VaultsTest do
     test "excludes soft-deleted vaults", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "Keep"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "Delete"})
+      {:ok, v1, _} = Vaults.register_vault(user, "Keep", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "Delete", Ecto.UUID.generate())
       Vaults.delete_vault(user, v2.id)
 
       vaults = Vaults.list_vaults(user)
@@ -333,8 +354,8 @@ defmodule Engram.VaultsTest do
     end
 
     test "does not return other user's vaults", %{user: user, other_user: other_user} do
-      {:ok, my_vault} = Vaults.create_vault(user, %{name: "Mine"})
-      {:ok, their_vault} = Vaults.create_vault(other_user, %{name: "Theirs"})
+      {:ok, my_vault, _} = Vaults.register_vault(user, "Mine", Ecto.UUID.generate())
+      {:ok, their_vault, _} = Vaults.register_vault(other_user, "Theirs", Ecto.UUID.generate())
 
       my_list = Vaults.list_vaults(user)
       their_list = Vaults.list_vaults(other_user)
@@ -348,12 +369,12 @@ defmodule Engram.VaultsTest do
     test "returns vaults ordered by inserted_at ascending", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "Alpha"})
+      {:ok, v1, _} = Vaults.register_vault(user, "Alpha", Ecto.UUID.generate())
       # 1.1s gap ensures distinct second-precision `created_at` timestamps so the
       # secondary `v.id` ordering doesn't race with UUIDv7 sub-millisecond
       # tiebreaker randomness.
       Process.sleep(1100)
-      {:ok, v2} = Vaults.create_vault(user, %{name: "Beta"})
+      {:ok, v2, _} = Vaults.register_vault(user, "Beta", Ecto.UUID.generate())
 
       [first, second | _] = Vaults.list_vaults(user)
       assert first.id == v1.id
@@ -368,8 +389,8 @@ defmodule Engram.VaultsTest do
     end
 
     test "returns only soft-deleted vaults, newest-deleted first", %{user: user} do
-      {:ok, keep} = Vaults.create_vault(user, %{name: "Keep"})
-      {:ok, gone} = Vaults.create_vault(user, %{name: "Gone"})
+      {:ok, keep, _} = Vaults.register_vault(user, "Keep", Ecto.UUID.generate())
+      {:ok, gone, _} = Vaults.register_vault(user, "Gone", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, gone.id)
 
       deleted = Vaults.list_deleted_vaults(user)
@@ -381,8 +402,8 @@ defmodule Engram.VaultsTest do
 
     test "excludes other users' deleted vaults", %{user: user, other_user: other} do
       insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, mine} = Vaults.create_vault(user, %{name: "Mine"})
-      {:ok, theirs} = Vaults.create_vault(other, %{name: "Theirs"})
+      {:ok, mine, _} = Vaults.register_vault(user, "Mine", Ecto.UUID.generate())
+      {:ok, theirs, _} = Vaults.register_vault(other, "Theirs", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, mine.id)
       {:ok, _} = Vaults.delete_vault(other, theirs.id)
 
@@ -393,7 +414,7 @@ defmodule Engram.VaultsTest do
   describe "restore_vault/2" do
     test "clears deleted_at and returns the vault", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, v} = Vaults.create_vault(user, %{name: "Temp"})
+      {:ok, v, _} = Vaults.register_vault(user, "Temp", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
 
       assert {:ok, restored} = Vaults.restore_vault(user, v.id)
@@ -405,9 +426,9 @@ defmodule Engram.VaultsTest do
 
     test "blocks restore when it would exceed the vault cap", %{user: user} do
       # Cap of 1: create one, delete it, create a replacement, then try to restore.
-      {:ok, first} = Vaults.create_vault(user, %{name: "First"})
+      {:ok, first, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, first.id)
-      {:ok, _replacement} = Vaults.create_vault(user, %{name: "Replacement"})
+      {:ok, _replacement, _} = Vaults.register_vault(user, "Replacement", Ecto.UUID.generate())
 
       assert {:error, {:limit_reached, 1, 1}} = Vaults.restore_vault(user, first.id)
       # Blocked restore leaves the vault soft-deleted: it stays in the trash
@@ -418,13 +439,13 @@ defmodule Engram.VaultsTest do
 
     test "returns :not_found for an active vault", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      {:ok, v, _} = Vaults.register_vault(user, "Active", Ecto.UUID.generate())
       assert {:error, :not_found} = Vaults.restore_vault(user, v.id)
     end
 
     test "returns :not_found for another user's deleted vault", %{user: user, other_user: other} do
       insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, v} = Vaults.create_vault(other, %{name: "Theirs"})
+      {:ok, v, _} = Vaults.register_vault(other, "Theirs", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(other, v.id)
       assert {:error, :not_found} = Vaults.restore_vault(user, v.id)
     end
@@ -439,7 +460,7 @@ defmodule Engram.VaultsTest do
   describe "purge_vault/2" do
     test "enqueues an immediate force cleanup for a soft-deleted vault", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, v} = Vaults.create_vault(user, %{name: "Doomed"})
+      {:ok, v, _} = Vaults.register_vault(user, "Doomed", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
 
       assert {:ok, vault} = Vaults.purge_vault(user, v.id)
@@ -453,7 +474,7 @@ defmodule Engram.VaultsTest do
 
     test "returns :not_found for an active vault", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      {:ok, v, _} = Vaults.register_vault(user, "Active", Ecto.UUID.generate())
       assert {:error, :not_found} = Vaults.purge_vault(user, v.id)
       refute_enqueued(worker: Engram.Workers.CleanupVault)
     end
@@ -465,7 +486,7 @@ defmodule Engram.VaultsTest do
 
   describe "get_vault/2" do
     test "returns {:ok, vault} for owned vault", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Mine"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Mine", Ecto.UUID.generate())
       assert {:ok, found} = Vaults.get_vault(user, vault.id)
       assert found.id == vault.id
     end
@@ -484,14 +505,14 @@ defmodule Engram.VaultsTest do
       user: user,
       other_user: other_user
     } do
-      {:ok, their_vault} = Vaults.create_vault(other_user, %{name: "Theirs"})
+      {:ok, their_vault, _} = Vaults.register_vault(other_user, "Theirs", Ecto.UUID.generate())
       assert {:error, :not_found} = Vaults.get_vault(user, their_vault.id)
     end
 
     test "returns {:error, :not_found} for soft-deleted vault", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Gone"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Gone", Ecto.UUID.generate())
       Vaults.delete_vault(user, vault.id)
       assert {:error, :not_found} = Vaults.get_vault(user, vault.id)
     end
@@ -503,7 +524,7 @@ defmodule Engram.VaultsTest do
 
   describe "get_default_vault/1" do
     test "returns the default vault", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Default"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Default", Ecto.UUID.generate())
       assert {:ok, found} = Vaults.get_default_vault(user)
       assert found.id == vault.id
     end
@@ -519,7 +540,7 @@ defmodule Engram.VaultsTest do
 
   describe "update_vault/3" do
     test "updates name and description", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Old Name"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Old Name", Ecto.UUID.generate())
 
       assert {:ok, updated} =
                Vaults.update_vault(user, vault.id, %{name: "New Name", description: "Desc"})
@@ -529,7 +550,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "regenerates slug when name changes", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Original"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Original", Ecto.UUID.generate())
       assert vault.slug == "original"
 
       assert {:ok, updated} = Vaults.update_vault(user, vault.id, %{name: "Renamed Vault"})
@@ -539,7 +560,7 @@ defmodule Engram.VaultsTest do
     test "renaming into a reserved word gets a numeric suffix instead of being rejected", %{
       user: user
     } do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Original"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Original", Ecto.UUID.generate())
 
       assert {:ok, updated} = Vaults.update_vault(user, vault.id, %{name: "Search"})
       assert updated.slug == "search-2"
@@ -548,8 +569,8 @@ defmodule Engram.VaultsTest do
     test "setting is_default clears other defaults", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "First"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "Second"})
+      {:ok, v1, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "Second", Ecto.UUID.generate())
       assert v1.is_default == true
       assert v2.is_default == false
 
@@ -579,7 +600,7 @@ defmodule Engram.VaultsTest do
       Process.flag(:trap_exit, true)
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
       {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Rooms"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Rooms", Ecto.UUID.generate())
 
       {:ok, note} =
         Engram.Notes.upsert_note(user, vault, %{
@@ -615,7 +636,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "soft-deletes vault by setting deleted_at", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Temp"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Temp", Ecto.UUID.generate())
       assert {:ok, deleted} = Vaults.delete_vault(user, vault.id)
       assert deleted.deleted_at != nil
       assert deleted.is_default == false
@@ -624,8 +645,8 @@ defmodule Engram.VaultsTest do
     test "promotes next vault to default when default is deleted", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "First"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "Second"})
+      {:ok, v1, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "Second", Ecto.UUID.generate())
       assert v1.is_default == true
 
       Vaults.delete_vault(user, v1.id)
@@ -642,8 +663,8 @@ defmodule Engram.VaultsTest do
     test "does not promote when non-default vault is deleted", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "First"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "Second"})
+      {:ok, v1, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "Second", Ecto.UUID.generate())
 
       Vaults.delete_vault(user, v2.id)
 
@@ -657,7 +678,7 @@ defmodule Engram.VaultsTest do
 
     test "delete_vault enqueues the deletion-notice email", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, v} = Vaults.create_vault(user, %{name: "Bye"})
+      {:ok, v, _} = Vaults.register_vault(user, "Bye", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
 
       assert_enqueued(
@@ -668,8 +689,8 @@ defmodule Engram.VaultsTest do
 
     test "revokes vault-scoped OAuth and device tokens on soft-delete", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, gone} = Vaults.create_vault(user, %{name: "Gone"})
-      {:ok, kept} = Vaults.create_vault(user, %{name: "Kept"})
+      {:ok, gone, _} = Vaults.register_vault(user, "Gone", Ecto.UUID.generate())
+      {:ok, kept, _} = Vaults.register_vault(user, "Kept", Ecto.UUID.generate())
       client = insert(:oauth_client, kind: "mcp")
 
       # Connections on the doomed vault…
@@ -710,19 +731,19 @@ defmodule Engram.VaultsTest do
 
   describe "check_api_key_access/2" do
     test "nil api_key (JWT auth) always returns :ok", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, vault, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
       assert :ok = Vaults.check_api_key_access(nil, vault)
     end
 
     test "unrestricted key (no api_key_vaults rows) returns :ok", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, vault, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
       {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "unrestricted")
 
       assert :ok = Vaults.check_api_key_access(api_key, vault)
     end
 
     test "restricted key with matching vault returns :ok", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, vault, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
       {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "restricted")
 
       Engram.Repo.insert_all("api_key_vaults", [
@@ -736,8 +757,8 @@ defmodule Engram.VaultsTest do
       user: user,
       other_user: other_user
     } do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "V"})
-      {:ok, other_vault} = Vaults.create_vault(other_user, %{name: "Other"})
+      {:ok, vault, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
+      {:ok, other_vault, _} = Vaults.register_vault(other_user, "Other", Ecto.UUID.generate())
       {:ok, _raw, api_key} = Engram.Accounts.create_api_key(user, "restricted")
 
       # Restrict to other vault only
@@ -818,8 +839,8 @@ defmodule Engram.VaultsTest do
       %{user: user}
     end
 
-    test "create_vault populates name_hmac/ciphertext/nonce", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "client-acme"})
+    test "register_vault populates name_hmac/ciphertext/nonce", %{user: user} do
+      {:ok, vault, _} = Vaults.register_vault(user, "client-acme", Ecto.UUID.generate())
 
       {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
       expected_hmac = Engram.Crypto.hmac_field(filter_key, "client-acme")
@@ -831,7 +852,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "update_vault re-encrypts name on change", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "old-name"})
+      {:ok, vault, _} = Vaults.register_vault(user, "old-name", Ecto.UUID.generate())
       {:ok, updated} = Vaults.update_vault(user, vault.id, %{name: "new-name"})
 
       {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
@@ -861,8 +882,8 @@ defmodule Engram.VaultsTest do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
       same_time = DateTime.utc_now(:second)
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "vault-order-a"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "vault-order-b"})
+      {:ok, v1, _} = Vaults.register_vault(user, "vault-order-a", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "vault-order-b", Ecto.UUID.generate())
 
       # Force both vaults to the same created_at timestamp via Repo.update_all
       Engram.Repo.update_all(
@@ -882,9 +903,9 @@ defmodule Engram.VaultsTest do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
       same_time = DateTime.utc_now(:second)
 
-      {:ok, v1} = Vaults.create_vault(user, %{name: "alpha"})
-      {:ok, v2} = Vaults.create_vault(user, %{name: "beta"})
-      {:ok, v3} = Vaults.create_vault(user, %{name: "gamma"})
+      {:ok, v1, _} = Vaults.register_vault(user, "alpha", Ecto.UUID.generate())
+      {:ok, v2, _} = Vaults.register_vault(user, "beta", Ecto.UUID.generate())
+      {:ok, v3, _} = Vaults.register_vault(user, "gamma", Ecto.UUID.generate())
 
       Engram.Repo.update_all(
         Ecto.Query.from(v in Engram.Vaults.Vault,
@@ -917,14 +938,14 @@ defmodule Engram.VaultsTest do
     # routes to self(); concurrent async tests firing :vault_count also land
     # in this test's mailbox. Pin user_id in every pattern so we only match
     # our own user's events.
-    test "emits :vault_count on create_vault success", %{user: user} do
+    test "emits :vault_count on vault creation", %{user: user} do
       user_id = user.id
-      assert {:ok, _} = Vaults.create_vault(user, %{name: "V1"})
+      assert {:ok, _, _} = Vaults.register_vault(user, "V1", Ecto.UUID.generate())
 
       assert_received {[:engram, :abuse, :vault_count], _ref, %{count: 1},
                        %{user_id: ^user_id, op: :created}}
 
-      assert {:ok, _} = Vaults.create_vault(user, %{name: "V2"})
+      assert {:ok, _, _} = Vaults.register_vault(user, "V2", Ecto.UUID.generate())
 
       assert_received {[:engram, :abuse, :vault_count], _, %{count: 2},
                        %{user_id: ^user_id, op: :created}}
@@ -932,7 +953,7 @@ defmodule Engram.VaultsTest do
 
     test "emits :vault_count on delete_vault success", %{user: user} do
       user_id = user.id
-      {:ok, v} = Vaults.create_vault(user, %{name: "V1"})
+      {:ok, v, _} = Vaults.register_vault(user, "V1", Ecto.UUID.generate())
       drain_vault_count_messages()
 
       assert {:ok, _} = Vaults.delete_vault(user, v.id)
@@ -958,22 +979,22 @@ defmodule Engram.VaultsTest do
     end
   end
 
-  describe "create_vault/2 onboarding hook" do
+  describe "register_vault/4 onboarding hook" do
     test "records first_vault_created on first vault" do
       user = insert(:user)
       assert [] = Engram.Onboarding.list_actions(user.id)
 
-      {:ok, _v} = Engram.Vaults.create_vault(user, %{name: "Main"})
+      {:ok, _v, _} = Engram.Vaults.register_vault(user, "Main", Ecto.UUID.generate())
       assert ["first_vault_created"] = Engram.Onboarding.list_actions(user.id)
     end
 
     test "second vault does not double-record" do
       user = insert(:user)
-      {:ok, _} = Engram.Vaults.create_vault(user, %{name: "Main"})
+      {:ok, _, _} = Engram.Vaults.register_vault(user, "Main", Ecto.UUID.generate())
       # First create cached the override MISS — evict so the grant lands.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
       :ok = OverrideCache.evict(user.id)
-      {:ok, _} = Engram.Vaults.create_vault(user, %{name: "Second"})
+      {:ok, _, _} = Engram.Vaults.register_vault(user, "Second", Ecto.UUID.generate())
 
       assert ["first_vault_created"] = Engram.Onboarding.list_actions(user.id)
     end

--- a/test/engram/workers/backfill_content_hash_hmac_test.exs
+++ b/test/engram/workers/backfill_content_hash_hmac_test.exs
@@ -24,7 +24,7 @@ defmodule Engram.Workers.BackfillContentHashHmacTest do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "BackfillTest"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "BackfillTest", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/workers/backfill_crdt_head_test.exs
+++ b/test/engram/workers/backfill_crdt_head_test.exs
@@ -10,7 +10,7 @@ defmodule Engram.Workers.BackfillCrdtHeadTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "BackfillTest"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "BackfillTest", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 
@@ -119,7 +119,9 @@ defmodule Engram.Workers.BackfillCrdtHeadTest do
       other = insert(:user)
       insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => -1})
       {:ok, other} = Engram.Crypto.ensure_user_dek(other)
-      {:ok, other_vault} = Engram.Vaults.create_vault(other, %{name: "OtherVault"})
+
+      {:ok, other_vault, _} =
+        Engram.Vaults.register_vault(other, "OtherVault", Ecto.UUID.generate())
 
       {:ok, _} =
         Notes.upsert_note(other, other_vault, %{path: "B/y.md", content: "# Y", mtime: 1.0})

--- a/test/engram/workers/backfill_crdt_state_test.exs
+++ b/test/engram/workers/backfill_crdt_state_test.exs
@@ -13,7 +13,7 @@ defmodule Engram.Workers.BackfillCrdtStateTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "BackfillCrdtStateTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "BackfillCrdtStateTest", Ecto.UUID.generate())
     %{user: user, vault: vault}
   end
 

--- a/test/engram/workers/backfill_note_links_test.exs
+++ b/test/engram/workers/backfill_note_links_test.exs
@@ -21,7 +21,7 @@ defmodule Engram.Workers.BackfillNoteLinksTest do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "BackfillTest"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "BackfillTest", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/workers/cleanup_vault_test.exs
+++ b/test/engram/workers/cleanup_vault_test.exs
@@ -40,7 +40,7 @@ defmodule Engram.Workers.CleanupVaultTest do
 
     test "enqueue/2 is called when delete_vault soft-deletes" do
       user = insert(:user)
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Temp Vault"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Temp Vault", Ecto.UUID.generate())
 
       assert {:ok, _deleted} = Vaults.delete_vault(user, vault.id)
 
@@ -302,13 +302,13 @@ defmodule Engram.Workers.CleanupVaultTest do
     end
 
     test "skips when the vault was restored (deleted_at nil)", %{user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, v, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
       assert :ok = CleanupVault.perform_cleanup(v.id, user.id)
       assert Repo.get(Vault, v.id, skip_tenant_check: true)
     end
 
     test "snoozes when deleted_at is younger than 30 days", %{user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, v, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
       backdate_deleted_at(v.id, 5)
 
@@ -319,7 +319,7 @@ defmodule Engram.Workers.CleanupVaultTest do
 
     test "purges when deleted_at is older than 30 days", %{bypass: bypass, user: user} do
       stub_qdrant_ack(bypass)
-      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, v, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
       backdate_deleted_at(v.id, 31)
 
@@ -329,7 +329,7 @@ defmodule Engram.Workers.CleanupVaultTest do
 
     test "force purges immediately regardless of age", %{bypass: bypass, user: user} do
       stub_qdrant_ack(bypass)
-      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, v, _} = Vaults.register_vault(user, "V", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
       # freshly deleted (age ~0) but force=true
 

--- a/test/engram/workers/project_vault_index_test.exs
+++ b/test/engram/workers/project_vault_index_test.exs
@@ -32,7 +32,7 @@ defmodule Engram.Workers.ProjectVaultIndexTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "ProjectionTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "ProjectionTest", Ecto.UUID.generate())
 
     %{user: user, vault: vault}
   end

--- a/test/engram/workers/reconcile_embeddings_test.exs
+++ b/test/engram/workers/reconcile_embeddings_test.exs
@@ -54,7 +54,7 @@ defmodule Engram.Workers.ReconcileEmbeddingsTest do
       user = insert(:user)
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
       {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
 
       {:ok, marker} = Engram.Notes.create_folder_marker(user, vault, "Empty")
       # Sanity: marker has nil embed_hash, so the unfiltered query would pick it up.

--- a/test/engram/workers/reindex_keyword_test.exs
+++ b/test/engram/workers/reindex_keyword_test.exs
@@ -36,7 +36,7 @@ defmodule Engram.Workers.ReindexKeywordTest do
     insert(:user_limit_override, user: build(:user), key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Engram.Crypto.ensure_user_dek(insert(:user))
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test", Ecto.UUID.generate())
 
     note = insert(:note, user: user, vault: vault)
     {:ok, marker} = Engram.Notes.create_folder_marker(user, vault, "Docs")

--- a/test/engram/workers/vault_deleted_email_test.exs
+++ b/test/engram/workers/vault_deleted_email_test.exs
@@ -26,7 +26,7 @@ defmodule Engram.Workers.VaultDeletedEmailTest do
   end
 
   test "perform sends the notice for a soft-deleted vault", %{user: user} do
-    {:ok, v} = Vaults.create_vault(user, %{name: "Gone"})
+    {:ok, v, _} = Vaults.register_vault(user, "Gone", Ecto.UUID.generate())
     {:ok, _} = Vaults.delete_vault(user, v.id)
 
     expect(Engram.Email.ProviderMock, :send, 1, fn to, subject, _html, _opts ->
@@ -40,7 +40,7 @@ defmodule Engram.Workers.VaultDeletedEmailTest do
   end
 
   test "perform is a no-op when the vault was restored before send", %{user: user} do
-    {:ok, v} = Vaults.create_vault(user, %{name: "Restored"})
+    {:ok, v, _} = Vaults.register_vault(user, "Restored", Ecto.UUID.generate())
     {:ok, _} = Vaults.delete_vault(user, v.id)
 
     # Restore the vault (clear deleted_at) before the job runs.
@@ -63,7 +63,7 @@ defmodule Engram.Workers.VaultDeletedEmailTest do
 
   test "manage_url keeps the query ahead of the fragment so location.search can parse it",
        %{user: user} do
-    {:ok, v} = Vaults.create_vault(user, %{name: "Gone"})
+    {:ok, v, _} = Vaults.register_vault(user, "Gone", Ecto.UUID.generate())
     {:ok, _} = Vaults.delete_vault(user, v.id)
 
     expect(Engram.Email.ProviderMock, :send, 1, fn _to, _subject, html, _opts ->

--- a/test/engram_web/api_spec_test.exs
+++ b/test/engram_web/api_spec_test.exs
@@ -192,15 +192,13 @@ defmodule EngramWeb.ApiSpecTest do
       assert Map.has_key?(op.responses, 200)
     end
 
-    test "POST /api/vaults documents request + 201/402/422", %{spec: spec} do
-      op = spec.paths["/api/vaults"].post
-      assert op.tags == ["Vaults"]
-      assert op.requestBody
-      assert Enum.sort(Map.keys(op.responses)) == [201, 402, 422]
+    test "POST /api/vaults is gone — register is the only create endpoint", %{spec: spec} do
+      refute spec.paths["/api/vaults"].post
     end
 
     test "POST /api/vaults/register documents request + 200/201/400/402/422", %{spec: spec} do
       op = spec.paths["/api/vaults/register"].post
+      assert op.tags == ["Vaults"]
       assert op.requestBody
       # 422 joins the set with the blank-name fix: a name that is present but
       # blank clears the is_nil guard and fails the changeset, which the

--- a/test/engram_web/channels/crdt_channel_drain_test.exs
+++ b/test/engram_web/channels/crdt_channel_drain_test.exs
@@ -32,7 +32,7 @@ defmodule EngramWeb.CrdtChannelDrainTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtChannelDrainTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtChannelDrainTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "base"})
 
     {:ok, _, socket} =

--- a/test/engram_web/channels/crdt_channel_origin_test.exs
+++ b/test/engram_web/channels/crdt_channel_origin_test.exs
@@ -16,7 +16,7 @@ defmodule EngramWeb.CrdtChannelOriginTest do
 
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtOriginTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtOriginTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "Old.md", "content" => "# t"})
     %{user: user, vault: vault, note: note}
   end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -20,7 +20,7 @@ defmodule EngramWeb.CrdtChannelTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtChannelTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "CrdtChannelTest", Ecto.UUID.generate())
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "base"})
     other_user = insert(:user)
     {:ok, other_user} = Crypto.ensure_user_dek(other_user)
@@ -1047,7 +1047,8 @@ defmodule EngramWeb.CrdtChannelTest do
       # id, so every re-minted entry fell into the create_failed arm, its content
       # frame was dropped, and the row committed EMPTY. Asserting the content (not
       # just the status) is what makes this a real regression test.
-      {:ok, other_vault} = Vaults.create_vault(user, %{name: "CrdtChannelTestB"})
+      {:ok, other_vault, _} =
+        Vaults.register_vault(user, "CrdtChannelTestB", Ecto.UUID.generate())
 
       {:ok, foreign} =
         Notes.upsert_note(user, other_vault, %{"path" => "Copied.md", "content" => "vault B body"})
@@ -1289,7 +1290,10 @@ defmodule EngramWeb.CrdtChannelTest do
 
     test "rejects join for vault belonging to another user", %{user: user, other_user: other_user} do
       insert(:user_limit_override, user: other_user, key: "vaults_cap", value: %{"v" => -1})
-      {:ok, other_vault} = Vaults.create_vault(other_user, %{name: "OtherVault"})
+
+      {:ok, other_vault, _} =
+        Vaults.register_vault(other_user, "OtherVault", Ecto.UUID.generate())
+
       socket = user_socket(user)
 
       assert {:error, %{reason: "vault_not_found"}} =
@@ -1897,7 +1901,7 @@ defmodule EngramWeb.CrdtChannelTest do
       # Attacker (other_user) forges device_id to the VICTIM's user id, trying to
       # land in the victim's rate bucket, and hammers from their OWN vault.
       insert(:user_limit_override, user: other_user, key: "vaults_cap", value: %{"v" => -1})
-      {:ok, atk_vault} = Vaults.create_vault(other_user, %{name: "AtkVault"})
+      {:ok, atk_vault, _} = Vaults.register_vault(other_user, "AtkVault", Ecto.UUID.generate())
 
       {:ok, _, atk_sock} =
         user_socket(other_user)

--- a/test/engram_web/channels/crdt_index_channel_test.exs
+++ b/test/engram_web/channels/crdt_index_channel_test.exs
@@ -25,7 +25,7 @@ defmodule EngramWeb.CrdtIndexChannelTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "IndexChannelTest"})
+    {:ok, vault, _} = Vaults.register_vault(user, "IndexChannelTest", Ecto.UUID.generate())
 
     {:ok, _, socket} =
       subscribe_and_join(

--- a/test/engram_web/channels/crdt_index_end_to_end_test.exs
+++ b/test/engram_web/channels/crdt_index_end_to_end_test.exs
@@ -37,7 +37,7 @@ defmodule EngramWeb.CrdtIndexEndToEndTest do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
     {:ok, user} = Crypto.ensure_user_dek(user)
-    {:ok, vault} = Vaults.create_vault(user, %{name: "IndexE2E"})
+    {:ok, vault, _} = Vaults.register_vault(user, "IndexE2E", Ecto.UUID.generate())
 
     {:ok, _, socket} =
       subscribe_and_join(

--- a/test/engram_web/channels/sync_channel_test.exs
+++ b/test/engram_web/channels/sync_channel_test.exs
@@ -106,7 +106,7 @@ defmodule EngramWeb.SyncChannelTest do
 
     test "restricted key cannot join unauthorized vault", %{user: user, vault: vault} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Vault B"})
+      {:ok, vault_b, _} = Engram.Vaults.register_vault(user, "Vault B", Ecto.UUID.generate())
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-chan2")
 
       # Only grant access to vault_b — NOT the default vault

--- a/test/engram_web/channels/user_channel_test.exs
+++ b/test/engram_web/channels/user_channel_test.exs
@@ -52,21 +52,21 @@ defmodule EngramWeb.UserChannelTest do
 
   describe "vault_created broadcast" do
     test "subscriber receives vault_created when their vault is created", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Demo"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Demo", Ecto.UUID.generate())
 
       assert_broadcast "vault_created", %{vault_id: vault_id}
       assert vault_id == vault.id
     end
 
     test "subscriber does NOT receive vault_created for another user", %{other_user: other_user} do
-      {:ok, _} = Vaults.create_vault(other_user, %{name: "Other"})
+      {:ok, _, _} = Vaults.register_vault(other_user, "Other", Ecto.UUID.generate())
       refute_broadcast "vault_created", %{}, 200
     end
   end
 
   describe "vault_populated broadcast" do
     test "fires when first note is upserted into an empty vault", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Notes"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Notes", Ecto.UUID.generate())
 
       {:ok, _note} =
         Notes.upsert_note(user, vault, %{
@@ -80,7 +80,7 @@ defmodule EngramWeb.UserChannelTest do
     end
 
     test "does NOT fire on the second note in the same vault", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Notes"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Notes", Ecto.UUID.generate())
 
       {:ok, _} =
         Notes.upsert_note(user, vault, %{
@@ -110,7 +110,7 @@ defmodule EngramWeb.UserChannelTest do
       # Free tier caps vaults at 1 — lift it so this user can hold two.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
 
-      {:ok, vault_a} = Vaults.create_vault(user, %{name: "A"})
+      {:ok, vault_a, _} = Vaults.register_vault(user, "A", Ecto.UUID.generate())
 
       {:ok, _} =
         Notes.upsert_note(user, vault_a, %{
@@ -121,7 +121,7 @@ defmodule EngramWeb.UserChannelTest do
 
       assert_broadcast "vault_populated", %{}
 
-      {:ok, vault_b} = Vaults.create_vault(user, %{name: "B"})
+      {:ok, vault_b, _} = Vaults.register_vault(user, "B", Ecto.UUID.generate())
 
       {:ok, _} =
         Notes.upsert_note(user, vault_b, %{

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -8,9 +8,9 @@ defmodule EngramWeb.McpControllerTest do
   setup %{conn: conn} do
     user = insert(:user)
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    # Use the public create_vault path so name_ciphertext is real and
+    # Use the public register_vault path so name_ciphertext is real and
     # decrypts back to "Test Vault" — not random factory bytes.
-    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test Vault"})
+    {:ok, vault, _} = Engram.Vaults.register_vault(user, "Test Vault", Ecto.UUID.generate())
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
     grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
@@ -205,14 +205,14 @@ defmodule EngramWeb.McpControllerTest do
   describe "MCP multi-vault selection (#985)" do
     # Self-contained fresh user (not the single-vault main-setup user, whose
     # vaults_cap is already resolved at 1). Override is inserted BEFORE any
-    # create_vault so the cap resolves at 10 from the first call.
+    # register_vault so the cap resolves at 10 from the first call.
     setup do
       user = insert(:user)
       {:ok, user} = Engram.Crypto.ensure_user_dek(user)
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, default} = Engram.Vaults.create_vault(user, %{name: "Personal"})
-      {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Health"})
+      {:ok, default, _} = Engram.Vaults.register_vault(user, "Personal", Ecto.UUID.generate())
+      {:ok, vault_b, _} = Engram.Vaults.register_vault(user, "Health", Ecto.UUID.generate())
       {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "multi-key")
       grant_api_write!(user)
 
@@ -715,7 +715,7 @@ defmodule EngramWeb.McpControllerTest do
 
       # Override limit so user can have 2 vaults
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Vault B"})
+      {:ok, vault_b, _} = Engram.Vaults.register_vault(user, "Vault B", Ecto.UUID.generate())
 
       {:ok, api_key, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-key")
       grant_api_write!(user)
@@ -809,9 +809,9 @@ defmodule EngramWeb.McpControllerTest do
       {:ok, user} = Engram.Crypto.ensure_user_dek(user)
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
 
-      {:ok, va} = Engram.Vaults.create_vault(user, %{name: "A"})
-      {:ok, vb} = Engram.Vaults.create_vault(user, %{name: "B"})
-      {:ok, _vc} = Engram.Vaults.create_vault(user, %{name: "C"})
+      {:ok, va, _} = Engram.Vaults.register_vault(user, "A", Ecto.UUID.generate())
+      {:ok, vb, _} = Engram.Vaults.register_vault(user, "B", Ecto.UUID.generate())
+      {:ok, _vc, _} = Engram.Vaults.register_vault(user, "C", Ecto.UUID.generate())
 
       {:ok, api_key, key_rec} = Engram.Accounts.create_api_key(user, "subset-key")
       grant_api_write!(user)
@@ -850,7 +850,7 @@ defmodule EngramWeb.McpControllerTest do
       {:ok, user} = Engram.Crypto.ensure_user_dek(user)
       vault_a = insert(:vault, user: user, is_default: true, name: "A")
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
-      {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "B"})
+      {:ok, vault_b, _} = Engram.Vaults.register_vault(user, "B", Ecto.UUID.generate())
       {:ok, api_key, key_rec} = Engram.Accounts.create_api_key(user, "b-only")
       grant_api_write!(user)
 

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -311,7 +311,7 @@ defmodule EngramWeb.OnboardingControllerTest do
   describe "GET /api/onboarding/status payload extensions" do
     test "includes actions list and vault_count", %{conn: conn, user: user} do
       :ok = Engram.Onboarding.record_action(user.id, :first_vault_created)
-      {:ok, _vault} = Engram.Vaults.create_vault(user, %{name: "Demo"})
+      {:ok, _vault, _} = Engram.Vaults.register_vault(user, "Demo", Ecto.UUID.generate())
 
       resp = conn |> get("/api/onboarding/status") |> json_response(200)
 

--- a/test/engram_web/controllers/vault_tree_controller_test.exs
+++ b/test/engram_web/controllers/vault_tree_controller_test.exs
@@ -162,7 +162,7 @@ defmodule EngramWeb.VaultTreeControllerTest do
       # VaultTreeController.render_tree/5 actually does something.
       post(conn, "/api/notes", %{path: "InDefaultVault.md", content: "# d", mtime: 1_000.0})
 
-      {:ok, other_vault} = Engram.Vaults.create_vault(user, %{name: "Other"})
+      {:ok, other_vault, _} = Engram.Vaults.register_vault(user, "Other", Ecto.UUID.generate())
 
       other_vault_conn = put_req_header(conn, "x-vault-id", to_string(other_vault.id))
 

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -30,7 +30,7 @@ defmodule EngramWeb.VaultsControllerTest do
     end
 
     test "lists user's vaults", %{conn: conn, user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "My Vault"})
+      {:ok, vault, _} = Vaults.register_vault(user, "My Vault", Ecto.UUID.generate())
       conn = get(conn, "/api/vaults")
       body = json_response(conn, 200)
       ids = Enum.map(body["vaults"], & &1["id"])
@@ -40,8 +40,11 @@ defmodule EngramWeb.VaultsControllerTest do
     test "does not include vaults of other users", %{conn: conn, user: user} do
       other_user = insert(:user)
       insert(:user_limit_override, user: other_user, key: "vaults_cap", value: %{"v" => 5})
-      {:ok, other_vault} = Vaults.create_vault(other_user, %{name: "Other Vault"})
-      {:ok, _my_vault} = Vaults.create_vault(user, %{name: "My Vault"})
+
+      {:ok, other_vault, _} =
+        Vaults.register_vault(other_user, "Other Vault", Ecto.UUID.generate())
+
+      {:ok, _my_vault, _} = Vaults.register_vault(user, "My Vault", Ecto.UUID.generate())
 
       conn = get(conn, "/api/vaults")
       body = json_response(conn, 200)
@@ -154,56 +157,14 @@ defmodule EngramWeb.VaultsControllerTest do
     end
   end
 
-  describe "POST /api/vaults" do
-    test "creates a vault and returns 201", %{conn: conn} do
-      conn = post(conn, "/api/vaults", %{name: "Work Notes"})
-      body = json_response(conn, 201)
-      assert body["vault"]["name"] == "Work Notes"
-      assert is_binary(body["vault"]["id"])
-      assert is_binary(body["vault"]["slug"])
-    end
-
-    test "returns 402 when vault limit reached", %{conn: conn, user: user} do
-      # Override to limit of 1
-      Engram.Repo.delete_all(
-        from o in Engram.Billing.UserLimitOverride, where: o.user_id == ^user.id
-      )
-
-      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 1})
-      # Re-grant API access after wiping all overrides above.
-      grant_api_write!(user)
-
-      {:ok, _} = Vaults.create_vault(user, %{name: "First"})
-
-      conn = post(conn, "/api/vaults", %{name: "Second"})
-      body = json_response(conn, 402)
-      assert body["error"] == "limit_exceeded"
-      assert body["reason"] == "vaults_cap_exceeded"
-      assert body["limit_key"] == "vaults_cap"
-      assert body["limit"] == 1
-      assert body["current"] == 1
-    end
-
-    test "returns 422 with missing name", %{conn: conn} do
-      conn = post(conn, "/api/vaults", %{})
-
-      assert json_response(conn, 422) == %{
-               "errors" => %{"name" => ["can't be blank"]}
-             }
-    end
-
-    test "returns 422 with blank name", %{conn: conn} do
-      conn = post(conn, "/api/vaults", %{name: "  "})
-
-      assert json_response(conn, 422) == %{
-               "errors" => %{"name" => ["can't be blank"]}
-             }
-    end
-  end
+  # `POST /api/vaults` is gone — it created a vault per call with no
+  # idempotency key. Its coverage (201, 402, 422 blank name) now lives in the
+  # `POST /api/vaults/register` describe below, which additionally covers the
+  # duplicate-client_id 200 that made the old endpoint redundant.
 
   describe "GET /api/vaults/:id" do
     test "returns vault by id", %{conn: conn, user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Fetched"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Fetched", Ecto.UUID.generate())
       conn = get(conn, "/api/vaults/#{vault.id}")
       body = json_response(conn, 200)
       assert body["vault"]["id"] == vault.id
@@ -218,7 +179,7 @@ defmodule EngramWeb.VaultsControllerTest do
     test "returns 404 for another user's vault", %{conn: conn} do
       other_user = insert(:user)
       insert(:user_limit_override, user: other_user, key: "vaults_cap", value: %{"v" => 5})
-      {:ok, other_vault} = Vaults.create_vault(other_user, %{name: "Other"})
+      {:ok, other_vault, _} = Vaults.register_vault(other_user, "Other", Ecto.UUID.generate())
 
       conn = get(conn, "/api/vaults/#{other_vault.id}")
       assert json_response(conn, 404)
@@ -227,7 +188,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
   describe "PATCH /api/vaults/:id" do
     test "updates vault name", %{conn: conn, user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Old Name"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Old Name", Ecto.UUID.generate())
       conn = patch(conn, "/api/vaults/#{vault.id}", %{name: "New Name"})
       body = json_response(conn, 200)
       assert body["vault"]["name"] == "New Name"
@@ -239,7 +200,7 @@ defmodule EngramWeb.VaultsControllerTest do
     end
 
     test "returns 422 with changeset errors for an invalid is_default", %{conn: conn, user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Valid"})
+      {:ok, vault, _} = Vaults.register_vault(user, "Valid", Ecto.UUID.generate())
       conn = patch(conn, "/api/vaults/#{vault.id}", %{is_default: "banana"})
       assert %{"errors" => %{"is_default" => [_ | _]}} = json_response(conn, 422)
     end
@@ -247,7 +208,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
   describe "DELETE /api/vaults/:id" do
     test "soft-deletes vault and returns 200", %{conn: conn, user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "To Delete"})
+      {:ok, vault, _} = Vaults.register_vault(user, "To Delete", Ecto.UUID.generate())
       conn = delete(conn, "/api/vaults/#{vault.id}")
       body = json_response(conn, 200)
       assert body["deleted"] == true
@@ -265,7 +226,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
   describe "GET /api/vaults?deleted=true" do
     test "lists soft-deleted vaults with a purge_at and content counts", %{conn: conn, user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "Trashed"})
+      {:ok, v, _} = Vaults.register_vault(user, "Trashed", Ecto.UUID.generate())
       insert(:note, user: user, vault: v)
       insert(:attachment, user: user, vault: v)
       {:ok, _} = Vaults.delete_vault(user, v.id)
@@ -280,7 +241,7 @@ defmodule EngramWeb.VaultsControllerTest do
     end
 
     test "active listing excludes deleted vaults", %{conn: conn, user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "Trashed"})
+      {:ok, v, _} = Vaults.register_vault(user, "Trashed", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
 
       body = conn |> get("/api/vaults") |> json_response(200)
@@ -290,7 +251,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
   describe "POST /api/vaults/:id/restore" do
     test "restores a deleted vault", %{conn: conn, user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "Back"})
+      {:ok, v, _} = Vaults.register_vault(user, "Back", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
 
       body = conn |> post("/api/vaults/#{v.id}/restore") |> json_response(200)
@@ -304,9 +265,9 @@ defmodule EngramWeb.VaultsControllerTest do
       grant_api_write!(other)
       oconn = build_conn() |> put_req_header("authorization", "Bearer #{raw_key}")
 
-      {:ok, first} = Vaults.create_vault(other, %{name: "First"})
+      {:ok, first, _} = Vaults.register_vault(other, "First", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(other, first.id)
-      {:ok, _} = Vaults.create_vault(other, %{name: "Replacement"})
+      {:ok, _, _} = Vaults.register_vault(other, "Replacement", Ecto.UUID.generate())
 
       body = oconn |> post("/api/vaults/#{first.id}/restore") |> json_response(402)
       assert body["error"] == "limit_exceeded"
@@ -317,14 +278,14 @@ defmodule EngramWeb.VaultsControllerTest do
     end
 
     test "returns 404 for an active vault", %{conn: conn, user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      {:ok, v, _} = Vaults.register_vault(user, "Active", Ecto.UUID.generate())
       conn |> post("/api/vaults/#{v.id}/restore") |> json_response(404)
     end
   end
 
   describe "POST /api/vaults/:id/purge" do
     test "purges a deleted vault", %{conn: conn, user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "Doomed"})
+      {:ok, v, _} = Vaults.register_vault(user, "Doomed", Ecto.UUID.generate())
       {:ok, _} = Vaults.delete_vault(user, v.id)
 
       body = conn |> post("/api/vaults/#{v.id}/purge") |> json_response(200)
@@ -333,7 +294,7 @@ defmodule EngramWeb.VaultsControllerTest do
     end
 
     test "returns 404 for an active vault", %{conn: conn, user: user} do
-      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      {:ok, v, _} = Vaults.register_vault(user, "Active", Ecto.UUID.generate())
       conn |> post("/api/vaults/#{v.id}/purge") |> json_response(404)
     end
   end
@@ -372,7 +333,7 @@ defmodule EngramWeb.VaultsControllerTest do
       # Re-grant API access after wiping all overrides above.
       grant_api_write!(user)
 
-      {:ok, _} = Vaults.create_vault(user, %{name: "First"})
+      {:ok, _, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
 
       conn = post(conn, "/api/vaults/register", %{name: "New", client_id: "xyz"})
       body = json_response(conn, 402)
@@ -415,7 +376,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
       {:ok, raw_key, _} = Engram.Accounts.create_api_key(user, "ft-test-key")
       grant_api_write!(user)
-      {:ok, _first} = Vaults.create_vault(user, %{name: "First"})
+      {:ok, _first, _} = Vaults.register_vault(user, "First", Ecto.UUID.generate())
 
       authed =
         build_conn()
@@ -425,7 +386,7 @@ defmodule EngramWeb.VaultsControllerTest do
     end
 
     test "returns standardized 402 shape", %{conn: conn} do
-      conn = post(conn, ~p"/api/vaults", %{name: "Second"})
+      conn = post(conn, ~p"/api/vaults/register", %{name: "Second", client_id: "ft-second"})
       body = json_response(conn, 402)
       assert body["error"] == "limit_exceeded"
       assert body["reason"] == "vaults_cap_exceeded"

--- a/test/engram_web/onboarding_gate_channel_test.exs
+++ b/test/engram_web/onboarding_gate_channel_test.exs
@@ -44,7 +44,7 @@ defmodule EngramWeb.OnboardingGateChannelTest do
     # opt-out of its "already onboarded" default.
     user = insert_user(onboarding_profile: %{})
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
-    {:ok, vault} = Vaults.create_vault(user, %{name: "Ungated"})
+    {:ok, vault, _} = Vaults.register_vault(user, "Ungated", Ecto.UUID.generate())
 
     {:ok, user: user, vault: vault, socket: user_socket(user)}
   end

--- a/test/engram_web/plugs/require_onboarding_test.exs
+++ b/test/engram_web/plugs/require_onboarding_test.exs
@@ -135,7 +135,7 @@ defmodule EngramWeb.Plugs.RequireOnboardingTest do
     {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
     insert(:subscription, user: user, status: "active")
     {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
-    {:ok, _} = Engram.Vaults.create_vault(user, %{name: "My Vault"})
+    {:ok, _, _} = Engram.Vaults.register_vault(user, "My Vault", Ecto.UUID.generate())
     conn = conn |> assign(:current_user, user) |> RequireOnboarding.call([])
     refute conn.halted
   end
@@ -189,7 +189,7 @@ defmodule EngramWeb.Plugs.RequireOnboardingTest do
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
       insert(:subscription, user: user, status: "active")
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
-      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "My Vault"})
+      {:ok, vault, _} = Engram.Vaults.register_vault(user, "My Vault", Ecto.UUID.generate())
       {user, vault}
     end
 

--- a/test/engram_web/plugs/vault_plug_test.exs
+++ b/test/engram_web/plugs/vault_plug_test.exs
@@ -9,11 +9,11 @@ defmodule EngramWeb.Plugs.VaultPlugTest do
     user = insert(:user)
     other_user = insert(:user)
 
-    {:ok, vault} =
-      Vaults.create_vault(user, %{name: "My Vault", client_id: "client-abc"})
+    {:ok, vault, _} =
+      Vaults.register_vault(user, "My Vault", "client-abc")
 
-    {:ok, other_vault} =
-      Vaults.create_vault(other_user, %{name: "Other Vault", client_id: "client-xyz"})
+    {:ok, other_vault, _} =
+      Vaults.register_vault(other_user, "Other Vault", "client-xyz")
 
     %{user: user, other_user: other_user, vault: vault, other_vault: other_vault}
   end

--- a/test/mix/tasks/engram_backfill_onboarding_actions_test.exs
+++ b/test/mix/tasks/engram_backfill_onboarding_actions_test.exs
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Engram.BackfillOnboardingActionsTest do
   test "inserts first_vault_created for every user with at least one vault" do
     user_with = insert_user()
     user_without = insert_user()
-    {:ok, _} = Vaults.create_vault(user_with, %{name: "Main"})
+    {:ok, _, _} = Vaults.register_vault(user_with, "Main", Ecto.UUID.generate())
 
     # Simulate a legacy user: clear the row created by the T5 hook so the test
     # exercises pure backfill. Cross-tenant test cleanup — onboarding_actions is
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Engram.BackfillOnboardingActionsTest do
 
   test "idempotent — second run is a no-op" do
     user = insert_user()
-    {:ok, _} = Vaults.create_vault(user, %{name: "Main"})
+    {:ok, _, _} = Vaults.register_vault(user, "Main", Ecto.UUID.generate())
 
     BackfillOnboardingActions.run([])
     BackfillOnboardingActions.run([])


### PR DESCRIPTION
Closes the "two ways to make a vault" problem behind the duplicate-vault bug. Pairs with plugin PR engram-app/Engram-obsidian#456.

## Why

Two create paths existed and they had drifted apart.

**`POST /vaults` → `Vaults.create_vault/2`** had no idempotency key, so a retry after a slow or failed request made a **second vault**. That is how one Obsidian first-sync produced two vaults two minutes apart:

```
b87e6c7a  created 08:37:32  →  292 notes  (abandoned mid-sync)
32f46dbb  created 08:43:34  →  319 notes  (completed)
```

Every vault created locally carried `client_id = nil` — the signature of this endpoint.

**`POST /vaults/register` → `Vaults.register_vault/3`** was idempotent, but kept its own copy of the insert, and that copy had **silently fallen behind**:

| | `create_vault/2` | `register_vault/3` |
|---|---|---|
| billing cap, slug, is_default, encryption | ✅ | ✅ |
| `emit_vault_count` | ✅ | ✅ |
| `Onboarding.record_action(:first_vault_created)` | ✅ | ❌ |
| `broadcast_vault_created/2` | ✅ | ❌ |

So a vault created **by the plugin** never ticked the onboarding checklist and never live-appeared in an open web app. The broadcast's own comment says it exists so the FTUX page can auto-transition *"once a vault appears (e.g. the Obsidian plugin creates one)"* — the exact case it was failing.

## What

One implementation, `insert_vault/4`, reachable only through `register_vault/4`. Two production callers remain (register endpoint, device link); nothing else inserts a vault row — verified by grep, not assumption.

- **`create_vault/2` deleted.** `register_vault/4` gains an `extra_attrs` map for optional columns (`:description`). Computed columns (name, client_id, slug, user_id, is_default) cannot be overridden through it, with a test that tries.
- **`POST /vaults` deleted** — route, action, and the now-orphaned `CreateVaultRequest` schema.
- **Device link** keys its vault on `"device-link:" <> user_code`, so a double-tapped Authorize no longer mints a second vault.
- **Web SPA** moves to `/vaults/register`. `client_id` is minted when the form **mounts**, not per submit — minting per submit would make the idempotency a no-op — and re-minted after success, since that is a new intent.
- **231 test call sites across 87 files** migrated mechanically.

## Breaking change

`POST /vaults` is gone from the public API. Callers updated: web SPA, e2e helpers, plugin (#456). Two differences to be aware of, and **`/vaults/register` is not a strict superset** (an earlier revision of this description wrongly said it was):

- It answers with the vault **flat**, not wrapped in `{vault: ...}`.
- `CreateVaultRequest` accepted `name`, `description`, `is_default`. `RegisterVaultRequest` accepts only `name` + `client_id`, so **`description` and `is_default` can no longer be set at creation time** — `PATCH /vaults/:id` still sets both. `register_vault/4` does take an `extra_attrs` map for exactly this, but the controller deliberately does not expose it; say the word and I will widen the request schema.

## Concurrency fix found during review (c15c59fd)

The lookup-then-insert meant two concurrent registers of one `client_id` both saw `nil` and both inserted. The partial unique index stopped the duplicate row, but the violation **aborted the transaction** with no savepoint to roll back to, so `with_tenant`'s role reset died with `25P02 in_failed_sql_transaction` and the losing caller got a **500** — in the exact scenario `client_id` exists to make safe.

```
before: ** (Postgrex.Error) ERROR 25P02 (in_failed_sql_transaction)
after:  OK created  id=773cef9f-...
        OK existing id=773cef9f-...   # same id, one row
```

Fixed with `mode: :savepoint` plus a re-read that returns `:existing`. Not covered by an automated test: staging a real race needs two connections (`Sandbox.unboxed_run`), and that attempt leaked users into the shared test DB and timed out in cleanup. Reproducible by hand with two `Task.async` calls against a non-sandboxed repo.

## Sobelow

One fingerprint re-pinned. Deleting the route shifted `router.ex` 586 → 585, and skips hash over `[check, source, file, line]`. Same 21 findings before and after; only the `CSRFRoute` entry's hash changed (`git diff --numstat` = 1 add / 1 delete).

## Verification

| Gate | Result |
|---|---|
| `mix test` | **4694 tests, 0 failures** |
| `vitest run` | **1650 tests, 0 failures** |
| `mix format` / `credo --strict` | clean |
| `mix dialyzer` | passed |
| `mix sobelow --exit low --skip` | exit 0 |
| `tsc --noEmit` / `biome ci` | clean |

## Follow-up (not in this PR)

Test factories still `insert(:vault, ...)` directly, bypassing the context. That is a test-only path, but it means a factory-made vault skips the billing cap and the broadcast.

Refs #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp

