### PR TITLE
fix(links): chunk note_links inserts under the bind-parameter cap

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -23,7 +23,7 @@
   # rather than the literal `200` dialyzer infers from the current
   # `@backlinks_limit` value — the spec documents the contract callers (and
   # tests) can rely on, not today's specific cap. Same pattern as above.
-  {"lib/engram/links.ex", :contract_supertype, 711},
+  {"lib/engram/links.ex", :contract_supertype, 727},
 
   # `EmbedNote.backfill_priority/0` is intentionally specced as `pos_integer()`
   # rather than the literal `9` dialyzer infers from `@backfill_priority` — the
@@ -37,5 +37,5 @@
   # `Repo.one/2` types as `term()`, so dialyzer widens the `+` to `number()`
   # and flags `float()` as missing from the `non_neg_integer()` spec. The
   # spec states the real contract.
-  {"lib/engram/links.ex", :missing_range, 355}
+  {"lib/engram/links.ex", :missing_range, 371}
 ]

--- a/lib/engram/links.ex
+++ b/lib/engram/links.ex
@@ -42,6 +42,12 @@ defmodule Engram.Links do
   @note_exts ~w(.md .canvas)
   @backlinks_limit 200
 
+  # Rows per `insert_all` statement. See replace_links/4: 17 binds per row
+  # against the protocol's 65535 cap leaves room for 3855, so 2000 is a
+  # deliberate half-margin — a new optional column must not silently re-arm
+  # the overflow.
+  @insert_chunk 2000
+
   @doc """
   Lowercased basename with `.md`/`.canvas` stripped (other extensions kept).
   Obsidian link resolution is case-insensitive and matches on basename
@@ -125,7 +131,17 @@ defmodule Engram.Links do
         skip_tenant_check: true
       )
 
-      if rows != [], do: Repo.insert_all(NoteLink, rows, skip_tenant_check: true)
+      # Chunked, not one statement: the wire protocol caps a query at 65535 bind
+      # parameters, and a NoteLink row binds up to 17 of them (13 base + the
+      # optional alias/anchor envelopes). One MOC-style note with a few thousand
+      # wikilinks therefore overflows the limit, and Postgrex answers that by
+      # KILLING the connection ("can not handle N parameters"), not by returning
+      # a query error — so a single oversized note costs a pooled connection and
+      # takes the whole extraction down with it. Observed on a real vault at
+      # 145792 params (8576 links). @insert_chunk keeps the worst case at 34k.
+      rows
+      |> Enum.chunk_every(@insert_chunk)
+      |> Enum.each(&Repo.insert_all(NoteLink, &1, skip_tenant_check: true))
     end)
 
     :ok

--- a/test/engram/links_test.exs
+++ b/test/engram/links_test.exs
@@ -639,6 +639,67 @@ defmodule Engram.LinksTest do
     end
   end
 
+  describe "replace_links/4 statement sizing" do
+    @tag timeout: 120_000
+    test "a note with more links than one statement can bind still persists all of them",
+         %{user: user, vault: vault} do
+      source = Engram.Fixtures.insert_note!(user, vault, %{path: "MOC.md"})
+
+      # 5_000 edges x 17 binds = 85_000 parameters — past the protocol's 65535
+      # cap. Every edge carries BOTH optional envelopes so the row hits its
+      # widest column count; a version of this test without alias/anchor binds
+      # only 13 per row and would pass against the unchunked insert.
+      #
+      # Pre-fix this did not fail the assertion below, it KILLED the pooled
+      # connection ("Postgrex.Protocol disconnected: postgresql protocol can
+      # not handle 85000 parameters"), so the failure mode to watch for on a
+      # regression is a connection error, not a count mismatch.
+      parsed =
+        for i <- 0..4999 do
+          %{
+            target: "Target #{i}",
+            alias: "alias #{i}",
+            anchor: "anchor #{i}",
+            link_type: "wikilink",
+            position: i
+          }
+        end
+
+      :ok = Links.replace_links(user, vault, source.id, parsed)
+
+      {:ok, count} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.aggregate(from(l in NoteLink, where: l.source_note_id == ^source.id), :count)
+        end)
+
+      assert count == 5_000
+    end
+
+    test "replacing links is still last-writer-wins across the chunk boundary",
+         %{user: user, vault: vault} do
+      source = Engram.Fixtures.insert_note!(user, vault, %{path: "MOC.md"})
+
+      wide = for i <- 0..2_499, do: parsed_link("Target #{i}", i)
+      :ok = Links.replace_links(user, vault, source.id, wide)
+
+      # A chunked insert must not turn the delete+insert into a partial update:
+      # the second call spans fewer chunks than the first, and every row from
+      # the first must be gone.
+      :ok = Links.replace_links(user, vault, source.id, [parsed_link("Only", 0)])
+
+      {:ok, edges} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.all(from(l in NoteLink, where: l.source_note_id == ^source.id))
+        end)
+
+      assert length(edges) == 1
+    end
+  end
+
+  defp parsed_link(target, position) do
+    %{target: target, alias: nil, anchor: nil, link_type: "wikilink", position: position}
+  end
+
   # Counts SELECTs against the candidate tables (notes/attachments) issued on
   # this process while `fun` runs.
   defp count_candidate_queries(fun) do


### PR DESCRIPTION
## What

`Engram.Links.replace_links/4` built **one** `insert_all` for every edge in a note. A `NoteLink` row binds up to 17 parameters (13 base + the optional `alias`/`anchor` envelopes), so a note with more than ~3800 wikilinks overflows the wire protocol's 65535-parameter limit.

Postgrex answers that overflow by **killing the connection**, not by returning a query error:

```
[error] Postgrex.Protocol (#PID<0.503.0>) disconnected:
  ** (Postgrex.QueryError) postgresql protocol can not handle 145792 parameters,
     the maximum is 65535
```

So a single oversized note costs a pooled connection every time its extraction runs, and the job retries until it discards.

## How it was found

Watching a real vault sync into a dev backend. 145792 params = **8576 links in one note**, against `pool_size: 10`, with 41 `ExtractNoteLinks` jobs already in `discarded`.

## Fix

Chunk at 2000 rows — a deliberate half-margin under the 3855 the cap allows, so adding an optional column cannot silently re-arm this. The `rows != []` guard goes away because `chunk_every([], n)` is `[]`.

The delete+insert stays inside the existing advisory-locked transaction, so replacement is still atomic and last-writer-wins across chunks.

## Tests

- 5000 edges × 17 binds = 85000 params. Pre-fix this **kills the connection** rather than failing an assertion, so the regression signal is a connection error — called out in the test comment. Verified failing on the unfixed code:
  ```
  ** (Postgrex.QueryError) postgresql protocol can not handle 85000 parameters
  ```
- a narrower rewrite still clears every row from a wider one (chunking must not turn delete+insert into a partial update)

`mix test test/engram/links_test.exs` 36 pass / 0 fail. `format` + `credo --strict` + `dialyzer` clean.

## Note on `.dialyzer_ignore.exs`

Two pre-existing, intentional entries for this file are pinned **by line number**, and the added lines shifted them (dialyxir line-matches — that file's own comment warns about exactly this). Re-anchored 355→371 and 711→727. No new suppressions.