### PR TITLE
perf(attachments): stop paying for bytes the server already has

### DIFF
--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -8,7 +8,7 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/crypto.ex:581,7EA51D6
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/crypto/user_dek_rotation.ex:1411,772DFE4
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:4647,3A4840D
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:4982,12982FE
-SQL.Query: SQL injection,lib/engram/attachments.ex:1028,4FC776E
+SQL.Query: SQL injection,lib/engram/attachments.ex:1049,2991CD5
 SQL.Query: SQL injection,lib/engram/notes.ex:6632,68DCD6B
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/legal/seeder.ex:84,12C6307
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/release/preflight.ex:114,30D4B80

--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -8,14 +8,14 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/crypto.ex:581,7EA51D6
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/crypto/user_dek_rotation.ex:1411,772DFE4
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:4647,3A4840D
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:4982,12982FE
-SQL.Query: SQL injection,lib/engram/attachments.ex:988,22EF6CC
+SQL.Query: SQL injection,lib/engram/attachments.ex:1028,4FC776E
 SQL.Query: SQL injection,lib/engram/notes.ex:6632,68DCD6B
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/legal/seeder.ex:84,12C6307
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/release/preflight.ex:114,30D4B80
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram_web/controllers/spa_controller.ex:58,5A4EB4C
 Traversal.FileModule: Directory Traversal in `File.read`,lib/engram/spa_integrity.ex:43,5D1BE94
-XSS.ContentType: XSS in `put_resp_content_type`,lib/engram_web/controllers/attachments_controller.ex:416,16CA695
-XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/attachments_controller.ex:418,779A094
+XSS.ContentType: XSS in `put_resp_content_type`,lib/engram_web/controllers/attachments_controller.ex:417,2CE3444
+XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/attachments_controller.ex:420,70EA2A0
 XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/oauth_authorize_controller.ex:119,4A1F9AA
 XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/oauth_authorize_controller.ex:139,46A4AE8
 XSS.SendResp: XSS in `send_resp`,lib/engram_web/controllers/spa_controller.ex:7,589845D

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -60,17 +60,21 @@ defmodule Engram.Attachments do
          :ok <- MimeWhitelist.check(explicit_mime || MimeWhitelist.detect_mime(path), path),
          :ok <- validate_size(plaintext, user),
          {:ok, user} <- Crypto.ensure_user_dek(user),
-         {:ok, filter_key} <- Crypto.dek_filter_key(user) do
-      path_hmac = Crypto.hmac_field(filter_key, path)
+         {:ok, filter_key} <- Crypto.dek_filter_key(user),
+         path_hmac = Crypto.hmac_field(filter_key, path),
+         # Pre-lock window: probable-id read, cap check, encrypt, and the S3
+         # PUT all run WITHOUT holding a pool transaction or the advisory
+         # lock — a slow multi-MB upload must not pin a DB connection
+         # (POOL_SIZE defaults to 10; a handful of concurrent uploads used to
+         # starve the whole API). The locked transaction below re-checks
+         # `existing` and repairs the rare race.
+         existing0 = fetch_existing(user, vault.id, path_hmac),
+         # Re-offering bytes the server already holds is a no-op. Returning the
+         # live row here skips the encrypt, the S3 PUT, the locked row write
+         # AND the "upsert" broadcast every peer would otherwise chase. See
+         # `identical_or_changed/4`.
+         :changed <- identical_or_changed(user, existing0, plaintext, path) do
       basename_hmac = Crypto.hmac_field(filter_key, Links.basename_key(path))
-
-      # Pre-lock window: probable-id read, cap check, encrypt, and the S3
-      # PUT all run WITHOUT holding a pool transaction or the advisory
-      # lock — a slow multi-MB upload must not pin a DB connection
-      # (POOL_SIZE defaults to 10; a handful of concurrent uploads used to
-      # starve the whole API). The locked transaction below re-checks
-      # `existing` and repairs the rare race.
-      existing0 = fetch_existing(user, vault.id, path_hmac)
 
       att_id0 =
         case existing0 do
@@ -178,6 +182,42 @@ defmodule Engram.Attachments do
       end
     end
   end
