### PR TITLE
feat(crdt): attribute why a genesis body was not seeded roomlessly

### DIFF
--- a/e2e/helpers/room_probe.py
+++ b/e2e/helpers/room_probe.py
@@ -42,20 +42,33 @@ from helpers.backend_rpc import backend_rpc
 # RoomStarts — all three are read positionally.
 SOURCES = ("handshake", "edit", "create_batch", "unknown")
 
+# SOURCES is the ONE definition of both the slot count and the atom->slot
+# mapping. An earlier revision hard-coded `:counters.new(4, [])` and `1..4`
+# alongside it — three places encoding the same number, so adding a fifth
+# source would have silently under-counted (and `:counters.add` past the end
+# raises INSIDE the telemetry handler, which detaches it: the probe would then
+# report zeros, and zeros read as "no rooms allocated"). Derived, not repeated.
+_N = len(SOURCES)
+_LAST = _N  # the catch-all slot; SOURCES[-1] must stay "unknown"
+
+_CASE_ARMS = "; ".join(
+    f":{name} -> {i}" for i, name in enumerate(SOURCES[:-1], start=1)
+)
+
 _ARM_EXPR = (
-    ":persistent_term.put(:e2e_room_starts, :counters.new(4, [])); "
+    f":persistent_term.put(:e2e_room_starts, :counters.new({_N}, [])); "
     ':telemetry.detach("e2e-room-starts"); '
     ':telemetry.attach("e2e-room-starts", [:engram, :crdt, :room_start], '
     "fn _, _, meta, _ -> "
     ":counters.add(:persistent_term.get(:e2e_room_starts), "
-    "(case meta[:source] do :handshake -> 1; :edit -> 2; :create_batch -> 3; _ -> 4 end), 1) "
+    f"(case meta[:source] do {_CASE_ARMS}; _ -> {_LAST} end), 1) "
     "end, nil); "
     'IO.puts("armed")'
 )
 
 _READ_EXPR = (
     "c = :persistent_term.get(:e2e_room_starts); "
-    "1..4 |> Enum.map(&:counters.get(c, &1)) |> Enum.join(\",\") |> IO.puts()"
+    f"1..{_N} |> Enum.map(&:counters.get(c, &1)) |> Enum.join(\",\") |> IO.puts()"
 )
 
 

