### PR TITLE
fix(billing): one source of truth for limits, and no inverted flags

### DIFF
--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -14,8 +14,8 @@ Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/legal/seede
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/release/preflight.ex:114,30D4B80
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram_web/controllers/spa_controller.ex:58,5A4EB4C
 Traversal.FileModule: Directory Traversal in `File.read`,lib/engram/spa_integrity.ex:43,5D1BE94
-XSS.ContentType: XSS in `put_resp_content_type`,lib/engram_web/controllers/attachments_controller.ex:411,541DC61
-XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/attachments_controller.ex:413,18E84B
+XSS.ContentType: XSS in `put_resp_content_type`,lib/engram_web/controllers/attachments_controller.ex:416,16CA695
+XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/attachments_controller.ex:418,779A094
 XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/oauth_authorize_controller.ex:119,4A1F9AA
 XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/oauth_authorize_controller.ex:139,46A4AE8
 XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/spa_controller.ex:7,589845D

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -121,7 +121,16 @@ defmodule Engram.Billing do
   """
   @spec attachments_all_types?(Engram.Accounts.User.t()) :: boolean()
   def attachments_all_types?(%Engram.Accounts.User{} = user) do
-    effective_limit(user, :attachments_all_types) != false
+    # Mirrors `normalize_capability(:boolean, _)`: only `:unlimited` and a real
+    # `true` grant. Anything else fails CLOSED. `!= false` would have been
+    # fail-open — a hand-written override row holding the string "false"
+    # instead of the boolean would then hand a Free user the paid attachment
+    # surface, which the `== true` code this replaced correctly refused.
+    case effective_limit(user, :attachments_all_types) do
+      :unlimited -> true
+      true -> true
+      _ -> false
+    end
   end
 
   @doc """

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -134,6 +134,25 @@ defmodule Engram.Billing do
   end
 
   @doc """
+  Whether this user is exempt from the free-tier inactivity dunning.
+
+  The single answer, same as `attachments_all_types?/1` — but the fail
+  direction is deliberately the OPPOSITE, and that is a decision, not an
+  oversight. Failing "closed" on a grant normally means refusing it, which for
+  attachments means refusing an upload: harmless. Refusing THIS grant means
+  mailing the user about inactivity and starting the deletion clock. On a value
+  we cannot read, the safe answer is to leave them alone, so anything that is
+  not an explicit `false` counts as exempt.
+
+  `:unlimited` (enforcement off, i.e. self-host) is exempt: a self-hosted
+  instance must never send free-tier dunning about its operator's own data.
+  """
+  @spec inactivity_warnings_exempt?(Engram.Accounts.User.t()) :: boolean()
+  def inactivity_warnings_exempt?(%Engram.Accounts.User{} = user) do
+    effective_limit(user, :inactivity_warnings_exempt) != false
+  end
+
+  @doc """
   Returns :ok if current_count is below the limit, or the limit is -1 (unlimited).
   Returns {:error, :limit_reached} when at or over the limit.
   """

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -60,11 +60,68 @@ defmodule Engram.Billing do
 
     with :miss <- user_override_lookup(user.id, string_key),
          :miss <- env_override_lookup(user_tier, key),
-         :miss <- plan_lookup(user, string_key) do
+         :miss <- plan_lookup(user, string_key),
+         :miss <- legacy_alias_lookup(user, user_tier, key) do
       LimitKeys.default_for(key, user_tier)
     else
       {:hit, v} -> v
     end