+
+  # `{:ok, att}` when the stored bytes are already the offered bytes (the `with`
+  # above short-circuits and returns it); `:changed` otherwise.
+  #
+  # Why this exists: on 2026-08-21 a single looping Obsidian client re-uploaded
+  # the same 667 attachments for 90 minutes and held prod at ~30% CPU on a
+  # 0.5-vCPU task. Every request was individually legal and no limit came close
+  # — the loop ran at ~1 req/s against a 30 rps cap, and a bytes/minute cap
+  # would not have helped either (it moved ~45 MB/min, well UNDER a legitimate
+  # first sync's ~240 MB/min). Rate is not what separates a loop from a bulk
+  # import; redundancy is.
+  #
+  # ponytail: trusts the DB row, not S3. If an object vanished from the bucket
+  # behind a live row, re-sending identical bytes no longer repairs it —
+  # delete-then-reupload does. Upgrade path if that ever bites: HEAD the
+  # storage key here before returning {:ok, att}.
+  defp identical_or_changed(_user, nil, _plaintext, _path), do: :changed
+
+  defp identical_or_changed(user, %Attachment{content_hash: stored} = att, plaintext, path)
+       when is_binary(stored) do
+    case Crypto.dek_content_hash_key(user) do
+      # Not a secret comparison — both sides are HMACs over content the caller
+      # just supplied, so there is no oracle to time. Plain `==`.
+      {:ok, content_key} ->
+        if stored == Crypto.hmac_content_hash(content_key, plaintext),
+          # `path` is virtual (Phase B.3); splice it on so this return is
+          # shape-identical to the write path's.
+          do: {:ok, %{att | path: path}},
+          else: :changed
+
+      _ ->
+        :changed
+    end
+  end
+
+  defp identical_or_changed(_user, _existing, _plaintext, _path), do: :changed
 
   defp fetch_existing(user, vault_id, path_hmac) do
     Repo.with_tenant(user.id, fn ->
@@ -1114,7 +1154,13 @@ defmodule Engram.Attachments do
         {:ok, atts,
          Crypto.measure_decrypt_batch(:attachments, length(atts), fn ->
            decrypt_each(atts, user, fn att, meta ->
-             meta |> Map.delete(:deleted_at) |> Map.put(:id, att.id)
+             # content_hash rides along so the listing a client sweeps before
+             # deciding what to push can answer "you already have these bytes"
+             # without a per-file round trip. Additive for every other caller.
+             meta
+             |> Map.delete(:deleted_at)
+             |> Map.put(:id, att.id)
+             |> Map.put(:content_hash, att.content_hash)
            end)
          end)}
 

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -72,8 +72,9 @@ defmodule Engram.Attachments do
          # Re-offering bytes the server already holds is a no-op. Returning the
          # live row here skips the encrypt, the S3 PUT, the locked row write
          # AND the "upsert" broadcast every peer would otherwise chase. See
-         # `identical_or_changed/4`.
-         :changed <- identical_or_changed(user, existing0, plaintext, path) do
+         # `identical_or_changed/5`.
+         :changed <-
+           identical_or_changed(user, existing0, plaintext, path, explicit_mime) do
       basename_hmac = Crypto.hmac_field(filter_key, Links.basename_key(path))
 
       att_id0 =
@@ -194,30 +195,50 @@ defmodule Engram.Attachments do
   # first sync's ~240 MB/min). Rate is not what separates a loop from a bulk
   # import; redundancy is.
   #
+  # Gated on the effective MIME as well as the bytes. Content alone is NOT
+  # enough: re-uploading identical bytes with a corrected `mime_type` is the
+  # documented way to fix a mis-detected type, and short-circuiting on content
+  # alone silently discarded that correction while returning 200 with the OLD
+  # type. A MIME change falls through to the full write — wasteful for a
+  # metadata-only edit, but rare, and obviously correct.
+  #
+  # `mtime` deliberately does NOT gate. It is client-reported metadata that no
+  # read path consults: the plugin's `applyAttachmentChange` decides by
+  # comparing BYTES, not mtime, so a preserved-old mtime cannot strand or loop
+  # a client. Gating on it would spend a full re-encrypt + PUT on a field
+  # nothing reads.
+  #
   # ponytail: trusts the DB row, not S3. If an object vanished from the bucket
   # behind a live row, re-sending identical bytes no longer repairs it —
-  # delete-then-reupload does. Upgrade path if that ever bites: HEAD the
-  # storage key here before returning {:ok, att}.
-  defp identical_or_changed(_user, nil, _plaintext, _path), do: :changed
+  # delete-then-reupload does (verified: `fetch_existing` is `scoped_live`, so
+  # a tombstoned row is invisible here and resurrection takes the full path).
+  # Upgrade path if that ever bites: HEAD the storage key before returning.
+  defp identical_or_changed(_user, nil, _plaintext, _path, _explicit_mime), do: :changed
 
-  defp identical_or_changed(user, %Attachment{content_hash: stored} = att, plaintext, path)
+  defp identical_or_changed(
+         user,
+         %Attachment{content_hash: stored} = att,
+         plaintext,
+         path,
+         explicit_mime
+       )
        when is_binary(stored) do
-    case Crypto.dek_content_hash_key(user) do
-      # Not a secret comparison — both sides are HMACs over content the caller
-      # just supplied, so there is no oracle to time. Plain `==`.
-      {:ok, content_key} ->
-        if stored == Crypto.hmac_content_hash(content_key, plaintext),
-          # `path` is virtual (Phase B.3); splice it on so this return is
-          # shape-identical to the write path's.
-          do: {:ok, %{att | path: path}},
-          else: :changed
+    effective_mime = explicit_mime || MimeWhitelist.detect_mime(path)
 
-      _ ->
-        :changed
+    with true <- att.mime_type == effective_mime,
+         # Not a secret comparison — both sides are HMACs over content the
+         # caller just supplied, so there is no oracle to time. Plain `==`.
+         {:ok, content_key} <- Crypto.dek_content_hash_key(user),
+         true <- stored == Crypto.hmac_content_hash(content_key, plaintext) do
+      # `path` is virtual (Phase B.3); splice it on so this return is
+      # shape-identical to the write path's.
+      {:ok, %{att | path: path}}
+    else
+      _ -> :changed
     end
   end
 
-  defp identical_or_changed(_user, _existing, _plaintext, _path), do: :changed
+  defp identical_or_changed(_user, _existing, _plaintext, _path, _explicit_mime), do: :changed
 
   defp fetch_existing(user, vault_id, path_hmac) do
     Repo.with_tenant(user.id, fn ->

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -105,7 +105,7 @@ defmodule EngramWeb.AttachmentsController do
   # uploading `" text/plain"` got 402 `attachment_must_be_text` while
   # `MimeWhitelist.check/2` considered the same string text.
   defp text_mime?(mime) when is_binary(mime),
-    do: String.starts_with?(Engram.Storage.MimeWhitelist.normalize(mime), "text/")
+    do: String.starts_with?(MimeWhitelist.normalize(mime), "text/")
 
   defp do_upload(conn, user, vault, params) do
     case Attachments.upsert_attachment(user, vault, params) do
@@ -341,6 +341,7 @@ defmodule EngramWeb.AttachmentsController do
                 mime_type: a.mime_type,
                 size_bytes: a.size_bytes,
                 mtime: a.mtime,
+                content_hash: a.content_hash,
                 updated_at: a.updated_at
               }
             end)