--- a/e2e/helpers/room_probe.py
+++ b/e2e/helpers/room_probe.py
@@ -1,0 +1,99 @@
+"""Count CRDT rooms ALLOCATED on the backend node, broken down by the call
+path that allocated each one.
+
+Backs the #1409 acceptance criterion — "a bulk/first sync of N notes creates
+O(open editors) rooms, not O(N)" — with a number instead of a hope.
+
+Why allocation and not residency: `ci/compose.yml` sets `CRDT_IDLE_EXIT_MS`,
+so rooms a regression opened at the top of a test have drained long before it
+ends. Sampling `:global` afterwards measures instantaneous residency, and a
+full room-per-note regression passes that assertion — the burst comes and goes
+entirely between two samples. Allocation is the claim; count allocation.
+(test_09 makes the same argument for its flat counter, which this generalises.)
+
+Why by source: a count alone says how many rooms an import allocated, never
+WHY. The 2026-08-19 staging import measured 406 rooms for 1,516 notes with no
+way to attribute them, which is what motivated the `source` tag (#1432). The
+buckets mirror the closed set of atoms fixed in `crdt_channel.ex`:
+
+    handshake / edit  — a `crdt_msg` frame, classified by `frame_class_b64/1`
+    create_batch      — `crdt_create_batch` room enrollment (the web SPA path)
+    unknown           — CrdtDoc.start_link's default: a caller that passed no
+                        source. Not expected to move; it is the "someone added
+                        an allocation path and forgot to tag it" tripwire, and
+                        a silent zero here is a real signal, not filler.
+
+The counter lives in `:persistent_term` (an `:atomics` ref, the same idiom
+`FanoutPacer.test_drop_next/2` uses for e2e-armed counters) so it survives the
+rpc process that arms it.
+
+Both expressions are ONE logical Elixir line: `bin/engram rpc` takes the
+expression as a single argv, and a one-liner cannot be reshaped by any newline
+handling on the way through the release wrapper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from helpers.backend_rpc import backend_rpc
+
+# Counter slot order. Must match the `case` in _ARM_EXPR and the field order of
+# RoomStarts — all three are read positionally.
+SOURCES = ("handshake", "edit", "create_batch", "unknown")
+
+_ARM_EXPR = (
+    ":persistent_term.put(:e2e_room_starts, :counters.new(4, [])); "
+    ':telemetry.detach("e2e-room-starts"); '
+    ':telemetry.attach("e2e-room-starts", [:engram, :crdt, :room_start], '
+    "fn _, _, meta, _ -> "
+    ":counters.add(:persistent_term.get(:e2e_room_starts), "
+    "(case meta[:source] do :handshake -> 1; :edit -> 2; :create_batch -> 3; _ -> 4 end), 1) "
+    "end, nil); "
+    'IO.puts("armed")'
+)
+
+_READ_EXPR = (
+    "c = :persistent_term.get(:e2e_room_starts); "
+    "1..4 |> Enum.map(&:counters.get(c, &1)) |> Enum.join(\",\") |> IO.puts()"
+)
+
+
+@dataclass(frozen=True)
+class RoomStarts:
+    """Rooms allocated, per call path. Field order matches SOURCES."""
+
+    handshake: int
+    edit: int
+    create_batch: int
+    unknown: int
+
+    @property
+    def total(self) -> int:
+        return self.handshake + self.edit + self.create_batch + self.unknown
+
+    def __sub__(self, other: "RoomStarts") -> "RoomStarts":
+        """Delta between two samples — the counter is cumulative per node, so a
+        test measures its own window rather than everything since boot."""
+        return RoomStarts(
+            *(getattr(self, s) - getattr(other, s) for s in SOURCES)
+        )
+
+    def __str__(self) -> str:
+        parts = ", ".join(f"{s}={getattr(self, s)}" for s in SOURCES)
+        return f"{self.total} rooms ({parts})"
+
+
+def arm_room_starts() -> None:
+    """Install the telemetry handler. Call once before the measured window."""
+    # backend_rpc raises on a non-zero exit, and this asserts the sentinel, so a
+    # mis-staged probe fails loudly here rather than leaving a vacuously green
+    # assertion at the end of the test.
+    out = backend_rpc(_ARM_EXPR)
+    assert "armed" in out, f"room-start counter did not arm: {out!r}"
+
+
+def read_room_starts() -> RoomStarts:
+    """Sample the cumulative per-source counts."""
+    line = backend_rpc(_READ_EXPR).strip().splitlines()[-1]
+    return RoomStarts(*(int(v) for v in line.split(",")))

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -1,11 +1,18 @@
-"""Test 77: 1k-note bulk first sync lands via crdt_create_batch in bounded time.
+"""Test 77: a 1k-note bulk first sync lands in bounded time, and does not
+allocate a CRDT room per note.
 
-CRDT single-push-path migration: pushGenesisBatch sends notes through the
-WS `crdt_create_batch` op in chunks, not POST /notes/batch (removed) — a
-1,000-note first sync is a handful of socket round-trips instead of 1,000.
-The duration bound is deliberately generous for CI noise but far below
-what the per-note path costs (1,000 paced requests), so a silent fallback
-to per-note pushes fails this test.
+Push path: `pushPartitioned` -> `pushFile` -> socket-native `crdt_create`,
+one bounded per-file work unit each (the `crdt_create_batch` RPC this test
+was originally written against was retired in the Relay-pattern rewrite, in
+favour of per-file failure isolation). The duration bound is deliberately
+generous for CI noise but far below what a REST per-note fallback costs
+(1,000 paced requests), so a silent regression to that path fails here.
+
+The room-allocation bound is the #1409 acceptance criterion. A room is a
+live-collaboration actor; an import has no collaborators, so genesis content
+is seeded detached (#1424) and rooms should be allocated only for notes
+actually open in an editor. Importing a 1,700-file vault once allocated
+~1,700 rooms and took prod's BEAM from 757 to 2,744 processes (2026-08-18).
 """
 
 import shutil
@@ -13,10 +20,23 @@ import time
 
 import pytest
 
+from helpers.room_probe import arm_room_starts, read_room_starts
 from helpers.vault import write_note
 
 NOTE_COUNT = 1000
 PUSH_TIME_BOUND_S = 120