+  end
+
+  # Booleans that used to be RESTRICTION-shaped (`true` == denied) and were
+  # renamed to grant-shaped spellings so that `:unlimited` (enforcement off)
+  # can mean "granted" for every boolean without exception. Overrides already
+  # set by operators still carry the old key, and dropping a key from the
+  # catalog also stops `env_var_names/0` from generating its env var — so
+  # resolve the old spelling here and flip the sense. Without this an operator
+  # who deliberately restricted a tier would silently have that lifted.
+  # Delete alongside the legacy wire field in the contract step.
+  @legacy_inverted_keys %{
+    attachments_all_types: "attachments_text_only",
+    inactivity_warnings_exempt: "inactivity_warn_60_days"
+  }
+
+  defp legacy_alias_lookup(user, tier, key) do
+    case Map.fetch(@legacy_inverted_keys, key) do
+      {:ok, legacy_key} ->
+        with :miss <- user_override_lookup(user.id, legacy_key),
+             :miss <- legacy_env_lookup(tier, legacy_key),
+             :miss <- plan_lookup(user, legacy_key) do
+          :miss
+        else
+          # The old key meant "restricted", the new one means "granted".
+          {:hit, restricted} -> {:hit, restricted != true}
+        end
+
+      :error ->
+        :miss
+    end
+  end
+
+  defp legacy_env_lookup(tier, legacy_key) do
+    name = "ENGRAM_#{String.upcase(to_string(tier))}_#{String.upcase(legacy_key)}"
+
+    case System.get_env(name) do
+      nil -> :miss
+      raw -> {:hit, Engram.Billing.EnvLimits.parse!(raw, :boolean, name)}
+    end
+  end
+
+  @doc """
+  THE answer to "may this user upload non-text attachments?".
+
+  Every caller — the plugin's `plan_state/1` pre-gate payload, the web app's
+  `capabilities/1` map, and the upload controller — must route through this one
+  function. They used to each re-derive it, and `capabilities/1` got it
+  backwards whenever enforcement was off, which is how self-hosters silently
+  lost every image and PDF while the server would have accepted them.
+
+  `:unlimited` (enforcement off, i.e. self-host) means yes, same as every other
+  grant-shaped capability.
+  """
+  @spec attachments_all_types?(Engram.Accounts.User.t()) :: boolean()
+  def attachments_all_types?(%Engram.Accounts.User{} = user) do
+    effective_limit(user, :attachments_all_types) != false
   end
 
   @doc """
@@ -176,9 +233,16 @@ defmodule Engram.Billing do
   `nil` (JSON null) so the wire shape stays `number | null`.
   """
   def plan_state(%Engram.Accounts.User{} = user) do
+    all_types? = attachments_all_types?(user)
+
     %{
       tier: tier(user),
-      attachments_text_only: effective_limit(user, :attachments_text_only) == true,
+      attachments_all_types: all_types?,
+      # EXPAND step: kept so plugin builds older than the rename keep working.
+      # Both fields are derived from the same `attachments_all_types?/1` call,
+      # so they cannot drift. Remove in the contract step once the released
+      # plugin reads `attachments_all_types`.
+      attachments_text_only: not all_types?,
       max_file_bytes: numeric_limit(user, :max_file_bytes),
       attachment_bytes_cap: numeric_limit(user, :attachment_bytes_cap)
     }
@@ -687,10 +751,20 @@ defmodule Engram.Billing do
       case Engram.Accounts.get_user(user_id) do
         %Engram.Accounts.User{} = u ->
           plan_state(u)
-          |> Map.take([:attachments_text_only, :max_file_bytes, :attachment_bytes_cap])
+          |> Map.take([
+            :attachments_all_types,
+            :attachments_text_only,
+            :max_file_bytes,
+            :attachment_bytes_cap
+          ])
 
         _ ->
-          %{attachments_text_only: nil, max_file_bytes: nil, attachment_bytes_cap: nil}
+          %{
+            attachments_all_types: nil,
+            attachments_text_only: nil,
+            max_file_bytes: nil,
+            attachment_bytes_cap: nil
+          }
       end
 
     _ =

--- a/lib/engram/billing/limit_keys.ex
+++ b/lib/engram/billing/limit_keys.ex
@@ -20,13 +20,20 @@ defmodule Engram.Billing.LimitKeys do
       defaults: %{free: 1_073_741_824, starter: 3_221_225_472, pro: 16_106_127_360}
     },
     attachments_enabled: %{type: :boolean, defaults: %{free: true, starter: true, pro: true}},