@@ -415,6 +416,7 @@ defmodule EngramWeb.AttachmentsController do
           conn
           |> put_resp_content_type(att.mime_type || "application/octet-stream")
           |> put_resp_header("content-disposition", ~s(#{disposition}; filename="#{filename}"))
+          |> maybe_skip_compression(att.mime_type)
           |> send_resp(200, att.content)
         else
           json(conn, %{
@@ -423,6 +425,7 @@ defmodule EngramWeb.AttachmentsController do
             mime_type: att.mime_type,
             size_bytes: att.size_bytes,
             mtime: att.mtime,
+            content_hash: att.content_hash,
             content_base64: Base.encode64(att.content),
             created_at: att.created_at,
             updated_at: att.updated_at
@@ -505,7 +508,7 @@ defmodule EngramWeb.AttachmentsController do
     # serve gate must agree on what a value MEANS, or the same media type gets
     # opposite answers depending on whitespace. Normalizing here only, as an
     # earlier version of this fix did, was how that split appeared.
-    case Engram.Storage.MimeWhitelist.normalize(mime) do
+    case MimeWhitelist.normalize(mime) do
       "image/svg+xml" -> false
       "application/pdf" -> true
       "text/plain" -> true
@@ -513,6 +516,93 @@ defmodule EngramWeb.AttachmentsController do
     end
   end
 
+  # Bandit compresses ANY response body when the client sends `Accept-Encoding:
+  # gzip`: `Bandit.Compression.negotiate_content_encoding/2` defaults `compress`
+  # to true, and `new/5` applies NO content-type check. So a PNG, PDF or video
+  # gets deflated on the way out — CPU spent to produce a payload that is
+  # usually LARGER than the input. A 2026-08-21 prod profile put
+  # `:zlib.append_iolist/2` at 8.57s, 5.79% of all CPU, reached straight from
+  # this controller's `action/2`.
+  #
+  # `cache-control: no-transform` is the one opt-out Bandit honours
+  # (`response_indicates_no_transform/1`) that is also semantically correct:
+  # RFC 9111 no-transform tells intermediaries not to re-encode the payload,
+  # which is exactly the claim being made. The alternatives are worse — a
+  # `content-encoding: identity` header is not valid in a response per RFC 9110
+  # (identity is an Accept-Encoding-only token), and faking a strong ETag to
+  # suppress compression would be a lie about the representation.
+  #
+  # APPEND, never replace. Phoenix already sets `cache-control: max-age=0,
+  # private, must-revalidate` on these responses, so a `put_resp_header/3` with
+  # a bare `no-transform` silently drops `private` — quietly making attachment
+  # bytes shared-cacheable as a side effect of a CPU fix, which is exactly the
+  # class of accident docs/context/edge-cache-request-varying-headers.md is
+  # about. Bandit only needs the token present in the list, not alone.
+  @doc false
+  @spec no_transform_directive() :: String.t()
+  def no_transform_directive, do: "no-transform"
+
+  # Types whose bytes are already entropy-coded. Note the exclusions:
+  # `image/svg+xml` is XML, `image/bmp` and `image/tiff` are commonly stored
+  # uncompressed, and `application/octet-stream` says nothing about the
+  # payload — all keep gzip.
+  #
+  # Deliberately an allow-list, not a deny-list: an unrecognised type keeps
+  # compressing, so a stale list costs a little CPU rather than shipping a
+  # large payload uncompressed.
+  @precompressed_exact MapSet.new(~w(
+    application/pdf application/zip application/gzip application/x-gzip
+    application/x-7z-compressed application/x-rar-compressed application/x-bzip2
+    application/vnd.rar application/epub+zip
+    font/woff font/woff2
+  ))
+
+  @precompressed_prefixes ~w(video/ audio/)
+
+  @doc false
+  @spec precompressed?(String.t() | nil) :: boolean()
+  def precompressed?(mime) do
+    # Same normalizer as the upload gate and `inline_safe?/1`: a media type
+    # must not mean different things to different gates just because it
+    # carries a parameter or odd casing.
+    case MimeWhitelist.normalize(mime) do
+      nil -> false
+      "image/svg+xml" -> false
+      "image/bmp" -> false
+      "image/tiff" -> false
+      type -> precompressed_type?(type)
+    end
+  end
+
+  defp precompressed_type?(type) do
+    String.starts_with?(type, "image/") or
+      Enum.any?(@precompressed_prefixes, &String.starts_with?(type, &1)) or
+      MapSet.member?(@precompressed_exact, type)
+  end
+
+  defp maybe_skip_compression(conn, mime) do
+    if precompressed?(mime), do: append_no_transform(conn), else: conn
+  end
+
+  defp append_no_transform(conn) do
+    case get_resp_header(conn, "cache-control") do
+      [] ->
+        put_resp_header(conn, "cache-control", no_transform_directive())
+
+      [existing | _] ->
+        if no_transform_directive() in Plug.Conn.Utils.list(existing) do
+          conn
+        else
+          put_resp_header(conn, "cache-control", existing <> ", " <> no_transform_directive())
+        end
+    end
+  end
+
+  # `content_hash` is a keyed HMAC over the plaintext, scoped to this user's
+  # own DEK — it is not derivable by anyone else and tells its owner exactly
+  # one thing: whether the bytes they hold are the bytes we hold. Exposing it
+  # is what lets a client stop re-sending attachments the server already has
+  # (see Engram.Attachments.identical_or_changed/4).
   defp serialize_metadata(att) do
     %{
       id: att.id,
@@ -520,6 +610,7 @@ defmodule EngramWeb.AttachmentsController do
       mime_type: att.mime_type,
       size_bytes: att.size_bytes,
       mtime: att.mtime,
+      content_hash: att.content_hash,
       created_at: att.created_at,
       updated_at: att.updated_at
     }

--- a/lib/engram_web/controllers/vault_tree_controller.ex
+++ b/lib/engram_web/controllers/vault_tree_controller.ex
@@ -78,7 +78,12 @@ defmodule EngramWeb.VaultTreeController do
     json(conn, %{
       folders: Notes.folders_payload(user, vault),
       notes: Enum.sort_by(notes, & &1.path),
-      attachments: Enum.sort_by(attachments, & &1.path),
+      # `list_attachments/2` carries content_hash for the sync-facing listing;
+      # the tree never reads it, and the whole point of this endpoint is that
+      # it does not ship per-file hashes (see the moduledoc). Dropped here so
+      # the attachment half keeps the promise the notes half already makes.
+      attachments:
+        attachments |> Enum.sort_by(& &1.path) |> Enum.map(&Map.delete(&1, :content_hash)),
       change_seq: current_seq
     })
   end

--- a/lib/engram_web/schemas/attachments.ex
+++ b/lib/engram_web/schemas/attachments.ex
@@ -12,6 +12,14 @@ defmodule EngramWeb.Schemas.AttachmentMeta do
       mime_type: %Schema{type: :string, nullable: true},
       size_bytes: %Schema{type: :integer},
       mtime: %Schema{type: :number, format: :float, description: "Client mtime (epoch seconds)"},
+      content_hash: %Schema{
+        type: :string,
+        nullable: true,
+        description:
+          "Opaque content fingerprint. Stable for identical bytes and scoped to the " <>
+            "owning account. Compare against a local copy to decide whether an upload " <>
+            "is needed; re-uploading matching bytes is accepted but does no work."
+      },
       created_at: %Schema{type: :string, format: :"date-time", nullable: true},
       updated_at: %Schema{type: :string, format: :"date-time", nullable: true}
     },
@@ -33,6 +41,11 @@ defmodule EngramWeb.Schemas.AttachmentWithContent do
       mime_type: %Schema{type: :string, nullable: true},
       size_bytes: %Schema{type: :integer},
       mtime: %Schema{type: :number, format: :float},
+      content_hash: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Opaque content fingerprint — see AttachmentMeta.content_hash."
+      },
       content_base64: %Schema{type: :string, description: "Base64-encoded file bytes."},
       created_at: %Schema{type: :string, format: :"date-time", nullable: true},
       updated_at: %Schema{type: :string, format: :"date-time", nullable: true}

--- a/openapi.json
+++ b/openapi.json
@@ -1142,6 +1142,13 @@
       },
       "AttachmentMeta": {
         "properties": {
+          "content_hash": {
+            "description": "Opaque content fingerprint. Stable for identical bytes and scoped to the owning account. Compare against a local copy to decide whether an upload is needed; re-uploading matching bytes is accepted but does no work.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "created_at": {
             "format": "date-time",
             "nullable": true,
@@ -2155,6 +2162,13 @@
         "properties": {
           "content_base64": {
             "description": "Base64-encoded file bytes.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "content_hash": {
+            "description": "Opaque content fingerprint — see AttachmentMeta.content_hash.",
+            "nullable": true,
             "type": "string",
             "x-struct": null,
             "x-validate": null

--- a/test/engram/attachments_seq_feed_test.exs
+++ b/test/engram/attachments_seq_feed_test.exs
@@ -18,10 +18,10 @@ defmodule Engram.AttachmentsSeqFeedTest do
     row
   end
 
-  defp put(user, vault, path) do
+  defp put(user, vault, path, content \\ nil) do
     Attachments.upsert_attachment(user, vault, %{
       "path" => path,
-      "content_base64" => b64(path),
+      "content_base64" => b64(content || path),
       "mime_type" => "image/png"
     })
   end
@@ -30,8 +30,26 @@ defmodule Engram.AttachmentsSeqFeedTest do
     {:ok, a} = put(user, vault, "a.png")
     assert att_row(user, a.id).version == 1
 
-    {:ok, _} = put(user, vault, "a.png")
+    # An UPDATE means different bytes. This used to re-send the identical
+    # payload (the helper defaulted content to the path) and still expect a
+    # bump — which is the behaviour the identical-content short-circuit
+    # deliberately removed, and is asserted below instead.
+    {:ok, _} = put(user, vault, "a.png", "genuinely new bytes")
     assert att_row(user, a.id).version == 2
+  end
+
+  test "re-sending identical bytes does not bump version", %{user: user, vault: vault} do
+    # `version` and `seq` drive the sync feed: bumping them for a write that
+    # changed nothing hands every other device a change to chase. A looping
+    # client did exactly this ~5,400 times on 2026-08-21.
+    {:ok, a} = put(user, vault, "a.png")
+    before = att_row(user, a.id)
+
+    {:ok, _} = put(user, vault, "a.png")
+    after_row = att_row(user, a.id)
+
+    assert after_row.version == before.version
+    assert after_row.seq == before.seq
   end
 
   test "attachment seq feed returns seq>cursor incl tombstones", %{user: user, vault: vault} do

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -197,6 +197,89 @@ defmodule Engram.AttachmentsTest do
     end
   end
 
+  # A client that re-sends bytes the server already has must not cost a
+  # re-encrypt, an S3 PUT, or a row write. On 2026-08-21 one looping Obsidian
+  # client re-uploaded the same 667 attachments for 90 minutes and held prod at
+  # ~30% CPU on a 0.5-vCPU task; every request was individually legal and no
+  # rate limit came close to firing (the loop ran at ~1 req/s against a 30 rps
+  # cap). `content_hash` is already computed and stored on every write — this
+  # makes the write path consult it.
+  describe "upsert_attachment/3 — identical-content short-circuit" do
+    test "re-uploading identical bytes does not touch storage again", %{
+      user: user,
+      vault: vault
+    } do
+      # Exactly ONE put across two upserts. Mox fails the test if a second
+      # arrives, which is the whole assertion.
+      expect(Engram.MockStorage, :put, 1, fn _key, _binary, _opts -> :ok end)
+
+      params = %{"path" => @path, "content_base64" => @valid_content}
+
+      assert {:ok, first} = Attachments.upsert_attachment(user, vault, params)
+      assert {:ok, second} = Attachments.upsert_attachment(user, vault, params)
+
+      assert second.id == first.id
+      assert second.content_hash == first.content_hash
+    end
+
+    test "the short-circuit does not bump the row (no spurious sync fan-out)", %{
+      user: user,
+      vault: vault
+    } do
+      expect(Engram.MockStorage, :put, 1, fn _key, _binary, _opts -> :ok end)
+      params = %{"path" => @path, "content_base64" => @valid_content}
+
+      {:ok, first} = Attachments.upsert_attachment(user, vault, params)
+      {:ok, second} = Attachments.upsert_attachment(user, vault, params)
+
+      # A bumped seq is a change event every other device would chase. The
+      # loop was writing ~1/s; without this the fan-out is the second bill.
+      assert second.seq == first.seq
+      assert second.updated_at == first.updated_at
+    end
+
+    test "different bytes at the same path still write", %{user: user, vault: vault} do
+      expect(Engram.MockStorage, :put, 2, fn _key, _binary, _opts -> :ok end)
+
+      {:ok, first} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => @path,
+          "content_base64" => @valid_content
+        })
+
+      {:ok, second} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => @path,
+          "content_base64" => Base.encode64("genuinely different bytes")
+        })
+
+      assert second.id == first.id
+      refute second.content_hash == first.content_hash
+      assert second.size_bytes == byte_size("genuinely different bytes")
+    end
+
+    test "identical bytes at a DIFFERENT path still write", %{user: user, vault: vault} do
+      # The short-circuit keys on (path, hash) — matching content under a new
+      # path is a new attachment, not a no-op.
+      expect(Engram.MockStorage, :put, 2, fn _key, _binary, _opts -> :ok end)
+
+      {:ok, a} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => @path,
+          "content_base64" => @valid_content
+        })
+
+      {:ok, b} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "photos/copy.png",
+          "content_base64" => @valid_content
+        })
+
+      refute b.id == a.id
+      assert b.path == "photos/copy.png"
+    end
+  end
+
   describe "upsert_attachment/3" do
     test "creates attachment with vault_id scoped correctly", %{user: user, vault: vault} do
       expect(Engram.MockStorage, :put, fn _key, _binary, _opts -> :ok end)

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -258,6 +258,54 @@ defmodule Engram.AttachmentsTest do
       assert second.size_bytes == byte_size("genuinely different bytes")
     end
 