+
+# Rooms this sync may allocate. The criterion is O(open editors), not O(N) —
+# the bound is a small constant on purpose, so a per-note regression fails by
+# two orders of magnitude rather than by a tuning argument. Raising this is
+# only correct alongside a reason a first sync needs more live actors.
+#
+# MEASURED 0 locally on 0.18.0 (2026-08-20, 1,000 notes): with the genesis body
+# riding `crdt_create` (#1424 + plugin #452) the import never sends a `crdt_msg`,
+# and `crdt_msg` is what calls `ensure_room`. The headroom above 0 covers a note
+# open in the editor during the run and any seed that falls back to the
+# `crdt_msg` path (`seeded: false`, e.g. an ADOPT) — both allocate legitimately.
+ROOM_ALLOC_BOUND = 8
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
@@ -63,6 +83,12 @@ async def _cleanup_bulk_residue(vault_a, cdp_a, api_sync) -> None:
 @pytest.mark.asyncio
 async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
     try:
+        # Arm BEFORE the gate work: the counter is cumulative per node and the
+        # measured window is a delta, so arming early only widens what is
+        # attributed to this test — it can never under-count the sync.
+        arm_room_starts()
+        rooms_before = read_room_starts()
+
         # Close the sync gate FIRST: every raw write below fires the vault
         # watcher, and an open gate turns that into 1,000 debounced single-note
         # auto-pushes — a request storm that exhausts the rate budget and
@@ -129,6 +155,18 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
             f"bulk first sync converged only {bulk_count}/{NOTE_COUNT} notes in "
             f"{elapsed:.1f}s (bound {PUSH_TIME_BOUND_S}s) — did the plugin fall "
             "back to per-note pushes or stall?"
+        )
+
+        # Read AFTER convergence: a room allocated by the tail of the sync must
+        # be counted, and the drain means residency would already have shed it.
+        rooms = read_room_starts() - rooms_before
+        print(f"\ntest_77 rooms allocated for {NOTE_COUNT} notes: {rooms}")
+        assert rooms.total <= ROOM_ALLOC_BOUND, (
+            f"bulk first sync of {NOTE_COUNT} notes allocated {rooms} — expected "
+            f"<= {ROOM_ALLOC_BOUND} (#1409: rooms are for notes open in an editor, "
+            "not for imported files). The per-source split names the path that "
+            "regressed; `unknown` means an allocation site shipped without a "
+            "source tag."
         )
     finally:
         await _cleanup_bulk_residue(vault_a, cdp_a, api_sync)

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -859,11 +859,14 @@ defmodule EngramWeb.CrdtChannel do
   # makes the plugin stamp its local body as the synced baseline and stop, so a
   # skipped checkpoint would silently lose the file with no later bind to replay
   # from. Every `false` path falls back to the client's existing crdt_msg seed.
-  defp maybe_seed_detached(_user, _vault, _note, nil), do: false
+  defp maybe_seed_detached(_user, _vault, _note, nil) do
+    seed_outcome(:no_b64)
+    false
+  end
 
   defp maybe_seed_detached(user, vault, %{id: note_id} = note, b64) when is_binary(b64) do
-    with {:ok, frame} <- decode_frame(b64),
-         :ok <- guard_frame(frame),
+    with {:ok, frame} <- decode_genesis_frame(b64),
+         :ok <- guard_genesis_frame(frame),
          # CRDT projects to `notes.content` for MARKDOWN only — `checkpoint/5`
          # routes a non-`.md` doc to `do_structural_checkpoint`, which never
          # touches content. A `.canvas` genesis frame therefore projects
@@ -873,8 +876,8 @@ defmodule EngramWeb.CrdtChannel do
          # and stops. Unreachable today only because the plugin gates `.md`
          # client-side; the server's contract must not depend on that (#1409).
          # Same `.md` test CrdtDeliver and CrdtCheckpoint already use.
-         true <- markdown_path?(note.path),
-         {:ok, {:sync, {:sync_update, update}}} <- Yex.Sync.message_decode(frame),
+         :ok <- require_markdown(note.path),
+         {:ok, update} <- take_sync_update(frame),
          # Two writers, one document: a room holds the doc in memory and would
          # later checkpoint over anything written behind its back. CheckpointNote
          # snoozes on this exact condition (checkpoint_note.ex:50); a channel
@@ -889,15 +892,90 @@ defmodule EngramWeb.CrdtChannel do
          # window on its own — a room merely starting never bumps `notes.version`,
          # only a COMMITTED checkpoint does. That window is closed AFTER the
          # write instead, by `evict_racing_room/1` below (#1409).
-         nil <- CrdtRegistry.lookup(note_id),
-         {:ok, doc} <- apply_detached(update) do
-      seed_detached(user, vault, note_id, doc)
+         :ok <- require_room_free(note_id),
+         {:ok, doc} <- apply_genesis_update(update) do
+      result = seed_detached(user, vault, note_id, doc)
+      seed_outcome(if result, do: :seeded, else: :write_declined)
+      result
     else