-    # Free is restricted to text/* uploads only; Starter+ get the full
-    # MimeWhitelist surface (images, audio, video, PDFs, office docs).
-    # `true` means "Free-style restriction is ON" so the gate matches
-    # the pattern of every other paid-feature boolean.
-    attachments_text_only: %{
+    # Starter+ get the full MimeWhitelist surface (images, audio, video, PDFs,
+    # office docs); Free is text/* only.
+    #
+    # POLARITY IS LOAD-BEARING. This replaces `attachments_text_only`, whose
+    # `true` meant "restriction ON" — the only inverted boolean in this catalog.
+    # `normalize_capability/2` maps `:unlimited` (enforcement off) to `true` for
+    # every boolean, which is correct ONLY for grant-shaped flags. Under the old
+    # inverted key that rule read as "restriction ON", so turning enforcement
+    # OFF silently turned the restriction ON and every self-hoster lost images
+    # and PDFs. Keep every boolean here grant-shaped (`true` == the user gets
+    # the thing) and that whole failure class cannot come back.
+    attachments_all_types: %{
       type: :boolean,
-      defaults: %{free: true, starter: false, pro: false}
+      defaults: %{free: false, starter: true, pro: true}
     },
     max_file_bytes: %{
       type: :integer,
@@ -59,9 +66,14 @@ defmodule Engram.Billing.LimitKeys do
     # cap exists for spam defense, not to throttle the user in the app.
     external_ai_searches_per_day: %{type: :integer, defaults: %{free: 15, starter: nil, pro: nil}},
     inapp_searches_per_day: %{type: :integer, defaults: %{free: 60, starter: nil, pro: nil}},
-    inactivity_warn_60_days: %{
+    # Grant-shaped, like every other boolean here: `true` == this user is
+    # EXEMPT from the free-tier inactivity dunning. Was `inactivity_warn_60_days`
+    # (free: true), which is the same inverted shape that broke attachments —
+    # enforcement off resolved to `:unlimited` -> `true` -> "warn them", so
+    # self-hosters got free-tier inactivity warnings on their own hardware.
+    inactivity_warnings_exempt: %{
       type: :boolean,
-      defaults: %{free: true, starter: false, pro: false}
+      defaults: %{free: false, starter: true, pro: true}
     },
     inactivity_delete_days: %{type: :integer, defaults: %{free: 90, starter: nil, pro: nil}},
     # Legacy keys preserved for back-compat with existing call sites

--- a/lib/engram/workers/inactivity_cleanup.ex
+++ b/lib/engram/workers/inactivity_cleanup.ex
@@ -213,8 +213,11 @@ defmodule Engram.Workers.InactivityCleanup do
     end
   end
 
+  # Inverted deliberately: the catalog key is grant-shaped (`true` == exempt),
+  # so enforcement-off (`:unlimited`) means exempt and a self-hosted instance
+  # never sends free-tier inactivity dunning.
   defp warn_enabled?(user) do
-    Billing.effective_limit(user, :inactivity_warn_60_days) == true
+    Billing.effective_limit(user, :inactivity_warnings_exempt) == false
   end
 
   defp delete_after_days(user) do

--- a/lib/engram/workers/inactivity_cleanup.ex
+++ b/lib/engram/workers/inactivity_cleanup.ex
@@ -213,12 +213,10 @@ defmodule Engram.Workers.InactivityCleanup do
     end
   end
 
-  # Inverted deliberately: the catalog key is grant-shaped (`true` == exempt),
-  # so enforcement-off (`:unlimited`) means exempt and a self-hosted instance
-  # never sends free-tier inactivity dunning.
-  defp warn_enabled?(user) do
-    Billing.effective_limit(user, :inactivity_warnings_exempt) == false
-  end
+  # Routes through the single source of truth rather than re-deriving it. The
+  # key is grant-shaped (`true` == exempt), so enforcement-off (`:unlimited`)
+  # means exempt and a self-hosted instance never sends free-tier dunning.
+  defp warn_enabled?(user), do: not Billing.inactivity_warnings_exempt?(user)
 
   defp delete_after_days(user) do
     Billing.effective_limit(user, :inactivity_delete_days)

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -90,7 +90,12 @@ defmodule EngramWeb.AttachmentsController do
     end
   end
 
-  defp text_only?(user), do: Billing.effective_limit(user, :attachments_text_only) == true
+  # Routes through the single source of truth rather than re-deriving the
+  # answer, so this gate cannot disagree with the `plan_state/1` payload the
+  # plugin pre-gates on (they did disagree: see Billing.attachments_all_types?/1).
+  # The 402 body still names `attachments_text_only` — that is a client-facing
+  # wire identifier, not a catalog lookup, and it changes in the contract step.
+  defp text_only?(user), do: not Billing.attachments_all_types?(user)
 
   defp text_mime?(nil), do: false
 

--- a/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
+++ b/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
@@ -35,9 +35,9 @@ defmodule Mix.Tasks.Engram.Lint.NoClientOnlyRateLimits do
     # The §C InactivityCleanup cron filters to Free via Billing.tier/1
     # rather than reading these keys. TODO: migrate cron to read the
     # catalog so per-user overrides take effect.
-    inactivity_warn_60_days:
+    inactivity_warnings_exempt:
       "TODO follow-up: InactivityCleanup hardcodes 60d/80d/90d windows; migrate to LimitKeys",
-    inactivity_delete_days: "TODO follow-up: same as inactivity_warn_60_days",
+    inactivity_delete_days: "TODO follow-up: same as inactivity_warnings_exempt",
     # Device-auth caps — TODO follow-up. DeviceAuthController already enforces
     # vaults_cap; needs explicit concurrent_devices + cooldown checks.
     concurrent_devices: "TODO follow-up: DeviceAuthController needs per-user device count check",

--- a/test/engram/billing/limit_keys_test.exs
+++ b/test/engram/billing/limit_keys_test.exs
@@ -66,7 +66,7 @@ defmodule Engram.Billing.LimitKeysTest do
       assert LimitKeys.default_for(:reranker_enabled, :free) == false
       assert LimitKeys.default_for(:api_write_enabled, :free) == false
       assert LimitKeys.default_for(:api_rps_cap, :free) == 0
-      assert LimitKeys.default_for(:inactivity_warn_60_days, :free) == true
+      assert LimitKeys.default_for(:inactivity_warnings_exempt, :free) == false
       assert LimitKeys.default_for(:inactivity_delete_days, :free) == 90
     end
 
@@ -144,12 +144,34 @@ defmodule Engram.Billing.LimitKeysTest do
     assert LimitKeys.default_for(:attachments_enabled, :pro) == true
   end
 
-  test "attachments_text_only restricts Free uploads to text/* MIMEs" do
-    assert LimitKeys.defined?(:attachments_text_only)
-    assert LimitKeys.type(:attachments_text_only) == :boolean
-    assert LimitKeys.default_for(:attachments_text_only, :free) == true
-    assert LimitKeys.default_for(:attachments_text_only, :starter) == false
-    assert LimitKeys.default_for(:attachments_text_only, :pro) == false
+  test "attachments_all_types grants Starter+ the non-text MIME surface" do
+    assert LimitKeys.defined?(:attachments_all_types)
+    assert LimitKeys.type(:attachments_all_types) == :boolean
+    assert LimitKeys.default_for(:attachments_all_types, :free) == false
+    assert LimitKeys.default_for(:attachments_all_types, :starter) == true
+    assert LimitKeys.default_for(:attachments_all_types, :pro) == true
+  end
+
+  test "the inverted attachments_text_only key is gone" do
+    # It was the only boolean whose `true` meant "denied". `capabilities/1`
+    # maps `:unlimited` (enforcement off) to `true` for every boolean, so that
+    # one key inverted the meaning of disabling enforcement and cost every
+    # self-hoster their images and PDFs.
+    refute LimitKeys.defined?(:attachments_text_only)
+  end
+
+  test "every boolean limit is grant-shaped: enforcement-off must never restrict" do
+    # The invariant that makes the whole class impossible. `:unlimited` maps to
+    # `true` for booleans, so a key may only use `true` to mean "the user gets
+    # the thing". A future key defaulting Free to `true` while Pro gets `false`
+    # is inverted by construction and fails here.
+    for key <- LimitKeys.all(), LimitKeys.type(key) == :boolean do
+      free = LimitKeys.default_for(key, :free)
+      pro = LimitKeys.default_for(key, :pro)
+
+      refute free == true and pro == false,
+             "#{key} is inverted (free=true, pro=false): `true` must mean granted"
+    end
   end
 
   test "search dial keys are defined with correct types" do

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -9,6 +9,7 @@ defmodule Engram.BillingTest do
   import Mox
 
   alias Engram.Billing
+  alias Engram.Billing.LimitKeys
   alias Engram.Billing.Subscription
   alias Engram.Repo
 
@@ -154,6 +155,7 @@ defmodule Engram.BillingTest do
       user = build(:user, free_tier_accepted_at: nil)
       state = Billing.plan_state(user)
       assert state.tier == :free
+      assert state.attachments_all_types == false
       assert state.attachments_text_only == true
       assert is_integer(state.max_file_bytes)
       assert is_integer(state.attachment_bytes_cap) or is_nil(state.attachment_bytes_cap)
@@ -163,7 +165,62 @@ defmodule Engram.BillingTest do
       user = build(:user) |> with_subscription(tier: "pro", status: "active")
       state = Billing.plan_state(user)
       assert state.tier == :pro
+      assert state.attachments_all_types == true
       assert state.attachments_text_only == false
+    end
+
+    test "the legacy field is always the exact inverse of the new one" do
+      # EXPAND step: both fields ship until the released plugin reads the new
+      # one. They are derived from a single call, so a future edit cannot let
+      # them drift into disagreeing about the same user.
+      for user <- [
+            build(:user, free_tier_accepted_at: nil),
+            build(:user) |> with_subscription(tier: "starter", status: "active"),
+            build(:user) |> with_subscription(tier: "pro", status: "active")
+          ] do
+        state = Billing.plan_state(user)
+        assert state.attachments_text_only == not state.attachments_all_types
+      end
+    end
+  end
+
+  describe "self-host (enforcement off) grants every capability" do
+    setup do
+      prev = Application.get_env(:engram, :limits_enforced, true)
+      Application.put_env(:engram, :limits_enforced, false)
+      on_exit(fn -> Application.put_env(:engram, :limits_enforced, prev) end)
+      :ok
+    end
+
+    test "attachments_all_types? is true even for an otherwise-Free user" do
+      # The regression. `attachments_text_only` was restriction-shaped, and
+      # `normalize_capability(:boolean, :unlimited)` returns `true` for every
+      # boolean — so turning enforcement OFF turned the restriction ON, and
+      # self-hosters silently lost every image and PDF while their own server
+      # would have accepted them.
+      user = build(:user, free_tier_accepted_at: nil)
+      assert Billing.attachments_all_types?(user)
+    end
+
+    test "plan_state and capabilities agree — they used to disagree" do
+      user = insert(:user, free_tier_accepted_at: nil)
+
+      state = Billing.plan_state(user)
+      caps = Billing.capabilities(user)
+
+      assert state.attachments_all_types == true
+      assert caps.limits["attachments_all_types"] == true
+      assert state.attachments_text_only == false
+    end
+
+    test "no boolean capability resolves to a restriction" do
+      user = insert(:user, free_tier_accepted_at: nil)
+      caps = Billing.capabilities(user)
+
+      for key <- LimitKeys.all(), LimitKeys.type(key) == :boolean do
+        assert caps.limits[Atom.to_string(key)] == true,
+               "#{key} is not granted with enforcement off"
+      end
     end
   end
 

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -184,6 +184,39 @@ defmodule Engram.BillingTest do
     end
   end
 
+  describe "attachments_all_types?/1 fails closed" do
+    test "a malformed override does not grant the paid surface" do
+      # Overrides are operator-written JSON. A string "false" instead of the
+      # boolean must not read as "not false, therefore granted" — that is the
+      # fail-open shape, and the `== true` code this replaced refused it.
+      user = insert(:user, free_tier_accepted_at: nil)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "attachments_all_types",
+        value: %{"v" => "false"},
+        reason: "malformed on purpose",
+        set_by: "test"
+      )
+
+      refute Billing.attachments_all_types?(user)
+    end
+
+    test "an explicit true override grants" do
+      user = insert(:user, free_tier_accepted_at: nil)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "attachments_all_types",
+        value: %{"v" => true},
+        reason: "grant",
+        set_by: "test"
+      )
+
+      assert Billing.attachments_all_types?(user)
+    end
+  end
+
   describe "self-host (enforcement off) grants every capability" do
     setup do
       prev = Application.get_env(:engram, :limits_enforced, true)

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -184,6 +184,80 @@ defmodule Engram.BillingTest do
     end
   end
 
+  describe "inactivity_warnings_exempt?/1" do
+    test "self-host is exempt: no free-tier dunning on your own server" do
+      prev = Application.get_env(:engram, :limits_enforced, true)
+      Application.put_env(:engram, :limits_enforced, false)
+      on_exit(fn -> Application.put_env(:engram, :limits_enforced, prev) end)
+
+      assert Billing.inactivity_warnings_exempt?(build(:user, free_tier_accepted_at: nil))
+    end
+
+    test "Free is not exempt, paid tiers are" do
+      refute Billing.inactivity_warnings_exempt?(build(:user, free_tier_accepted_at: nil))
+
+      assert Billing.inactivity_warnings_exempt?(
+               build(:user)
+               |> with_subscription(tier: "pro", status: "active")
+             )
+    end
+
+    test "an unreadable override leaves the user ALONE (opposite fail direction)" do
+      # Deliberately not fail-closed. Refusing this grant means mailing someone
+      # about inactivity and starting the deletion clock, so an unreadable value
+      # must not trigger it. Contrast attachments_all_types?/1, where refusing
+      # only costs an upload.
+      user = insert(:user, free_tier_accepted_at: nil)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "inactivity_warnings_exempt",
+        value: %{"v" => "nonsense"},
+        reason: "malformed on purpose",
+        set_by: "test"
+      )
+
+      assert Billing.inactivity_warnings_exempt?(user)
+    end
+  end
+
+  describe "the helper and the capabilities map cannot drift" do
+    # `capabilities/1` does NOT call attachments_all_types?/1 — it resolves
+    # every key generically through normalize_capability/2. That is the split
+    # that produced the original bug (plan_state said allowed, capabilities
+    # said restricted, and the plugin believed capabilities). Nothing in the
+    # types binds the two paths, so this test does.
+    for {tier, opts} <- [
+          free: [free_tier_accepted_at: nil],
+          starter: [subscription: {"starter", "active"}],
+          pro: [subscription: {"pro", "active"}]
+        ] do
+      test "#{tier}: capabilities agrees with the helper" do
+        user =
+          case unquote(opts)[:subscription] do
+            nil -> insert(:user, free_tier_accepted_at: nil)
+            {t, s} -> insert(:user) |> with_subscription(tier: t, status: s)
+          end
+
+        assert Billing.capabilities(user).limits["attachments_all_types"] ==
+                 Billing.attachments_all_types?(user)
+      end
+    end
+
+    test "and they still agree with enforcement off" do
+      prev = Application.get_env(:engram, :limits_enforced, true)
+      Application.put_env(:engram, :limits_enforced, false)
+      on_exit(fn -> Application.put_env(:engram, :limits_enforced, prev) end)
+
+      user = insert(:user, free_tier_accepted_at: nil)
+
+      assert Billing.capabilities(user).limits["attachments_all_types"] ==
+               Billing.attachments_all_types?(user)
+
+      assert Billing.attachments_all_types?(user)
+    end
+  end
+
   describe "attachments_all_types?/1 fails closed" do
     test "a malformed override does not grant the paid surface" do
       # Overrides are operator-written JSON. A string "false" instead of the