+    test "a corrected mime_type still lands even when the bytes are identical", %{
+      user: user,
+      vault: vault
+    } do
+      # Re-uploading identical bytes with a corrected type is how a
+      # mis-detected MIME gets fixed. Gating the short-circuit on content
+      # ALONE silently swallowed the correction and answered 200 with the old
+      # type — found by adversarially reviewing the short-circuit, not by any
+      # existing test.
+      b64 = Base.encode64("PNGDATA")
+      expect(Engram.MockStorage, :put, 2, fn _key, _binary, _opts -> :ok end)
+
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "img/a.png",
+          "content_base64" => b64,
+          "mime_type" => "image/jpeg"
+        })
+
+      {:ok, corrected} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "img/a.png",
+          "content_base64" => b64,
+          "mime_type" => "image/png"
+        })
+
+      assert corrected.mime_type == "image/png"
+    end
+
+    test "delete then re-upload identical bytes resurrects the attachment", %{
+      user: user,
+      vault: vault
+    } do
+      # `fetch_existing` is `scoped_live`, so a tombstoned row is invisible to
+      # the short-circuit and resurrection takes the full write path. Pinned
+      # because "identical bytes are a no-op" is exactly the reasoning that
+      # would break it.
+      stub(Engram.MockStorage, :put, fn _key, _binary, _opts -> :ok end)
+      stub(Engram.MockStorage, :delete, fn _key -> :ok end)
+      params = %{"path" => @path, "content_base64" => @valid_content}
+
+      {:ok, _} = Attachments.upsert_attachment(user, vault, params)
+      :ok = Attachments.delete_attachment(user, vault, @path)
+      {:ok, _} = Attachments.upsert_attachment(user, vault, params)
+
+      assert @path in live_paths(user, vault)
+    end
+
     test "identical bytes at a DIFFERENT path still write", %{user: user, vault: vault} do
       # The short-circuit keys on (path, hash) — matching content under a new
       # path is a new attachment, not a no-op.

