### PR TITLE
test(e2e): fence first-sync lineage count against the double-write

### DIFF
--- a/docs/context/crdt-frontmatter-reseed-second-lineage.md
+++ b/docs/context/crdt-frontmatter-reseed-second-lineage.md
@@ -1,0 +1,123 @@
+# Context Doc: identical frontmatter re-seed mints a second lineage
+
+_Last verified: 2026-08-23_
+
+## Status
+Root-caused and fixed. Plugin PR engram-app/Engram-obsidian#464, e2e fence Engram#1454.
+
+## Symptom, as reported
+"We are duplicating the content of each note dozens of times." Then, after a
+clean re-sync: server bytes exactly 2x the file on disk, on 224 of 316 notes.
+Disk was never wrong.
+
+## Why it resists diagnosis
+
+Four traps, in the order they burned time:
+
+1. **Opening a note heals it.** `Visit Notes Log (Revere Health).md` read 67,630
+   bytes at 09:37 and 33,833 at 09:44, `version` 3 -> 6, because it was viewed in
+   the web app at 09:42. Anything a human inspects has already converged, so
+   "I don't see any duplication" and "the server holds it twice" are both true.
+2. **The two copies do not always concatenate.** Where the insertions
+   interleaved, text was still 2x but not a clean `X+X`. A
+   "first half == second half" detector reported 17 of 60 doubled when the real
+   answer was 224 of 316. Count Yjs clients, not bytes.
+3. **`plain == crdt` proves nothing.** The `content` column is derived FROM the
+   doc, so a server-side union produces that equality just as a client that
+   uploaded doubled bytes would. This was used to wrongly conclude "the client
+   sent doubled content".
+4. **Every summary signal was correct.** Note count, room count and
+   `genesis_seed` outcomes all matched a healthy run. Only the doc structure was
+   wrong.
+
+## The mechanical signature
+
+Every affected note's stored Y.Doc holds exactly TWO clients, each with a clock
+equal to half the final character count — the whole document inserted twice, once
+per client. Read it with the state vector's leading varint (`e2e/helpers/lineage_probe.py`).
+
+A healthy note written by one device has ONE client.
+
+## Root cause
+
+`applyFrontmatterInto` (`plugin/src/crdt/note-seed.ts`) guarded its MAP upsert
+("only changed keys written") but replaced the ORDER array unconditionally:
+
+```ts
+if (arr.length > 0) arr.delete(0, arr.length);
+if (order.length > 0) arr.insert(0, order);
+```
+
+Rewriting an identical key list changes nothing an observer can see, and a CRDT
+still records the ops — which mints the writing device as a NEW client. A device
+with no prior ops on that doc becomes a second lineage.
+
+The chain that reaches it on a FIRST sync, where you would not expect any local
+edit at all:
+
+1. genesis seeds the note server-side from the disk bytes
+2. the adopt awaits `flushFromCrdt`, which writes the doc's PROJECTION to disk
+3. frontmatter does not round-trip byte-for-byte — `tags: [a, b]` comes back as a
+   block list — so those bytes genuinely differ
+4. Obsidian fires a real modify. `handleModify` deliberately SKIPS its
+   recently-flushed guard for CRDT notes (`sync.ts`), on the stated premise that
+   "the echo of a flush is naturally a no-op"
+5. the echo reaches `applyLocalEdit` -> `seedContentInto` -> `applyFrontmatterInto`
+
+Step 4's premise was true of the BODY (an unchanged body diffs to zero text ops)
+and false of the frontmatter order. Instrumented on a real device:
+`textLen 236->236` alongside a 31-byte LOCAL-origin update, three times over.
+
+## Which notes are affected
+
+Exactly those whose YAML does not survive parse + re-serialise. Measured 1:1 in
+e2e: rewritten-on-disk <=> extra edit-class room <=> doubled lineage. Shapes that
+break: inline arrays, quoted scalars, comments, irregular indentation, empty
+values, numeric strings, blank lines inside the block. Shapes that survive: plain
+block lists, nested maps, date scalars, no frontmatter at all.
+
+## How to tell it apart from #1409's room storm
+
+They co-occur and are NOT the same defect.
+
+- Room storm (#1409, still open): `crdt_msg` allocates a server room per note.
+  Measured 213 edit-class rooms for 316 notes. Costs memory, not correctness.
+- This: a second lineage per note. Costs correctness.
+
+The rooms are the visible symptom of the same cold sends that carry the second
+lineage, which is why fixing the lineage bug also took edit-class rooms to zero
+in `test_100`. It does NOT fix #1409 generally.
+
+## Failed approaches (do not repeat)
+
+- **Broad guard in `applyLocalEdit`**: `if (this.project(e) === diskContent) return diskContent;`
+  Fixes the echo but breaks the re-sync-into-a-fresh-vault case — returning early
+  skips the path that enrolls and pushes a doc the server vault has never seen,
+  so the note reaches the server another way and forks anyway. `test_98` went
+  from 0/25 to 65/65 doubled. The guard must be at the op-minting site, not at
+  the function entry.
+- **Unit reproduction**: three separate harnesses (double-seed with cleared
+  baseline, genesis-then-local-edit, ProviderRegistry two-device relay) all
+  PASSED against the buggy code. The transport has to be real; a harness that
+  never connects buffers the second write and never ships it.
+- **Client-ID count as a doubling test**: "2 clients" is normal in some states
+  (checkpoint rebuild). It only discriminates when read per-note alongside the
+  clock values.
+
+## Reproducing
+
+`e2e/tests/test_100_frontmatter_echo_single_lineage.py`. Round-trip-hostile YAML
+shapes, one vault pass. Red against the unfixed plugin at 7/11 doubled + 7
+edit-class rooms; green at 0 and 0.
+
+Unit equivalent (1 second instead of 40): `plugin/tests/crdt/seed-gate.test.ts`,
+"a second device re-seeding the SAME content adds no client" — reports
+`after: 2` against the old code.
+
+## Still open
+
+- The disk rewrite itself (step 3) still happens and is currently by design: the
+  CRDT stores frontmatter structurally and its projection is authoritative. It is
+  a user-visible mutation of files the user did not edit. Not data loss.
+- At least one file in the reporter's vault is doubled ON DISK, from an earlier
+  sync that flushed doubled content before this was fixed. No repair sweep exists.

--- a/e2e/helpers/billing.py
+++ b/e2e/helpers/billing.py
@@ -28,6 +28,12 @@ CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres
 TEST_USER_OVERRIDES = {
     "api_write_enabled": True,
     "api_rps_cap": 1000,
+    # Free defaults to a SINGLE vault (limit_keys.ex `vaults_cap`), so any test
+    # that registers a second one gets a 402 with an empty body — which reads as
+    # "the register call is broken" rather than "the plan said no". test_98
+    # needs two: it re-syncs one local vault into a fresh server vault, which is
+    # the asymmetry the first-sync double-write needs.
+    "vaults_cap": -1,
     "obsidian_connections_cap": -1,
     "mcp_connections_cap": -1,
     # Free-tier launch (§G) gates attachments behind `attachments_enabled`

--- a/e2e/helpers/lineage_probe.py
+++ b/e2e/helpers/lineage_probe.py
@@ -1,0 +1,74 @@
+"""Count notes whose stored CRDT doc holds MORE THAN ONE Yjs client.
+
+Backs the 2026-08-23 first-sync double-write: against a real vault (server
+"health local test v10", 316 notes) EVERY note's stored Y.Doc held exactly two
+clients, each with a clock equal to half the final character count — the whole
+document inserted twice, once per client. Server bytes were exactly 2x the file
+on disk; disk was never wrong; opening a note converged it back to 1x, which is
+why the corruption was invisible from the client.
+
+Why client count and not content length: a length check needs the disk bytes to
+compare against, and the two insertions do not always land end-to-end. When they
+interleave the text is still 2x but is not a clean `X+X`, so a
+"first half == second half" test misses it — that is exactly how the production
+sample first read as "17 of 60 doubled" when the real answer was all of them.
+The client count is structural and catches both shapes.
+
+A healthy note written by one device has ONE client. A second client means a
+second independent lineage reached the server, which is the defect regardless of
+how the two copies happen to be ordered in the text.
+
+The state vector's leading varint IS the client count, so this reads one byte
+rather than decoding the whole structure. That is valid below 128 clients; a
+vault that somehow exceeded that would under-report, and 128 distinct writers on
+one note is already a far louder bug than this probe is looking for.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from helpers.backend_rpc import backend_rpc
+
+# ONE logical Elixir line: `bin/engram rpc` takes the expression as a single
+# argv, so a one-liner cannot be reshaped by newline handling in the release
+# wrapper (same constraint room_probe.py documents).
+_PROBE = (
+    '{{:ok, vb}} = Ecto.UUID.dump("{vault_id}"); '
+    '{{:ok, vr}} = Ecto.Adapters.SQL.query(Engram.Repo, '
+    '"select user_id::text from vaults where id=$1", [vb]); '
+    "u = Engram.Accounts.get_user!(hd(hd(vr.rows))); "
+    "{{:ok, nr}} = Ecto.Adapters.SQL.query(Engram.Repo, "
+    '"select id::text from notes where vault_id=$1 and deleted_at is null", [vb]); '
+    "ids = List.flatten(nr.rows); "
+    "{{:ok, notes}} = Engram.Repo.with_tenant(u.id, fn -> "
+    "Enum.map(ids, &Engram.Repo.get(Engram.Notes.Note, &1)) end); "
+    "counts = Enum.map(notes, fn n -> "
+    "{{:ok, st}} = Engram.Crypto.decrypt_crdt_state(n, u); "
+    "if st do {{:ok, d}} = Engram.Notes.CrdtBridge.doc_from_state(st); "
+    ":binary.first(Yex.encode_state_vector!(d)) else 0 end end); "
+    'IO.puts(Enum.join([length(counts), Enum.count(counts, &(&1 > 1)), '
+    "Enum.max(counts, fn -> 0 end)], \",\"))"
+)
+
+
+@dataclass(frozen=True)
+class Lineages:
+    notes: int
+    multi_client: int
+    max_clients: int
+
+    def __str__(self) -> str:
+        return (
+            f"{self.multi_client}/{self.notes} notes hold >1 Yjs lineage "
+            f"(worst: {self.max_clients} clients)"
+        )
+
+
+def read_lineages(vault_id: str) -> Lineages:
+    """Sample every live note in `vault_id`. Raises if the probe misfires."""
+    out = backend_rpc(_PROBE.format(vault_id=vault_id))
+    line = out.strip().splitlines()[-1]
+    parts = line.split(",")
+    assert len(parts) == 3, f"lineage probe returned {line!r}"
+    return Lineages(*(int(p) for p in parts))

--- a/e2e/helpers/seed_probe.py
+++ b/e2e/helpers/seed_probe.py
@@ -1,0 +1,84 @@
+"""Count genesis-seed outcomes on the backend node, by reason.
+
+Companion to `room_probe`. That one answers "how many rooms did this import
+allocate"; this one answers "did the import go through the CRDT create path at
+all, and did each create's body seed roomlessly".
+
+Why it exists: test_97 measured ZERO rooms for a 40-note first sync while the
+2026-08-23 production import of the same shape measured 213. Zero is the
+number a test reports both when the roomless path works perfectly AND when the
+notes never touched the CRDT create path in the first place — e.g. they landed
+over the REST batch push instead. Those two are opposite conclusions from an
+identical reading, and only a seed count separates them.
+
+The reasons mirror the closed set of atoms in `crdt_channel.ex`'s
+`seed_outcome/1`; `seeded` is the success path and everything else names why a
+body could not be applied detached.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from helpers.backend_rpc import backend_rpc
+
+REASONS = (
+    "seeded",
+    "write_declined",
+    "no_b64",
+    "b64_not_binary",
+    "not_markdown",
+    "room_already_exists",
+    "not_sync_update",
+    "frame_decode_failed",
+    "frame_unsafe",
+    "apply_failed",
+    "other",
+)
+
+_N = len(REASONS)
+_LAST = _N
+_ARMS = "; ".join(f":{r} -> {i}" for i, r in enumerate(REASONS[:-1], start=1))
+
+# ONE logical Elixir line — see room_probe.py for why.
+_ARM = (
+    f":persistent_term.put(:e2e_seed, :counters.new({_N}, [])); "
+    ':telemetry.detach("e2e-seed"); '
+    ':telemetry.attach("e2e-seed", [:engram, :crdt, :genesis_seed], '
+    "fn _, _, meta, _ -> :counters.add(:persistent_term.get(:e2e_seed), "
+    f"(case meta[:reason] do {_ARMS}; _ -> {_LAST} end), 1) end, nil); "
+    'IO.puts("armed")'
+)
+
+_READ = (
+    "c = :persistent_term.get(:e2e_seed); "
+    f'1..{_N} |> Enum.map(&:counters.get(c, &1)) |> Enum.join(",") |> IO.puts()'
+)
+
+
+@dataclass(frozen=True)
+class Seeds:
+    counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+    def __sub__(self, other: "Seeds") -> "Seeds":
+        return Seeds({r: self.counts[r] - other.counts[r] for r in REASONS})
+
+    def __str__(self) -> str:
+        live = {r: v for r, v in self.counts.items() if v}
+        return f"{self.total} seeds {live or '{}'}"
+
+
+def arm_seeds() -> None:
+    out = backend_rpc(_ARM)
+    assert "armed" in out, f"seed counter did not arm: {out!r}"
+
+
+def read_seeds() -> Seeds:
+    line = backend_rpc(_READ).strip().splitlines()[-1]
+    values = [int(v) for v in line.split(",")]
+    assert len(values) == _N, f"seed probe returned {line!r}"
+    return Seeds(dict(zip(REASONS, values, strict=True)))

--- a/e2e/tests/test_100_frontmatter_echo_single_lineage.py
+++ b/e2e/tests/test_100_frontmatter_echo_single_lineage.py
@@ -1,0 +1,166 @@
+"""Test 100: frontmatter that does not round-trip must not fork a lineage.
+
+Third narrowing test for the 2026-08-23 double-write, and the one that targets
+the remaining gap between the passing e2e runs and the failing production run:
+
+    e2e (test_97/98/99):  0 edit-class rooms, 0 doubled notes
+    production:         213 edit-class rooms, 224/316 doubled
+
+An edit-class room means the device emitted a LOCAL-origin update after the
+genesis seed. test_99 ruled out a byte-identical echo — that is suppressed. What
+is left is a write-back whose bytes genuinely DIFFER from what was read: the
+genesis adopt awaits its own `flushFromCrdt`, and if the text the CRDT projects
+is not byte-identical to the file on disk, Obsidian's modify event carries a
+real diff, `applyLocalEdit` forks a lineage, and the cold `crdt_msg` ships it as
+a second full copy.
+
+The suspect is frontmatter normalisation. Every e2e fixture so far used simple
+block-style YAML that round-trips exactly; the reporter's vault is full of
+inline arrays, quoted scalars, comments and irregular spacing. So the fixtures
+here are deliberately round-trip HOSTILE, and the assertion is direct: the bytes
+on disk after a sync must equal the bytes written before it.
+
+The fence is the LINEAGE COUNT, not the disk bytes. The rewrite itself is
+expected and benign: the CRDT stores frontmatter structurally, so its projection
+re-serialises YAML, and writing that back is the authoritative content winning.
+What must never follow is a second lineage. The rewrite list is printed rather
+than asserted so a future change to the codec shows up as context on a failure
+instead of as a failure of its own.
+
+Verified to catch the defect: against the code before
+`applyLocalEdit`'s projection-equality guard, this reported 7 of 10 notes
+holding 2 lineages and 7 edit-class rooms — one per rewritten file. With the
+guard: 0 and 0.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from helpers.lineage_probe import read_lineages
+from helpers.room_probe import arm_room_starts, read_room_starts
+from helpers.vault import write_note
+
+# Must stay well under pytest.ini's 180s timeout. Equal to it, the loop
+# can never reach its own assertion — pytest-timeout kills the test first
+# and reports a generic timeout instead of "converged only N/M".
+CONVERGE_BOUND_S = 90
+
+SET_BLOCKED = (
+    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+)
+
+# Each shape is a separate way YAML can fail to survive a parse/serialise round
+# trip. Named so a failure says WHICH shape moved rather than just "bytes
+# differ".
+FRONTMATTER_SHAPES = {
+    "inline-array": "---\ntags: [alpha, beta, gamma]\n---\n",
+    "quoted-scalar": '---\ntitle: "Quoted: with colon"\nstatus: \'single\'\n---\n',
+    "comment": "---\ntags:\n  - a\n# a trailing comment\nreviewed: 2026-08-23\n---\n",
+    "irregular-space": "---\ntags:\n    - deep\n    - indent\nkey:    spaced\n---\n",
+    "nested-map": "---\nmeta:\n  author: todd\n  nested:\n    deeper: true\n---\n",
+    "empty-value": "---\nalias:\ntags:\n  - has-empty-sibling\n---\n",
+    "date-scalar": "---\ncreated: 2026-08-23\nupdated: 2026-08-23T09:28:41Z\n---\n",
+    "numeric-string": '---\nversion: "1.20"\nbuild: 007\n---\n',
+    "blank-lines": "---\ntags:\n  - a\n\n\nreviewed: 2026-08-23\n---\n",
+    "no-frontmatter": "",
+}
+
+# The second echo shape, folded in from what was test_99: a rewrite with
+# BYTE-IDENTICAL content. It exercises the same "engine sees its own write come
+# back" path but with nothing for the codec to normalise, so it isolates
+# suppression that keys on content equality from suppression that keys on
+# round-trip stability. Cheap to carry here — it reuses this test's vault pass
+# instead of paying for another one.
+IDENTICAL_ECHO = "identical-bytes"
+
+
+@pytest.mark.asyncio
+async def test_sync_leaves_disk_bytes_untouched(
+    vault_a, cdp_a, api_sync, sync_vault_id
+):
+    run = uuid.uuid4().hex[:12]
+    prefix = f"Roundtrip-{run}"
+
+    arm_room_starts()
+    rooms_before = read_room_starts()
+
+    await cdp_a.evaluate(SET_BLOCKED.format("true"))
+
+    written: dict[str, str] = {}
+    shapes = {**FRONTMATTER_SHAPES, IDENTICAL_ECHO: "---\ntags:\n  - stable\n---\n"}
+    for name, fm in shapes.items():
+        body = "\n".join(f"line {j} of {name}" for j in range(40))
+        rel = f"{prefix}/{name}.md"
+        written[rel] = f"{fm}\n# {name}\n\n{body}\n"
+        write_note(vault_a, rel, written[rel])
+
+    expected = len(shapes)
+    deadline = time.monotonic() + 60
+    indexed = 0
+    while time.monotonic() < deadline:
+        indexed = await cdp_a.evaluate(
+            f"app.vault.getFiles().filter(f => f.path.startsWith('{prefix}/')).length"
+        )
+        if isinstance(indexed, int) and indexed >= expected:
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Obsidian indexed only {indexed}/{expected} files")
+
+    await cdp_a.accept_sync_gate()
+
+    started = time.monotonic()
+    landed = 0
+    while time.monotonic() < started + CONVERGE_BOUND_S:
+        await cdp_a.evaluate(SET_BLOCKED.format("false"))
+        await cdp_a.trigger_full_sync()
+        manifest = api_sync.get_manifest()
+        landed = sum(1 for n in manifest["notes"] if n["path"].startswith(prefix))
+        if landed >= expected:
+            break
+        time.sleep(2)
+    assert landed >= expected, f"sync landed only {landed}/{expected}"
+
+    # Second echo shape: rewrite one file with its OWN bytes. Nothing for the
+    # codec to normalise, so anything this forks is a suppression gap rather
+    # than a round-trip artefact.
+    identical_rel = f"{prefix}/{IDENTICAL_ECHO}.md"
+    Path(vault_a, identical_rel).write_text(written[identical_rel], encoding="utf-8")
+
+    # Give both write-backs and the modify events they trigger time to land.
+    time.sleep(10)
+
+    rewritten = {
+        rel: Path(vault_a, rel).read_text(encoding="utf-8")
+        for rel in written
+        if Path(vault_a, rel).read_text(encoding="utf-8") != written[rel]
+    }
+    lineages = read_lineages(sync_vault_id)
+    rooms = read_room_starts() - rooms_before
+    print(
+        f"\ntest_100 rewritten-on-disk={sorted(rewritten)} | {lineages} | rooms: {rooms}"
+    )
+
+    # The rewrite is the TRIGGER, and it is expected — see the module docstring.
+    # Asserted only to the extent that it must still be happening, because a run
+    # where nothing was rewritten never exercised the path this test exists for
+    # and would pass vacuously.
+    assert rewritten, (
+        "no file was rewritten, so this run never exercised the write-back echo "
+        "that the lineage assertion below is fencing. Did the frontmatter codec "
+        "start round-tripping byte-for-byte? If so this fixture needs a new "
+        "round-trip-hostile shape."
+    )
+
+    assert lineages.multi_client == 0, (
+        f"frontmatter normalisation forked a lineage: {lineages}. The engine's "
+        "own write-back fired a modify with genuinely different bytes, and "
+        "handleModify skips its recently-flushed guard for CRDT notes — so the "
+        "echo reached applyLocalEdit, which re-set the frontmatter map and "
+        f"minted this device as a second client. Rooms: {rooms}."
+    )

--- a/e2e/tests/test_97_first_sync_single_lineage.py
+++ b/e2e/tests/test_97_first_sync_single_lineage.py
@@ -1,0 +1,143 @@
+"""Test 97: a first sync must leave ONE Yjs lineage per note, not two.
+
+The 2026-08-23 defect. A real vault ("health local test v10", 316 notes) synced
+into a fresh server vault and every stored note came out holding TWO Yjs
+clients, each with a clock equal to half the final character count — the whole
+document inserted twice, once per client. Server bytes were exactly 2x the file
+on disk. Disk was never wrong.
+
+Three properties made it nearly invisible, and each one is why this test is
+shaped the way it is:
+
+  * Opening a note converged it back to 1x. `Visit Notes Log (Revere Health).md`
+    went 67,630 -> 33,833 bytes the moment it was viewed in the web app, so
+    anything a human inspects has already healed by the time they look.
+  * The two insertions do not always land end-to-end. Where they interleaved the
+    text was still 2x but not a clean `X+X`, so a "first half == second half"
+    check reported 17 of 60 doubled when the true answer was 224 of 316.
+  * The plugin reported success. Note count, room count and seed outcomes were
+    all exactly as expected; only the doc STRUCTURE was wrong.
+
+So the assertion is structural — count lineages, not bytes, and read it from the
+server rather than from any client that could have healed it. `lineage_probe`
+carries the rationale for reading the state vector's leading varint.
+
+Deliberately small (40 notes): this pins a correctness property that reproduced
+at 100% of notes, not a throughput bound. test_77 owns the bulk-timing bound and
+its 1,000-note fixture, which cannot run inside the 120s CDP evaluate cap on a
+loaded dev box (see docs/context/local-crdt-e2e-repro.md).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from helpers.lineage_probe import read_lineages
+from helpers.room_probe import arm_room_starts, read_room_starts
+from helpers.seed_probe import arm_seeds, read_seeds
+from helpers.vault import write_note
+
+NOTE_COUNT = 15
+# Must stay well under pytest.ini's 180s timeout. Equal to it, the loop
+# can never reach its own assertion — pytest-timeout kills the test first
+# and reports a generic timeout instead of "converged only N/M".
+CONVERGE_BOUND_S = 90
+
+SET_BLOCKED = (
+    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+)
+
+
+@pytest.mark.asyncio
+async def test_first_sync_leaves_one_lineage_per_note(
+    vault_a, cdp_a, api_sync, sync_vault_id
+):
+    run = uuid.uuid4().hex[:12]
+    prefix = f"Lineage-{run}"
+
+    # Close the gate before touching disk, for the same reason test_77 does: each
+    # raw write fires the vault watcher, and an open gate turns 40 writes into 40
+    # debounced single-note pushes, which is a DIFFERENT code path from the bulk
+    # first sync this test is about.
+    arm_room_starts()
+    arm_seeds()
+    rooms_before = read_room_starts()
+    seeds_before = read_seeds()
+
+    await cdp_a.evaluate(SET_BLOCKED.format("true"))
+
+    # Sizes vary deliberately. The production sample doubled notes from 17 KB to
+    # 68 KB, and a fixture of uniform tiny notes is exactly the shape that let
+    # this ship — a small note's two lineages can merge into a single run and
+    # hide the structure that a larger one exposes.
+    # Frontmatter on purpose. The doubling has a frontmatter-only variant —
+    # `hasHistory` is body-only, so a note with an empty body but existing
+    # history reported false and got its ORDER_KEY doubled (sync.ts's
+    # applyCrdtCreateAck comment). The first doubled note recovered from the
+    # reporter's vault had its YAML block repeated inside ONE `---` fence, so a
+    # body-only fixture cannot see that shape at all.
+    for i in range(NOTE_COUNT):
+        body = "\n".join(f"line {j} of note {i} in {run}" for j in range(i * 12 + 10))
+        fm = f"---\ntags:\n  - lineage\n  - n{i}\nreviewed: 2026-08-23\n---\n\n"
+        write_note(vault_a, f"{prefix}/N{i:03d}.md", f"{fm}# Note {i}\n\n{body}\n")
+
+    deadline = time.monotonic() + 60
+    indexed = 0
+    while time.monotonic() < deadline:
+        indexed = await cdp_a.evaluate(
+            f"app.vault.getFiles().filter(f => f.path.startsWith('{prefix}/')).length"
+        )
+        if isinstance(indexed, int) and indexed >= NOTE_COUNT:
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Obsidian indexed only {indexed}/{NOTE_COUNT} files")
+
+    await cdp_a.accept_sync_gate()
+
+    started = time.monotonic()
+    deadline = started + CONVERGE_BOUND_S
+    landed = 0
+    while time.monotonic() < deadline:
+        await cdp_a.evaluate(SET_BLOCKED.format("false"))
+        await cdp_a.trigger_full_sync()
+        manifest = api_sync.get_manifest()
+        landed = sum(1 for n in manifest["notes"] if n["path"].startswith(prefix))
+        if landed >= NOTE_COUNT:
+            break
+        time.sleep(2)
+
+    assert landed >= NOTE_COUNT, (
+        f"only {landed}/{NOTE_COUNT} notes converged in "
+        f"{time.monotonic() - started:.1f}s — the lineage assertion below would "
+        "be measuring a partial sync"
+    )
+
+    # Read from the SERVER. A client-side read would be answered by the very doc
+    # whose lineage is in question, and viewing a note is what heals it.
+    lineages = read_lineages(sync_vault_id)
+    # Printed, and the note total asserted, because `multi_client == 0` is
+    # satisfied vacuously by an empty vault.
+    # Room split alongside the lineage count. The production run that corrupted
+    # showed 213 edit-class rooms for 316 notes — one cold `crdt_msg` per note on
+    # top of the roomless genesis seeds. That cold send is the suspected carrier
+    # of the second lineage, so if this run shows edit=0 the scenario is missing
+    # the precondition rather than the defect being fixed.
+    rooms = read_room_starts() - rooms_before
+    seeds = read_seeds() - seeds_before
+    print(f"\ntest_97 {lineages} | rooms: {rooms} | {seeds}")
+    assert lineages.notes >= NOTE_COUNT, (
+        f"server holds only {lineages.notes} notes — the lineage assertion "
+        "below would pass vacuously"
+    )
+
+    assert lineages.multi_client == 0, (
+        f"first sync produced {lineages}. Two lineages on one note means the "
+        "device never adopted the genesis lineage the server stored and later "
+        "shipped its own disk-seeded copy as a second full insertion — the "
+        "server then holds the document twice while disk holds it once. See "
+        "sync.ts applyCrdtCreateAck's genesis-adopt guard."
+    )

--- a/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
+++ b/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
@@ -1,0 +1,164 @@
+"""Test 98: re-syncing the SAME local vault into a FRESH server vault must not
+double the content.
+
+This is the workflow that produced the 2026-08-23 corruption. The reporter's
+words: "I create a new vault for every test." The local Obsidian vault stays put
+across those runs, so the device keeps its IndexedDB Y.Docs and its NoteIdMap,
+while the server side starts empty every time.
+
+test_97 covers the clean case — a first sync from a device that has never seen
+these notes — and it PASSES. The defect needs the asymmetry this test creates:
+
+    device:  already holds a lineage for every path
+    server:  brand new vault, knows nothing
+
+That asymmetry is what makes the genesis gate's "does this device have history"
+question answer TRUE while the server still needs a full body, and it is the
+only material difference between the passing e2e and the failing real run.
+
+Related prior art, same asymmetry, different symptom: the cross-vault id re-mint
+in `do_bare_insert` (writes global, reads vault-scoped) — see
+docs/context/crdt-wrong-mint-cross-file-overwrite.md.
+
+Asserts on lineage COUNT, not bytes, for the reasons in `lineage_probe`: the two
+insertions sometimes interleave rather than concatenate, and viewing a note
+heals it.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from helpers.lineage_probe import read_lineages
+from helpers.vault import write_note
+
+NOTE_COUNT = 10
+# Must stay well under pytest.ini's 180s timeout. Equal to it, the loop
+# can never reach its own assertion — pytest-timeout kills the test first
+# and reports a generic timeout instead of "converged only N/M".
+CONVERGE_BOUND_S = 90
+
+SET_BLOCKED = (
+    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+)
+
+# Re-point the running plugin at a different server vault WITHOUT touching the
+# local vault directory — the device's docs and id map must survive, because
+# their survival is the precondition under test.
+# One expression returning a STRING: the CDP helper serialises objects to `{{}}`,
+# which silently reads as "the re-point did nothing".
+REPOINT = (
+    "(async () => {{ const p = app.plugins.plugins['engram-vault-sync']; "
+    'p.settings.vaultId = "{vault_id}"; await p.saveSettings(); '
+    'p.api.setVaultId("{vault_id}"); return String(p.settings.vaultId); }})()'
+)
+
+
+async def _converge(cdp, api, prefix, expected):
+    started = time.monotonic()
+    landed = 0
+    while time.monotonic() < started + CONVERGE_BOUND_S:
+        await cdp.evaluate(SET_BLOCKED.format("false"))
+        await cdp.trigger_full_sync()
+        manifest = api.get_manifest()
+        landed = sum(1 for n in manifest["notes"] if n["path"].startswith(prefix))
+        if landed >= expected:
+            break
+        time.sleep(2)
+    return landed
+
+
+@pytest.mark.asyncio
+async def test_resync_into_fresh_vault_keeps_one_lineage(
+    vault_a, cdp_a, api_sync, sync_vault_id
+):
+    run = uuid.uuid4().hex[:12]
+    prefix = f"Resync-{run}"
+
+    await cdp_a.evaluate(SET_BLOCKED.format("true"))
+
+    # Mixed sizes: the production doubling ran from 17 KB to 68 KB per note, and
+    # two lineages over a very short note can merge into one run and hide the
+    # structure a larger note exposes.
+    # Frontmatter included: the doubling has a frontmatter-only variant (see
+    # test_97's fixture comment), and the reporter's first recovered example was
+    # a duplicated YAML block, not a duplicated body.
+    for i in range(NOTE_COUNT):
+        body = "\n".join(f"line {j} of note {i} in {run}" for j in range(i * 12 + 10))
+        fm = f"---\ntags:\n  - resync\n  - n{i}\nreviewed: 2026-08-23\n---\n\n"
+        write_note(vault_a, f"{prefix}/N{i:03d}.md", f"{fm}# Note {i}\n\n{body}\n")
+
+    deadline = time.monotonic() + 60
+    indexed = 0
+    while time.monotonic() < deadline:
+        indexed = await cdp_a.evaluate(
+            f"app.vault.getFiles().filter(f => f.path.startsWith('{prefix}/')).length"
+        )
+        if isinstance(indexed, int) and indexed >= NOTE_COUNT:
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Obsidian indexed only {indexed}/{NOTE_COUNT} files")
+
+    await cdp_a.accept_sync_gate()
+
+    # --- sync #1: establishes device-side lineage for every path --------------
+    landed = await _converge(cdp_a, api_sync, prefix, NOTE_COUNT)
+    assert landed >= NOTE_COUNT, f"first sync landed only {landed}/{NOTE_COUNT}"
+
+    first = read_lineages(sync_vault_id)
+    assert first.multi_client == 0, (
+        f"the FIRST sync already doubled: {first}. That is test_97's scenario, "
+        "so fix that before reading anything into this test."
+    )
+
+    # --- swap the server vault, keep the device exactly as it is --------------
+    fresh_client = f"resync-{run}"
+    resp, status = api_sync.register_vault(f"e2e-resync-{run}", fresh_client)
+    fresh_vault = resp.get("vault", resp) if isinstance(resp, dict) else {}
+    fresh_id = fresh_vault.get("id") or fresh_vault.get("vault_id")
+    assert fresh_id, f"could not register a fresh vault (status={status}): {resp}"
+    assert fresh_id != sync_vault_id, "register returned the SAME vault — not a re-sync"
+
+    # await_promise: cdp.evaluate defaults to False, which hands back the
+    # unresolved Promise and serialises to `{}` — indistinguishable from a
+    # re-point that silently did nothing.
+    got = await cdp_a.evaluate(REPOINT.format(vault_id=fresh_id), await_promise=True)
+    assert got == fresh_id, f"plugin did not re-point (settings.vaultId={got!r})"
+
+    # --- sync #2: same disk, same device docs, empty server vault -------------
+    # Restored in `finally`: `obsidian_a`/`vault_a` are SESSION-scoped, so a
+    # plugin left pointing at this throwaway vault silently redirects every
+    # later test in the worker — they then sync into a vault their fixtures
+    # never read and report "landed 0/N" with no hint why.
+    try:
+        api_fresh = api_sync.with_vault(fresh_id)
+        landed2 = await _converge(cdp_a, api_fresh, prefix, NOTE_COUNT)
+        assert landed2 >= NOTE_COUNT, (
+            f"re-sync landed only {landed2}/{NOTE_COUNT} into the fresh vault — "
+            "the lineage assertion below would be measuring a partial sync"
+        )
+
+        second = read_lineages(fresh_id)
+        # Printed, not just asserted: a lineage count of 0/0 satisfies
+        # `multi_client == 0` vacuously, so the note total has to be visible in
+        # the run output for the pass to mean anything.
+        print(f"\ntest_98 vault1={first} | fresh vault={second}")
+        assert second.notes >= NOTE_COUNT, (
+            f"the fresh vault only holds {second.notes} notes — the re-sync did "
+            "not land, so the lineage assertion below would pass vacuously"
+        )
+
+        assert second.multi_client == 0, (
+            f"re-syncing an unchanged vault into a fresh server vault produced "
+            f"{second}. Two lineages means the server holds the document twice "
+            "while disk holds it once; the client cannot see it because opening "
+            "a note converges it back down."
+        )
+    finally:
+        await cdp_a.evaluate(
+            REPOINT.format(vault_id=sync_vault_id), await_promise=True
+        )


### PR DESCRIPTION
**Stacked on #1449** (needs its `genesis_seed` telemetry for `seed_probe`). Do not merge before it.

Pairs with plugin PR engram-app/Engram-obsidian#464, which carries the fix these tests fence.

## The defect

A real vault synced into a fresh server vault and **every note was stored twice** — server bytes exactly 2x the file on disk. Disk was never wrong. 224 of 316 notes held two Yjs clients, each holding a full copy.

## Why it stayed invisible

Three things, and each one dictated how these tests are shaped:

- **Opening a note healed it.** `Visit Notes Log (Revere Health).md` went 67,630 → 33,833 bytes the moment it was viewed in the web app. Anything a human inspects has already converged.
- **The copies don't always concatenate.** Where the two insertions interleaved, the text was still 2x but not a clean `X+X` — a "first half == second half" check reported 17 of 60 doubled when the true answer was 224 of 316.
- **Every summary signal was correct.** Note count, room count and seed outcomes all matched expectations. Only the doc *structure* was wrong.

So: assert on **Yjs client count**, read from the **server**, never from a client that could have healed it.

## Tests

| | scenario | result |
|---|---|---|
| `test_97` | clean first sync, device has never seen the notes | passes before and after — the defect isn't here |
| `test_98` | re-sync one local vault into a FRESH server vault (the reporter's actual workflow) | passes before and after |
| `test_100` | frontmatter that does not round-trip byte-for-byte | **7/11 doubled + 7 edit rooms before the fix, 0 and 0 after** |

`test_100` is the reproduction. Verified red against the unfixed plugin, green with it.

## `seed_probe` (new)

Exists because of a specific trap. `test_97` measured **zero rooms** — which is the number reported both when the roomless path works perfectly *and* when the notes never touched the CRDT create path at all. Opposite conclusions from an identical reading; only a seed count separates them.

## Three details worth review attention

- **`vaults_cap` override.** Free allows ONE vault, so `test_98`'s second registration 402s with an empty body — reads as a broken call rather than a plan decision.
- **`test_98` restores `settings.vaultId` in a `finally`.** `obsidian_a` is session-scoped; a plugin left pointing at a throwaway vault silently redirects every later test in the worker. That surfaced here as `test_100` reporting "landed 0/11" with no hint why.
- **`CONVERGE_BOUND_S = 90`, deliberately under `pytest.ini`'s 180s.** Set equal to it, the loop can never reach its own assertion — pytest-timeout kills the test first and reports a generic timeout instead of "converged only N/M".

Refs #1409