--- a/test/engram/oauth/cimd_test.exs
+++ b/test/engram/oauth/cimd_test.exs
@@ -581,10 +581,26 @@ defmodule Engram.OAuth.CimdTest do
     test "our own fetch rate limiter is retryable" do
       stub(FetcherMock, :fetch, fn url -> {:ok, %{document() | "client_id" => url}} end)
 
-      for i <- 1..11, do: authorize("https://claude.ai/limiter-probe-#{i}")
+      # Burst until the limiter actually refuses, rather than firing a fixed 11
+      # and assuming the 12th is over. `@per_host_limit` is 10 per FIXED 60s
+      # window, so a burst that straddles a window boundary leaves the last
+      # probe in a fresh window and it is allowed — which failed this test with
+      # `{:ok, _}` for a reason unrelated to the behaviour it pins. Once the
+      # limiter refuses it keeps refusing for the rest of the window, so
+      # halting on the first refusal is stable.
+      #
+      # Bounded at 30 so a genuinely broken limiter fails instead of looping:
+      # comfortably over @per_host_limit even after one window roll, and under
+      # @discover_limit (60) so it stays the PER-HOST limiter being pinned.
+      result =
+        Enum.reduce_while(1..30, nil, fn i, _acc ->
+          case authorize("https://claude.ai/limiter-probe-#{i}") do
+            {:server_error, _} = refused -> {:halt, refused}
+            allowed -> {:cont, allowed}
+          end
+        end)
 