--- a/test/engram_web/controllers/attachment_compression_test.exs
+++ b/test/engram_web/controllers/attachment_compression_test.exs
@@ -1,0 +1,85 @@
+defmodule EngramWeb.AttachmentCompressionTest do
+  @moduledoc """
+  Bandit compresses ANY response body when the client sends `Accept-Encoding:
+  gzip` — `Bandit.Compression.negotiate_content_encoding/2` defaults `compress`
+  to true and `new/5` applies no content-type check whatsoever. So a PNG, a PDF
+  or a video gets deflated on the way out: CPU spent to produce a payload that
+  is usually LARGER than the input.
+
+  A 2026-08-21 prod profile put `:zlib.append_iolist/2` at 8.57s (5.79% of all
+  CPU), reached directly from `AttachmentsController.action/2`.
+
+  Bandit skips compression when the response carries `cache-control:
+  no-transform` (`response_indicates_no_transform/1`), which is also the
+  semantically correct header: RFC 9111 no-transform means intermediaries must
+  not re-encode the payload.
+  """
+  use EngramWeb.ConnCase, async: true
+
+  alias EngramWeb.AttachmentsController, as: C
+
+  describe "precompressed?/1" do
+    test "already-compressed binaries are marked no-transform" do
+      for mime <- [
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "image/avif",
+            "video/mp4",
+            "audio/mpeg",
+            "application/pdf",
+            "application/zip",
+            "application/gzip",
+            "font/woff2"
+          ] do
+        assert C.precompressed?(mime), "#{mime} should skip compression"
+      end
+    end
+
+    test "text-ish payloads still compress — gzip earns its keep there" do
+      for mime <- [
+            "text/plain",
+            "text/markdown",
+            "text/csv",
+            "image/svg+xml",
+            "application/json",
+            "application/xml",
+            "image/bmp"
+          ] do
+        refute C.precompressed?(mime), "#{mime} should still be compressed"
+      end
+    end
+
+    test "an unknown or nil type compresses (the safe default: never lose gzip)" do
+      refute C.precompressed?(nil)
+      refute C.precompressed?("application/octet-stream")
+      refute C.precompressed?("application/x-made-up")
+    end
+
+    test "parameters and casing do not defeat the match" do
+      assert C.precompressed?("IMAGE/PNG")
+      assert C.precompressed?("image/png; charset=binary")
+      assert C.precompressed?(" image/jpeg ")
+    end
+  end
+
+  describe "no_transform directive" do
+    test "uses the exact token Bandit looks for" do
+      # Bandit: `"no-transform" in Plug.Conn.Utils.list(header)`. If this token
+      # ever drifts, compression silently comes back and only the CPU profile
+      # would show it.
+      assert "no-transform" in Plug.Conn.Utils.list(C.no_transform_directive())
+    end
+
+    test "survives being appended to Phoenix's default cache-control" do
+      # The directive is appended, never substituted (see append_no_transform/1).
+      # Both the pre-existing directives and the new one must parse out.
+      appended = "max-age=0, private, must-revalidate, " <> C.no_transform_directive()
+      directives = Plug.Conn.Utils.list(appended)
+
+      assert "no-transform" in directives
+      assert "private" in directives
+    end
+  end
+end

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -48,6 +48,38 @@ defmodule EngramWeb.AttachmentsControllerTest do
       assert is_binary(att["updated_at"])
     end
 
