### PR TITLE
feat(attachments): send content_hash on the note_changed broadcast

### DIFF
--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -1105,7 +1105,13 @@ defmodule Engram.Attachments do
       "vault_id" => vault_id,
       "mime_type" => att.mime_type,
       "size_bytes" => att.size_bytes,
-      "mtime" => att.mtime
+      "mtime" => att.mtime,
+      # Engram#961 (1). Without this a peer that ALREADY holds these exact
+      # bytes has to GET the whole attachment — possibly many MB — purely to
+      # byte-compare and learn nothing changed. The value was in hand at every
+      # emit site; it just was not sent. Same value the REST endpoints serve,
+      # so a client can compare the two directly.
+      "content_hash" => att.content_hash
     }
 
     _ = Broadcast.emit("sync:#{user_id}:#{vault_id}", "note_changed", payload)

--- a/test/engram/attachments_broadcast_test.exs
+++ b/test/engram/attachments_broadcast_test.exs
@@ -42,6 +42,63 @@ defmodule Engram.AttachmentsBroadcastTest do
         }
       }
     end
+
+    test "the upsert payload carries content_hash so peers can skip the blob fetch", %{
+      user: user,
+      vault: vault
+    } do
+      # Engram#961 (1): without the hash, a peer that ALREADY holds these exact
+      # bytes must GET the whole attachment — possibly many MB — only to
+      # byte-compare and discover nothing changed. The hash is in hand at every
+      # emit site; it just was not being sent.
+      Mox.stub(Engram.MockStorage, :put, fn _key, _bin, _opts -> :ok end)
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      assert {:ok, att} =
+               Attachments.upsert_attachment(user, vault, %{
+                 "path" => "photos/live.png",
+                 "content_base64" => Base.encode64("live delivery content")
+               })
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{"event_type" => "upsert", "content_hash" => hash}
+      }
+
+      assert is_binary(hash)
+      # Must be the SAME value the REST endpoints serve, or a peer comparing
+      # the two would never match and the fetch-skip could never fire.
+      assert hash == att.content_hash
+    end
+
+    test "the move legs carry content_hash on both delete and upsert", %{
+      user: user,
+      vault: vault
+    } do
+      # A move fires delete(old) + upsert(new) through the same helper, so
+      # parity is structural — pin it so a future split cannot drop one leg.
+      Mox.stub(Engram.MockStorage, :put, fn _key, _bin, _opts -> :ok end)
+
+      {:ok, att} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "old/pic.png",
+          "content_base64" => Base.encode64("bytes")
+        })
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+      {:ok, _} = Attachments.move_attachment(user, vault, "old/pic.png", "new/pic.png")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        payload: %{"event_type" => "delete", "content_hash" => del_hash}
+      }
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        payload: %{"event_type" => "upsert", "content_hash" => up_hash}
+      }
+
+      assert del_hash == att.content_hash
+      assert up_hash == att.content_hash
+    end
   end
 
   describe "note_changed delete broadcast attribution (#970)" do


### PR DESCRIPTION
Closes the **download mirror** of the 2026-08-21 re-upload loop — [#961](https://github.com/engram-app/Engram/issues/961) part 1.

## The waste

`broadcast_attachment/5` omitted `content_hash`, even though the schema stores it and the value is in hand at every emit site. So a peer that **already held the exact bytes** had to `GET` the whole attachment — possibly many MB — purely to byte-compare and learn nothing had changed.

The plugin's hash-skip dedupe was `!isAttachment` for exactly this reason: with no hash on the wire, the check could never fire for a blob.

## The change

One line. Parity is structural — all three legs (`upsert`, plus the `delete`+`upsert` pair a move fires) route through this single helper — but pinned by a test anyway so a future split can't silently drop one.

The value is the **same one the REST endpoints serve**, which matters: a client compares the broadcast hash against what it recorded from an upload response or a fetch, so the two must be the same quantity or the skip could never match.

## Why this sat open since 2026-08-13

Either half alone is a no-op. The plugin also had to start **recording** the server hash on receive — the device that actually holds a file had nothing to compare against. That's [Engram-obsidian#463](https://github.com/engram-app/Engram-obsidian/pull/463).

Worth noting for triage calibration: #961 was filed as *p3 / post-beta*, describing part 2 as "purely a bandwidth cost... consider if attachment traffic grows." Part 2 is what pinned prod at ~30% CPU for 90 minutes on 2026-08-21.

## Testing

Two new tests: the upsert payload carries a hash equal to `att.content_hash`, and both move legs carry it.

Full suite 4781 pass / 0 fail. credo, dialyzer, sobelow all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2