-      _ -> false
+      # Every arm here means "the client falls back to its crdt_msg seed", and
+      # THAT is what allocates a room per imported note (#1409). A bare
+      # `_ -> false` made all of them indistinguishable, so a 70%-fallback rate
+      # could be measured but never explained.
+      #
+      # Each step returns a DISTINCT reason atom rather than a bare
+      # `{:error, _}`, so this one arm still attributes precisely. Three of the
+      # underlying calls (decode, guard, apply) all answer `{:error, _}` and
+      # would otherwise collapse into one bucket — a malformed frame, a crafted
+      # state vector and a NIF apply failure are a client bug, an attack and a
+      # server fault respectively, and lumping them answers none of the
+      # questions you would ask next.
+      #
+      # Tagged tuples as `with` placeholders would be the obvious way to do
+      # this; credo forbids them (Credo.Check.Refactor.WithClauses), so the
+      # distinction lives in the step functions instead.
+      {:error, reason} ->
+        seed_outcome(reason)
+        false
     end
   end
 
-  defp maybe_seed_detached(_user, _vault, _note, _b64), do: false
+  defp maybe_seed_detached(_user, _vault, _note, _b64) do
+    seed_outcome(:b64_not_binary)
+    false
+  end
+
+  # `with` steps for maybe_seed_detached/4. Each maps its underlying call onto a
+  # reason atom unique to THAT step — the whole point of the split. Thin on
+  # purpose: the reasoning for each check stays at the call site above.
+  defp decode_genesis_frame(b64) do
+    case decode_frame(b64) do
+      {:ok, frame} -> {:ok, frame}
+      _ -> {:error, :frame_decode_failed}
+    end
+  end
+
+  defp guard_genesis_frame(frame) do
+    case guard_frame(frame) do
+      :ok -> :ok
+      _ -> {:error, :frame_unsafe}
+    end
+  end
+
+  defp require_markdown(path) do
+    if markdown_path?(path), do: :ok, else: {:error, :not_markdown}
+  end
+
+  defp take_sync_update(frame) do
+    case Yex.Sync.message_decode(frame) do
+      {:ok, {:sync, {:sync_update, update}}} -> {:ok, update}
+      _ -> {:error, :not_sync_update}
+    end
+  end
+
+  defp require_room_free(note_id) do
+    if CrdtRegistry.lookup(note_id) == nil, do: :ok, else: {:error, :room_already_exists}
+  end
+
+  defp apply_genesis_update(update) do
+    case apply_detached(update) do
+      {:ok, doc} -> {:ok, doc}
+      _ -> {:error, :apply_failed}
+    end
+  end
+
+  # Why a genesis body did or did not get seeded roomlessly.
+  #
+  # `reason` is a small CLOSED SET OF ATOMS and nothing else rides along. An
+  # earlier revision passed the raw error term as a `detail` key with a comment
+  # saying it must never become a tag — but nothing enforced that, and any
+  # handler doing `inspect(meta)` would have leaked it. These terms are exactly
+  # the class line 418 of this module warns about ("error_kind/1, never
+  # inspect(reason)"): they can embed a wrapped DEK or a provider response body.
+  # The per-step tags above carry the diagnostic value the term used to.
+  defp seed_outcome(reason) when is_atom(reason) do
+    :telemetry.execute([:engram, :crdt, :genesis_seed], %{count: 1}, %{reason: reason})
+  end
 
   defp markdown_path?(path), do: is_binary(path) and String.ends_with?(path, ".md")
 

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -135,6 +135,98 @@ defmodule EngramWeb.CrdtChannelTest do
     end
   end
 