+    # `content_hash` has been computed and stored on every write since the
+    # encryption work, but no serializer ever returned it — so a client had no
+    # way to ask "do you already have these exact bytes?" and force-push paths
+    # had no choice but to re-send them. That gap is what let one looping
+    # client re-upload the same 667 attachments for 90 minutes on 2026-08-21.
+    test "returns content_hash so a client can skip re-sending known bytes", %{conn: conn} do
+      conn =
+        post(conn, "/api/attachments", %{
+          path: "photos/test.png",
+          content_base64: @sample_base64,
+          mtime: 1_709_234_567.0
+        })
+
+      assert %{"attachment" => att} = json_response(conn, 200)
+      assert is_binary(att["content_hash"])
+      assert att["content_hash"] != ""
+    end
+
+    test "the same bytes hash the same, different bytes differ", %{conn: conn} do
+      upload = fn path, b64 ->
+        conn
+        |> post("/api/attachments", %{path: path, content_base64: b64, mtime: 1.0})
+        |> json_response(200)
+        |> get_in(["attachment", "content_hash"])
+      end
+
+      # Stable across paths — the client compares hashes, so an unstable hash
+      # would silently reinstate the re-upload loop it exists to prevent.
+      assert upload.("a.png", @sample_base64) == upload.("b.png", @sample_base64)
+      refute upload.("c.png", @sample_base64) == upload.("d.png", @updated_base64)
+    end
+
     test "auto-detects MIME type from extension", %{conn: conn} do
       conn =
         post(conn, "/api/attachments", %{
@@ -451,6 +483,22 @@ defmodule EngramWeb.AttachmentsControllerTest do
       assert resp["attachments"] == []
     end
 
+    test "the listing carries content_hash", %{conn: conn} do
+      # The index is what a client sweeps before deciding what to push. Without
+      # a hash here it must either trust its own local stamp or re-send
+      # everything — and the force-push paths chose re-send.
+      conn
+      |> post("/api/attachments", %{
+        path: "diagrams/arch.png",
+        content_base64: Base.encode64("PNG"),
+        mtime: 1_000.0
+      })
+      |> json_response(200)
+
+      assert [a] = conn |> get("/api/attachments") |> json_response(200) |> Map.get("attachments")
+      assert is_binary(a["content_hash"])
+    end
+
     test "returns 401 without auth", %{conn: conn} do
       conn =
         conn
@@ -482,6 +530,51 @@ defmodule EngramWeb.AttachmentsControllerTest do
       assert response_content_type(resp, :png) =~ "image/png"
       assert resp.resp_body == "RAWBYTES"
       assert get_resp_header(resp, "content-disposition") == [~s(inline; filename="p.png")]
+    end
+
+    test "marks an already-compressed body no-transform so Bandit skips gzip",
+         %{conn: conn} do
+      # The pure predicate is covered in AttachmentCompressionTest; this is the
+      # WIRING check — without the `maybe_skip_compression/2` call in show/2
+      # everything else stays green while Bandit happily re-deflates every PNG.
+      _ =
+        conn
+        |> post("/api/attachments", %{
+          path: "p.png",
+          content_base64: Base.encode64("RAWBYTES"),
+          mtime: 1.0
+        })
+        |> json_response(200)
+
+      resp = get(conn, "/api/attachments/p.png?raw=1")
+
+      [cache_control] = get_resp_header(resp, "cache-control")
+      directives = Plug.Conn.Utils.list(cache_control)
+
+      assert "no-transform" in directives
+      # Phoenix's default directives must SURVIVE. Replacing the header instead
+      # of appending would strip `private` off attachment bytes as a side
+      # effect of a CPU fix — the whole point of asserting the list, not the
+      # string.
+      assert "private" in directives
+      assert "must-revalidate" in directives
+    end
+
+    test "leaves compressible bodies alone — gzip still earns its keep", %{conn: conn} do
+      _ =
+        conn
+        |> post("/api/attachments", %{
+          path: "notes.txt",
+          content_base64: Base.encode64("plain text, very compressible"),
+          mime_type: "text/plain",
+          mtime: 1.0
+        })
+        |> json_response(200)
+
+      resp = get(conn, "/api/attachments/notes.txt?raw=1")
+
+      [cache_control] = get_resp_header(resp, "cache-control")
+      refute "no-transform" in Plug.Conn.Utils.list(cache_control)
     end
 
     test "forces download for inline-script types (svg)", %{conn: conn} do


### PR DESCRIPTION
## What happened

A single looping Obsidian client held prod at **~30% CPU for 90 minutes** on 2026-08-21, re-uploading the same 667 attachments. CPU fell to 3.6% within two minutes of closing the client.

Pyroscope, 20-minute window (118s of CPU):

| Frame | Share |
|---|---|
| `AttachmentsController.action/2` | **44.7%** |
| ├─ `Attachments.upsert_attachment/3` | 34.2% |
| │  └─ `Base.decode64base!/1` | **30.4%** |
| └─ `send_resp` → `:zlib.deflate/3` | 12.2% |
| `Jason.Encode.escape_json_chunk/5` | 10.1% |

The tell was S3: object count frozen at exactly **667** while objects were rewritten at ~1/sec. No new attachments, ~5,400 redundant writes.

## Why nothing stopped it

Every rate control in the stack counts **requests**, and one request carrying 6 MB is indistinguishable from one carrying a note edit.

| Guard | Limit | Loop's usage |
|---|---|---|
| `PreAuthRateLimit` | 600/min (~10 rps) | ~1 rps |
| `RequireApiRpsBudget` (pro) | 30 rps | ~1 rps — **3% of budget** |
| `max_file_bytes` | per-file | every file legal |
| `attachment_bytes_cap` | lifetime **storage** | ~0 growth |

That last row is the sharp one: the loop *overwrote* the same keys, so stored bytes never grew and the quota stayed blind to all 5,400 writes.

**A bytes-per-minute cap was considered and rejected on the numbers.** The loop moved ~45 MB/min; a legitimate first sync moves ~240 MB/min. Any threshold safe for real bulk imports would have sailed straight past this. Rate is not what separates a loop from an import — redundancy is.

## Changes

**1. Identical-content short-circuit** (`identical_or_changed/5`). `content_hash` is already computed and stored on every write; the write path now consults it. Matching bytes skip the encrypt, the S3 PUT, the locked row write, and the `"upsert"` broadcast every peer would otherwise chase. Needs no client cooperation — this is the part that actually caps the blast radius.

Gated on the effective **MIME as well as the bytes**. Content alone was not enough, and that was a real defect caught in review: re-uploading identical bytes with a corrected `mime_type` is how a mis-detected type gets fixed, and gating on content alone silently swallowed the correction while answering 200 with the old type. A MIME change now falls through to the full write.

`mtime` deliberately does **not** gate — it is client-reported metadata no read path consults (the plugin's `applyAttachmentChange` decides by comparing bytes), so gating on it would spend a re-encrypt + PUT on a field nothing reads.

**2. Expose `content_hash` on the attachment endpoints.**

> **Correction.** An earlier version of this description claimed the hash "was stored but never serialized, so no client could ask *do you already have these bytes?*" **That was wrong.** `GET /sync/manifest` has been shipping attachment `content_hash` all along (`sync_controller.ex:131,155`), and the plugin already receives it (`ManifestResponse.attachments` in `types.ts`).

The real gap is narrower: the hash was missing from the *attachment* endpoints (`POST /attachments`, the index, `show`) — the ones the push path touches — so deciding about one file required a whole-vault manifest fetch. Adding it there is a **convenience, not a missing capability**. Trimmed from `/api/vault/tree`, which deliberately ships no per-file hashes.

Consequence worth noting: **the plugin-side fix does not depend on this PR.** The force-push paths already hold manifest hashes; they consult the local `syncState` stamp instead, which `force` deliberately distrusts.

**3. Skip gzip on already-compressed bodies.** Bandit's `negotiate_content_encoding/2` defaults `compress` to true and applies **no** content-type check, so every PNG, PDF and video was being deflated on the way out. Uses `cache-control: no-transform` — verified against the dependency source (`deps/bandit/lib/bandit/compression.ex:65-70`, a `Plug.Conn.Utils.list/1` token check). **Appended** to Phoenix's default directives, never substituted: replacing the header would strip `private` off attachment bytes as a side effect of a CPU fix.

## Contract change

A no-op upsert no longer bumps `version`/`seq`. `attachments_seq_feed_test` asserted the old behaviour, but its helper defaulted content to the path — so *"bumps on update"* was re-sending byte-identical content. The fixture now performs a real update, and a companion test pins the new contract. Not bumping is the point: `version` and `seq` drive the sync feed, so bumping them for a write that changed nothing hands every other device a change to chase.

## Known limitations

- **The short-circuit trusts the DB row, not S3.** If an object vanished from the bucket behind a live row, re-sending identical bytes no longer repairs it — delete-then-reupload does. Named at the call site with the upgrade path (HEAD the storage key).
- **The compression fix is not covered end-to-end.** `Phoenix.ConnTest` does not run the Bandit adapter, so the tests prove the predicate and that the header lands on the response; the "Bandit therefore skips gzip" link is verified by reading its source, not by an integration test. A Bandit change to that check would silently restore the CPU burn and only a profile would show it.

## Security note (verified, not assumed)

`content_hash` is keyed off the user's own DEK (`dek_content_hash_key/1`), whose documented purpose is to prevent "cross-user dedup oracles and dictionary attacks against known content". Exposing it to its owner leaks nothing new — and the sync manifest already exposed it.

## Testing

- Compression predicate + the exact token Bandit matches on
- **Wiring verified by unwiring it** and confirming the assertion fails — the header landing on a real response, with Phoenix's `private`/`must-revalidate` surviving
- Short-circuit negatives: different bytes at the same path, identical bytes at a *new* path, **corrected MIME with identical bytes**, and **delete-then-reupload resurrection** (`fetch_existing` is `scoped_live`, so a tombstone is invisible to the short-circuit — pinned because "identical bytes are a no-op" is exactly the reasoning that would break it)
- Hash stability across paths (an unstable hash would silently reinstate the loop)

Local: 4779 tests, `credo --strict` clean, dialyzer clean, sobelow clean (skip count held at 21 — no new suppressions; fingerprints rotated for line shifts only). One unrelated failure, `ObanQueueConfigTest`, is a 60s module-enumeration timeout under load — passes in isolation.

## Follow-ups (not in this PR)

- Plugin: force paths should compare the manifest hash they **already receive** before re-sending; the offline-queue drain at `sync.ts:9337` has **no** guard at all
- Plugin: `sync.ts:8252` comment claims "fullSync calls pushAll" — it calls `pushModifiedFiles`; stale and misleading
- Observability: client push decisions log via `rlog().info`, which never reaches Loki — this loop was undiagnosable from the server side

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2