-      assert {:server_error, "temporarily_unavailable"} =
-               authorize("https://claude.ai/limiter-probe-over")
+      assert {:server_error, "temporarily_unavailable"} = result
     end
 
     test "a document we cannot bind or parse really is the client's fault" do


### PR DESCRIPTION
Self-hosters silently lost **every image and PDF**. The server would have accepted them. The plugin never asked.

Found while debugging a first sync that reported "425 files", uploaded 319 notes, and went idle with 0 attachments.

## Root cause

`attachments_text_only` was the only **restriction-shaped** boolean in the catalog (`true` == denied). `capabilities/1` maps `:unlimited` (enforcement off) to `true` for every boolean, on the assumption a boolean always *grants*:

```elixir
defp normalize_capability(:boolean, :unlimited), do: true   # "enforcement off opens the gate"
```

For that one key `true` meant *restriction ON*, so **turning enforcement off turned the restriction on**. The plugin pre-gates attachments on that value and skipped all of them client-side, with no network call.

Three call sites each re-derived the same answer, and they disagreed:

| call site | enforcement off |
|---|---|
| `plan_state/1` | `false` ✓ |
| `attachments_controller.text_only?` | `false` ✓ |
| `capabilities/1` | **`true`** ✗ |

Verified against a live self-hosted instance: `billing_enabled: false`, `limits_enforced: false`, and `capabilities` still returned `attachments_text_only => true` while `Billing.effective_limit/2` returned `:unlimited`.