+  # The `genesis_seed` telemetry is how a fallback rate gets ATTRIBUTED — the
+  # 2026-08-20 investigation could measure "70% of notes still open a room" but
+  # not why, until these reasons existed. An instrument nobody tests reports
+  # zeros when it breaks, and zeros read as "no declines", which is the same
+  # vacuously-green failure the room-start probe was built to avoid. So the
+  # instrument gets its own coverage.
+  describe "genesis_seed telemetry" do
+    setup do
+      test_pid = self()
+      handler = "genesis-seed-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:engram, :crdt, :genesis_seed],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:genesis_seed, meta, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+      :ok
+    end
+
+    test "a bodyless create reports :no_b64", %{socket: socket} do
+      ref =
+        push(socket, "crdt_create", %{"doc_id" => Ecto.UUID.generate(), "path" => "Notes/a.md"})
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, %{reason: :no_b64}, %{count: 1}}
+    end
+
+    test "a body-bearing create reports :seeded", %{socket: socket} do
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/b.md",
+          "b64" => frame_for_content("body")
+        })
+
+      assert_reply ref, :ok, %{seeded: true}
+      assert_receive {:genesis_seed, %{reason: :seeded}, %{count: 1}}
+    end
+
+    test "a non-markdown path reports :not_markdown, not a frame error", %{socket: socket} do
+      # `.canvas` rides these same creates but CRDT projects to notes.content
+      # for markdown only. Distinguishing it from a malformed frame is the whole
+      # reason the steps are tagged.
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/board.canvas",
+          "b64" => frame_for_content("body")
+        })
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, %{reason: :not_markdown}, _}
+    end
+
+    test "a malformed body reports :frame_decode_failed", %{socket: socket} do
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/c.md",
+          "b64" => "!!!not base64!!!"
+        })
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, %{reason: :frame_decode_failed}, _}
+    end
+
+    test "metadata carries ONLY the reason atom — never a payload-derived term", %{
+      socket: socket
+    } do
+      # These error terms are the class this module's line ~418 warns about
+      # ("error_kind/1, never inspect(reason)"): they can embed a wrapped DEK or
+      # a provider response body. A `detail` key shipped here once; nothing
+      # stopped a handler from `inspect`ing it into a log.
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/d.md",
+          "b64" => "!!!not base64!!!"
+        })
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, meta, _}
+      assert Map.keys(meta) == [:reason]
+      assert is_atom(meta.reason)
+    end
+  end
+
   describe "crdt_create with b64 (detached genesis seed)" do
     test "persists the body and creates NO room", %{socket: socket, user: user, vault: vault} do
       id = Ecto.UUID.generate()


### PR DESCRIPTION
The #1409 investigation could measure the fallback rate — **70% of a real 319-note vault still opened a room** — but not explain it. `maybe_seed_detached/4` ended in a bare `_ -> false`, so every decline looked identical.

Adds `[:engram, :crdt, :genesis_seed]` with a reason per outcome: `seeded`, `write_declined`, `no_b64`, `b64_not_binary`, `not_markdown`, `room_already_exists`, `not_sync_update`, `frame_decode_failed`, `frame_unsafe`, `apply_failed`.

**This is what found the actual cause.** 318/318 notes reported `seeded` with zero declines, which ruled out the seed path entirely and pointed at the client re-sending the body afterwards — fixed in engram-app/Engram-obsidian#460 (content was doubling 2x per sync, 128x on a sampled note).

## Reasons are per step, and carry nothing else

Three underlying calls (decode, guard, apply) all answer `{:error, _}`, so one arm would lump a malformed frame, a crafted state vector and a NIF apply failure — a client bug, an attack and a server fault. Each step now returns a reason atom unique to that step. Tagged tuples would be the obvious mechanism; credo forbids them in `with` (`Refactor.WithClauses`), so the distinction lives in small step functions instead.

Metadata is the reason atom and **nothing else**. A first revision passed the raw error term as `detail` with a comment saying it must never become a tag — nothing enforced that, and any handler doing `inspect(meta)` would have leaked it. These are exactly the terms this module already warns about at `log_create_failed` ("error_kind/1, never inspect(reason)"): they can embed a wrapped DEK or a provider response body. A test pins `Map.keys(meta) == [:reason]`.

## e2e room probe

`helpers/room_probe.py` counts rooms **allocated** by call path; `test_77` asserts a bound on a 1,000-note bulk sync.

Residency is not usable here: `CRDT_IDLE_EXIT_MS` means rooms a regression opens have drained before the test ends, so a full room-per-note regression passes a `:global` sample taken afterwards — the burst comes and goes between two samples.

Slot count and the atom→slot mapping derive from `SOURCES`. An earlier revision repeated the number in three places; adding a fifth source would have silently under-counted, and `:counters.add` past the end raises *inside* the telemetry handler, which detaches it — the probe would then report zeros, and zeros read as "no rooms allocated".

## Known gap

`test_77` writes uniformly tiny notes (~40 bytes) and measured **0 rooms**, while a real 319-note vault measured **227** on the same code. The bound does not yet cover whatever the real vault trips; it needs a size-mixed fixture before it can be trusted as a regression fence.

## Verification

- 91 tests in the touched files, 0 failures (5 new)
- `mix format`, `mix credo --strict` clean, compiles with `--warnings-as-errors`
- Probe verified against a live node: all four buckets route correctly, including an untagged emit landing in `unknown`

Refs #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)