## Changes

- **`Billing.attachments_all_types?/1` is the single answer** for the two call sites that ask it directly (`plan_state/1`, the upload controller). `capabilities/1` resolves every key *generically* through `normalize_capability/2` rather than calling the helper, so the two paths are bound by **a test asserting they agree** across free / starter / pro and with enforcement off. (An earlier revision of this description claimed all three route through the helper. They do not — and that unbound split is exactly what produced the original bug.)
- **`Billing.inactivity_warnings_exempt?/1`** is the same treatment for the second key. Its fail direction is deliberately the *opposite*: failing closed on a grant normally means refusing it, which for attachments costs an upload, but refusing this one means mailing someone about inactivity and starting the deletion clock. Documented and tested rather than incidental.
- **Both helpers fail on unreadable values in the safe direction**, mirroring `normalize_capability(:boolean, _)`. `!= false` would have been fail-open: an override row holding the string `"false"` would have handed a Free user the paid attachment surface.
- **`attachments_text_only` → `attachments_all_types`**, grant-shaped (free `false`, starter/pro `true`). `:unlimited → true` is now correct for every boolean with **no special case**.
- **`inactivity_warn_60_days` → `inactivity_warnings_exempt`**, same reason. This was a *second* inverted key: enforcement off resolved to "warn them", so self-hosted instances sent free-tier inactivity dunning. **Found by the new invariant test, not by inspection** — which is the point.
- **An invariant test asserts no boolean is inverted** (`free == true and pro == false`). That is what makes this structural instead of two point fixes.

## Legacy overrides keep working

Renaming a key drops it from `env_var_names/0`, so its env var stops being parsed, and existing DB/plan overrides still carry the old spelling. `@legacy_inverted_keys` resolves the old names across user overrides, plan rows, and the env var, and **flips the sense**. Without it an operator who deliberately restricted a tier would silently have that lifted.

The two existing `inactivity_warn_60_days=false` override tests now exercise this path unchanged, so the alias has real coverage.

## Expand / migrate / contract

This is the **expand** step. `plan_state/1` emits both `attachments_all_types` and the legacy `attachments_text_only`, derived from a single call so they cannot disagree (there's a test asserting they're always exact inverses).

1. **This PR** — new field ships alongside the old one
2. Plugin reads the new field with a legacy fallback (Engram-obsidian)
3. Contract PR — drop the legacy field and `@legacy_inverted_keys`

## Verification

**4700 tests, 0 failures** · format, `credo --strict`, dialyzer, `sobelow --exit low --skip` all clean · `openapi.json` unchanged.

`.sobelow-skips`: 2 fingerprints re-pinned. Comments shifted lines 416/418 in `attachments_controller.ex`, and skips hash over `[check, source, file, line]`. Same 21 findings before and after; diff is 2 add / 2 delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp

