### PR TITLE
fix(crdt): first-sync double-write — telemetry, e2e lineage fence, note_links cap

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -23,7 +23,7 @@
   # rather than the literal `200` dialyzer infers from the current
   # `@backlinks_limit` value — the spec documents the contract callers (and
   # tests) can rely on, not today's specific cap. Same pattern as above.
-  {"lib/engram/links.ex", :contract_supertype, 711},
+  {"lib/engram/links.ex", :contract_supertype, 727},
 
   # `EmbedNote.backfill_priority/0` is intentionally specced as `pos_integer()`
   # rather than the literal `9` dialyzer infers from `@backfill_priority` — the
@@ -37,5 +37,5 @@
   # `Repo.one/2` types as `term()`, so dialyzer widens the `+` to `number()`
   # and flags `float()` as missing from the `non_neg_integer()` spec. The
   # spec states the real contract.
-  {"lib/engram/links.ex", :missing_range, 355}
+  {"lib/engram/links.ex", :missing_range, 371}
 ]

--- a/docs/context/crdt-frontmatter-reseed-second-lineage.md
+++ b/docs/context/crdt-frontmatter-reseed-second-lineage.md
@@ -1,0 +1,123 @@
+# Context Doc: identical frontmatter re-seed mints a second lineage
+
+_Last verified: 2026-08-23_
+
+## Status
+Root-caused and fixed. Plugin PR engram-app/Engram-obsidian#464, e2e fence Engram#1454.
+
+## Symptom, as reported
+"We are duplicating the content of each note dozens of times." Then, after a
+clean re-sync: server bytes exactly 2x the file on disk, on 224 of 316 notes.
+Disk was never wrong.
+
+## Why it resists diagnosis
+
+Four traps, in the order they burned time:
+
+1. **Opening a note heals it.** `Visit Notes Log (Revere Health).md` read 67,630
+   bytes at 09:37 and 33,833 at 09:44, `version` 3 -> 6, because it was viewed in
+   the web app at 09:42. Anything a human inspects has already converged, so
+   "I don't see any duplication" and "the server holds it twice" are both true.
+2. **The two copies do not always concatenate.** Where the insertions
+   interleaved, text was still 2x but not a clean `X+X`. A
+   "first half == second half" detector reported 17 of 60 doubled when the real
+   answer was 224 of 316. Count Yjs clients, not bytes.
+3. **`plain == crdt` proves nothing.** The `content` column is derived FROM the
+   doc, so a server-side union produces that equality just as a client that
+   uploaded doubled bytes would. This was used to wrongly conclude "the client
+   sent doubled content".
+4. **Every summary signal was correct.** Note count, room count and
+   `genesis_seed` outcomes all matched a healthy run. Only the doc structure was
+   wrong.
+
+## The mechanical signature
+
+Every affected note's stored Y.Doc holds exactly TWO clients, each with a clock
+equal to half the final character count — the whole document inserted twice, once
+per client. Read it with the state vector's leading varint (`e2e/helpers/lineage_probe.py`).
+
+A healthy note written by one device has ONE client.
+
+## Root cause
+
+`applyFrontmatterInto` (`plugin/src/crdt/note-seed.ts`) guarded its MAP upsert
+("only changed keys written") but replaced the ORDER array unconditionally:
+
+```ts
+if (arr.length > 0) arr.delete(0, arr.length);
+if (order.length > 0) arr.insert(0, order);
+```
+
+Rewriting an identical key list changes nothing an observer can see, and a CRDT
+still records the ops — which mints the writing device as a NEW client. A device
+with no prior ops on that doc becomes a second lineage.
+
+The chain that reaches it on a FIRST sync, where you would not expect any local
+edit at all:
+
+1. genesis seeds the note server-side from the disk bytes
+2. the adopt awaits `flushFromCrdt`, which writes the doc's PROJECTION to disk
+3. frontmatter does not round-trip byte-for-byte — `tags: [a, b]` comes back as a
+   block list — so those bytes genuinely differ
+4. Obsidian fires a real modify. `handleModify` deliberately SKIPS its
+   recently-flushed guard for CRDT notes (`sync.ts`), on the stated premise that
+   "the echo of a flush is naturally a no-op"
+5. the echo reaches `applyLocalEdit` -> `seedContentInto` -> `applyFrontmatterInto`
+
+Step 4's premise was true of the BODY (an unchanged body diffs to zero text ops)
+and false of the frontmatter order. Instrumented on a real device:
+`textLen 236->236` alongside a 31-byte LOCAL-origin update, three times over.
+
+## Which notes are affected
+
+Exactly those whose YAML does not survive parse + re-serialise. Measured 1:1 in
+e2e: rewritten-on-disk <=> extra edit-class room <=> doubled lineage. Shapes that
+break: inline arrays, quoted scalars, comments, irregular indentation, empty
+values, numeric strings, blank lines inside the block. Shapes that survive: plain
+block lists, nested maps, date scalars, no frontmatter at all.
+
+## How to tell it apart from #1409's room storm
+
+They co-occur and are NOT the same defect.
+
+- Room storm (#1409, still open): `crdt_msg` allocates a server room per note.
+  Measured 213 edit-class rooms for 316 notes. Costs memory, not correctness.
+- This: a second lineage per note. Costs correctness.
+
+The rooms are the visible symptom of the same cold sends that carry the second
+lineage, which is why fixing the lineage bug also took edit-class rooms to zero
+in `test_100`. It does NOT fix #1409 generally.
+
+## Failed approaches (do not repeat)
+
+- **Broad guard in `applyLocalEdit`**: `if (this.project(e) === diskContent) return diskContent;`
+  Fixes the echo but breaks the re-sync-into-a-fresh-vault case — returning early
+  skips the path that enrolls and pushes a doc the server vault has never seen,
+  so the note reaches the server another way and forks anyway. `test_98` went
+  from 0/25 to 65/65 doubled. The guard must be at the op-minting site, not at
+  the function entry.
+- **Unit reproduction**: three separate harnesses (double-seed with cleared
+  baseline, genesis-then-local-edit, ProviderRegistry two-device relay) all
+  PASSED against the buggy code. The transport has to be real; a harness that
+  never connects buffers the second write and never ships it.
+- **Client-ID count as a doubling test**: "2 clients" is normal in some states
+  (checkpoint rebuild). It only discriminates when read per-note alongside the
+  clock values.
+
+## Reproducing
+
+`e2e/tests/test_100_frontmatter_echo_single_lineage.py`. Round-trip-hostile YAML
+shapes, one vault pass. Red against the unfixed plugin at 7/11 doubled + 7
+edit-class rooms; green at 0 and 0.
+
+Unit equivalent (1 second instead of 40): `plugin/tests/crdt/seed-gate.test.ts`,
+"a second device re-seeding the SAME content adds no client" — reports
+`after: 2` against the old code.
+
+## Still open
+
+- The disk rewrite itself (step 3) still happens and is currently by design: the
+  CRDT stores frontmatter structurally and its projection is authoritative. It is
+  a user-visible mutation of files the user did not edit. Not data loss.
+- At least one file in the reporter's vault is doubled ON DISK, from an earlier
+  sync that flushed doubled content before this was fixed. No repair sweep exists.

--- a/e2e/helpers/billing.py
+++ b/e2e/helpers/billing.py
@@ -28,6 +28,12 @@ CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres
 TEST_USER_OVERRIDES = {
     "api_write_enabled": True,
     "api_rps_cap": 1000,
+    # Free defaults to a SINGLE vault (limit_keys.ex `vaults_cap`), so any test
+    # that registers a second one gets a 402 with an empty body — which reads as
+    # "the register call is broken" rather than "the plan said no". test_98
+    # needs two: it re-syncs one local vault into a fresh server vault, which is
+    # the asymmetry the first-sync double-write needs.
+    "vaults_cap": -1,
     "obsidian_connections_cap": -1,
     "mcp_connections_cap": -1,
     # Free-tier launch (§G) gates attachments behind `attachments_enabled`

--- a/e2e/helpers/billing.py
+++ b/e2e/helpers/billing.py
@@ -28,12 +28,6 @@ CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres
 TEST_USER_OVERRIDES = {
     "api_write_enabled": True,
     "api_rps_cap": 1000,
-    # Free defaults to a SINGLE vault (limit_keys.ex `vaults_cap`), so any test
-    # that registers a second one gets a 402 with an empty body — which reads as
-    # "the register call is broken" rather than "the plan said no". test_98
-    # needs two: it re-syncs one local vault into a fresh server vault, which is
-    # the asymmetry the first-sync double-write needs.
-    "vaults_cap": -1,
     "obsidian_connections_cap": -1,
     "mcp_connections_cap": -1,
     # Free-tier launch (§G) gates attachments behind `attachments_enabled`
@@ -103,3 +97,34 @@ def grant_test_plan(email: str) -> str:
     user_id = lines[-1].strip()
     logger.info("Granted e2e plan overrides to user %s (id=%s)", email, user_id)
     return user_id
+
+
+def grant_vault_headroom(email: str) -> None:
+    """Lift `vaults_cap` for ONE user, for a test that legitimately needs a
+    second vault (test_98 re-syncs one local vault into a fresh server one).
+
+    Deliberately NOT in `TEST_USER_OVERRIDES`: that dict is applied by every
+    `grant_test_plan` caller, and `test_32_vault_api_key_isolation` asserts the
+    Free plan BLOCKS a second vault. Granting it globally turned that test's
+    expected 402 into a 201 — the same leak the comments in that dict warn
+    about, so the fix is opt-in rather than a wider default.
+    """
+    sql = (
+        "INSERT INTO user_limit_overrides (user_id, key, value, reason, set_by) "
+        f"VALUES ((SELECT id FROM users WHERE email = '{email}'), 'vaults_cap', "
+        f"'{json.dumps({'v': -1})}'::jsonb, 'e2e-test', 'e2e') "
+        "ON CONFLICT (user_id, key) DO UPDATE "
+        "SET value = EXCLUDED.value, set_at = NOW();"
+    )
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", CI_POSTGRES_CONTAINER,
+            "psql", "-U", "engram", "-d", "engram", "-tA", "-c", sql,
+        ],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"grant_vault_headroom({email}) failed: {result.stderr.strip()}"
+        )
+    logger.info("Lifted vaults_cap for %s", email)

--- a/e2e/helpers/lineage_probe.py
+++ b/e2e/helpers/lineage_probe.py
@@ -1,0 +1,74 @@
+"""Count notes whose stored CRDT doc holds MORE THAN ONE Yjs client.
+
+Backs the 2026-08-23 first-sync double-write: against a real vault (server
+"health local test v10", 316 notes) EVERY note's stored Y.Doc held exactly two
+clients, each with a clock equal to half the final character count — the whole
+document inserted twice, once per client. Server bytes were exactly 2x the file
+on disk; disk was never wrong; opening a note converged it back to 1x, which is
+why the corruption was invisible from the client.
+
+Why client count and not content length: a length check needs the disk bytes to
+compare against, and the two insertions do not always land end-to-end. When they
+interleave the text is still 2x but is not a clean `X+X`, so a
+"first half == second half" test misses it — that is exactly how the production
+sample first read as "17 of 60 doubled" when the real answer was all of them.
+The client count is structural and catches both shapes.
+
+A healthy note written by one device has ONE client. A second client means a
+second independent lineage reached the server, which is the defect regardless of
+how the two copies happen to be ordered in the text.
+
+The state vector's leading varint IS the client count, so this reads one byte
+rather than decoding the whole structure. That is valid below 128 clients; a
+vault that somehow exceeded that would under-report, and 128 distinct writers on
+one note is already a far louder bug than this probe is looking for.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from helpers.backend_rpc import backend_rpc
+
+# ONE logical Elixir line: `bin/engram rpc` takes the expression as a single
+# argv, so a one-liner cannot be reshaped by newline handling in the release
+# wrapper (same constraint room_probe.py documents).
+_PROBE = (
+    '{{:ok, vb}} = Ecto.UUID.dump("{vault_id}"); '
+    '{{:ok, vr}} = Ecto.Adapters.SQL.query(Engram.Repo, '
+    '"select user_id::text from vaults where id=$1", [vb]); '
+    "u = Engram.Accounts.get_user!(hd(hd(vr.rows))); "
+    "{{:ok, nr}} = Ecto.Adapters.SQL.query(Engram.Repo, "
+    '"select id::text from notes where vault_id=$1 and deleted_at is null", [vb]); '
+    "ids = List.flatten(nr.rows); "
+    "{{:ok, notes}} = Engram.Repo.with_tenant(u.id, fn -> "
+    "Enum.map(ids, &Engram.Repo.get(Engram.Notes.Note, &1)) end); "
+    "counts = Enum.map(notes, fn n -> "
+    "{{:ok, st}} = Engram.Crypto.decrypt_crdt_state(n, u); "
+    "if st do {{:ok, d}} = Engram.Notes.CrdtBridge.doc_from_state(st); "
+    ":binary.first(Yex.encode_state_vector!(d)) else 0 end end); "
+    'IO.puts(Enum.join([length(counts), Enum.count(counts, &(&1 > 1)), '
+    "Enum.max(counts, fn -> 0 end)], \",\"))"
+)
+
+
+@dataclass(frozen=True)
+class Lineages:
+    notes: int
+    multi_client: int
+    max_clients: int
+
+    def __str__(self) -> str:
+        return (
+            f"{self.multi_client}/{self.notes} notes hold >1 Yjs lineage "
+            f"(worst: {self.max_clients} clients)"
+        )
+
+
+def read_lineages(vault_id: str) -> Lineages:
+    """Sample every live note in `vault_id`. Raises if the probe misfires."""
+    out = backend_rpc(_PROBE.format(vault_id=vault_id))
+    line = out.strip().splitlines()[-1]
+    parts = line.split(",")
+    assert len(parts) == 3, f"lineage probe returned {line!r}"
+    return Lineages(*(int(p) for p in parts))

--- a/e2e/helpers/room_probe.py
+++ b/e2e/helpers/room_probe.py
@@ -42,20 +42,33 @@ from helpers.backend_rpc import backend_rpc
 # RoomStarts — all three are read positionally.
 SOURCES = ("handshake", "edit", "create_batch", "unknown")
 
+# SOURCES is the ONE definition of both the slot count and the atom->slot
+# mapping. An earlier revision hard-coded `:counters.new(4, [])` and `1..4`
+# alongside it — three places encoding the same number, so adding a fifth
+# source would have silently under-counted (and `:counters.add` past the end
+# raises INSIDE the telemetry handler, which detaches it: the probe would then
+# report zeros, and zeros read as "no rooms allocated"). Derived, not repeated.
+_N = len(SOURCES)
+_LAST = _N  # the catch-all slot; SOURCES[-1] must stay "unknown"
+
+_CASE_ARMS = "; ".join(
+    f":{name} -> {i}" for i, name in enumerate(SOURCES[:-1], start=1)
+)
+
 _ARM_EXPR = (
-    ":persistent_term.put(:e2e_room_starts, :counters.new(4, [])); "
+    f":persistent_term.put(:e2e_room_starts, :counters.new({_N}, [])); "
     ':telemetry.detach("e2e-room-starts"); '
     ':telemetry.attach("e2e-room-starts", [:engram, :crdt, :room_start], '
     "fn _, _, meta, _ -> "
     ":counters.add(:persistent_term.get(:e2e_room_starts), "
-    "(case meta[:source] do :handshake -> 1; :edit -> 2; :create_batch -> 3; _ -> 4 end), 1) "
+    f"(case meta[:source] do {_CASE_ARMS}; _ -> {_LAST} end), 1) "
     "end, nil); "
     'IO.puts("armed")'
 )
 
 _READ_EXPR = (
     "c = :persistent_term.get(:e2e_room_starts); "
-    "1..4 |> Enum.map(&:counters.get(c, &1)) |> Enum.join(\",\") |> IO.puts()"
+    f"1..{_N} |> Enum.map(&:counters.get(c, &1)) |> Enum.join(\",\") |> IO.puts()"
 )
 
 

--- a/e2e/helpers/room_probe.py
+++ b/e2e/helpers/room_probe.py
@@ -1,0 +1,99 @@
+"""Count CRDT rooms ALLOCATED on the backend node, broken down by the call
+path that allocated each one.
+
+Backs the #1409 acceptance criterion — "a bulk/first sync of N notes creates
+O(open editors) rooms, not O(N)" — with a number instead of a hope.
+
+Why allocation and not residency: `ci/compose.yml` sets `CRDT_IDLE_EXIT_MS`,
+so rooms a regression opened at the top of a test have drained long before it
+ends. Sampling `:global` afterwards measures instantaneous residency, and a
+full room-per-note regression passes that assertion — the burst comes and goes
+entirely between two samples. Allocation is the claim; count allocation.
+(test_09 makes the same argument for its flat counter, which this generalises.)
+
+Why by source: a count alone says how many rooms an import allocated, never
+WHY. The 2026-08-19 staging import measured 406 rooms for 1,516 notes with no
+way to attribute them, which is what motivated the `source` tag (#1432). The
+buckets mirror the closed set of atoms fixed in `crdt_channel.ex`:
+
+    handshake / edit  — a `crdt_msg` frame, classified by `frame_class_b64/1`
+    create_batch      — `crdt_create_batch` room enrollment (the web SPA path)
+    unknown           — CrdtDoc.start_link's default: a caller that passed no
+                        source. Not expected to move; it is the "someone added
+                        an allocation path and forgot to tag it" tripwire, and
+                        a silent zero here is a real signal, not filler.
+
+The counter lives in `:persistent_term` (an `:atomics` ref, the same idiom
+`FanoutPacer.test_drop_next/2` uses for e2e-armed counters) so it survives the
+rpc process that arms it.
+
+Both expressions are ONE logical Elixir line: `bin/engram rpc` takes the
+expression as a single argv, and a one-liner cannot be reshaped by any newline
+handling on the way through the release wrapper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from helpers.backend_rpc import backend_rpc
+
+# Counter slot order. Must match the `case` in _ARM_EXPR and the field order of
+# RoomStarts — all three are read positionally.
+SOURCES = ("handshake", "edit", "create_batch", "unknown")
+
+_ARM_EXPR = (
+    ":persistent_term.put(:e2e_room_starts, :counters.new(4, [])); "
+    ':telemetry.detach("e2e-room-starts"); '
+    ':telemetry.attach("e2e-room-starts", [:engram, :crdt, :room_start], '
+    "fn _, _, meta, _ -> "
+    ":counters.add(:persistent_term.get(:e2e_room_starts), "
+    "(case meta[:source] do :handshake -> 1; :edit -> 2; :create_batch -> 3; _ -> 4 end), 1) "
+    "end, nil); "
+    'IO.puts("armed")'
+)
+
+_READ_EXPR = (
+    "c = :persistent_term.get(:e2e_room_starts); "
+    "1..4 |> Enum.map(&:counters.get(c, &1)) |> Enum.join(\",\") |> IO.puts()"
+)
+
+
+@dataclass(frozen=True)
+class RoomStarts:
+    """Rooms allocated, per call path. Field order matches SOURCES."""
+
+    handshake: int
+    edit: int
+    create_batch: int
+    unknown: int
+
+    @property
+    def total(self) -> int:
+        return self.handshake + self.edit + self.create_batch + self.unknown
+
+    def __sub__(self, other: "RoomStarts") -> "RoomStarts":
+        """Delta between two samples — the counter is cumulative per node, so a
+        test measures its own window rather than everything since boot."""
+        return RoomStarts(
+            *(getattr(self, s) - getattr(other, s) for s in SOURCES)
+        )
+
+    def __str__(self) -> str:
+        parts = ", ".join(f"{s}={getattr(self, s)}" for s in SOURCES)
+        return f"{self.total} rooms ({parts})"
+
+
+def arm_room_starts() -> None:
+    """Install the telemetry handler. Call once before the measured window."""
+    # backend_rpc raises on a non-zero exit, and this asserts the sentinel, so a
+    # mis-staged probe fails loudly here rather than leaving a vacuously green
+    # assertion at the end of the test.
+    out = backend_rpc(_ARM_EXPR)
+    assert "armed" in out, f"room-start counter did not arm: {out!r}"
+
+
+def read_room_starts() -> RoomStarts:
+    """Sample the cumulative per-source counts."""
+    line = backend_rpc(_READ_EXPR).strip().splitlines()[-1]
+    return RoomStarts(*(int(v) for v in line.split(",")))

--- a/e2e/helpers/seed_probe.py
+++ b/e2e/helpers/seed_probe.py
@@ -1,0 +1,84 @@
+"""Count genesis-seed outcomes on the backend node, by reason.
+
+Companion to `room_probe`. That one answers "how many rooms did this import
+allocate"; this one answers "did the import go through the CRDT create path at
+all, and did each create's body seed roomlessly".
+
+Why it exists: test_97 measured ZERO rooms for a 40-note first sync while the
+2026-08-23 production import of the same shape measured 213. Zero is the
+number a test reports both when the roomless path works perfectly AND when the
+notes never touched the CRDT create path in the first place — e.g. they landed
+over the REST batch push instead. Those two are opposite conclusions from an
+identical reading, and only a seed count separates them.
+
+The reasons mirror the closed set of atoms in `crdt_channel.ex`'s
+`seed_outcome/1`; `seeded` is the success path and everything else names why a
+body could not be applied detached.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from helpers.backend_rpc import backend_rpc
+
+REASONS = (
+    "seeded",
+    "write_declined",
+    "no_b64",
+    "b64_not_binary",
+    "not_markdown",
+    "room_already_exists",
+    "not_sync_update",
+    "frame_decode_failed",
+    "frame_unsafe",
+    "apply_failed",
+    "other",
+)
+
+_N = len(REASONS)
+_LAST = _N
+_ARMS = "; ".join(f":{r} -> {i}" for i, r in enumerate(REASONS[:-1], start=1))
+
+# ONE logical Elixir line — see room_probe.py for why.
+_ARM = (
+    f":persistent_term.put(:e2e_seed, :counters.new({_N}, [])); "
+    ':telemetry.detach("e2e-seed"); '
+    ':telemetry.attach("e2e-seed", [:engram, :crdt, :genesis_seed], '
+    "fn _, _, meta, _ -> :counters.add(:persistent_term.get(:e2e_seed), "
+    f"(case meta[:reason] do {_ARMS}; _ -> {_LAST} end), 1) end, nil); "
+    'IO.puts("armed")'
+)
+
+_READ = (
+    "c = :persistent_term.get(:e2e_seed); "
+    f'1..{_N} |> Enum.map(&:counters.get(c, &1)) |> Enum.join(",") |> IO.puts()'
+)
+
+
+@dataclass(frozen=True)
+class Seeds:
+    counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+    def __sub__(self, other: "Seeds") -> "Seeds":
+        return Seeds({r: self.counts[r] - other.counts[r] for r in REASONS})
+
+    def __str__(self) -> str:
+        live = {r: v for r, v in self.counts.items() if v}
+        return f"{self.total} seeds {live or '{}'}"
+
+
+def arm_seeds() -> None:
+    out = backend_rpc(_ARM)
+    assert "armed" in out, f"seed counter did not arm: {out!r}"
+
+
+def read_seeds() -> Seeds:
+    line = backend_rpc(_READ).strip().splitlines()[-1]
+    values = [int(v) for v in line.split(",")]
+    assert len(values) == _N, f"seed probe returned {line!r}"
+    return Seeds(dict(zip(REASONS, values, strict=True)))

--- a/e2e/tests/test_100_frontmatter_echo_single_lineage.py
+++ b/e2e/tests/test_100_frontmatter_echo_single_lineage.py
@@ -1,0 +1,166 @@
+"""Test 100: frontmatter that does not round-trip must not fork a lineage.
+
+Third narrowing test for the 2026-08-23 double-write, and the one that targets
+the remaining gap between the passing e2e runs and the failing production run:
+
+    e2e (test_97/98/99):  0 edit-class rooms, 0 doubled notes
+    production:         213 edit-class rooms, 224/316 doubled
+
+An edit-class room means the device emitted a LOCAL-origin update after the
+genesis seed. test_99 ruled out a byte-identical echo — that is suppressed. What
+is left is a write-back whose bytes genuinely DIFFER from what was read: the
+genesis adopt awaits its own `flushFromCrdt`, and if the text the CRDT projects
+is not byte-identical to the file on disk, Obsidian's modify event carries a
+real diff, `applyLocalEdit` forks a lineage, and the cold `crdt_msg` ships it as
+a second full copy.
+
+The suspect is frontmatter normalisation. Every e2e fixture so far used simple
+block-style YAML that round-trips exactly; the reporter's vault is full of
+inline arrays, quoted scalars, comments and irregular spacing. So the fixtures
+here are deliberately round-trip HOSTILE, and the assertion is direct: the bytes
+on disk after a sync must equal the bytes written before it.
+
+The fence is the LINEAGE COUNT, not the disk bytes. The rewrite itself is
+expected and benign: the CRDT stores frontmatter structurally, so its projection
+re-serialises YAML, and writing that back is the authoritative content winning.
+What must never follow is a second lineage. The rewrite list is printed rather
+than asserted so a future change to the codec shows up as context on a failure
+instead of as a failure of its own.
+
+Verified to catch the defect: against the code before
+`applyLocalEdit`'s projection-equality guard, this reported 7 of 10 notes
+holding 2 lineages and 7 edit-class rooms — one per rewritten file. With the
+guard: 0 and 0.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from helpers.lineage_probe import read_lineages
+from helpers.room_probe import arm_room_starts, read_room_starts
+from helpers.vault import write_note
+
+# Must stay well under pytest.ini's 180s timeout. Equal to it, the loop
+# can never reach its own assertion — pytest-timeout kills the test first
+# and reports a generic timeout instead of "converged only N/M".
+CONVERGE_BOUND_S = 90
+
+SET_BLOCKED = (
+    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+)
+
+# Each shape is a separate way YAML can fail to survive a parse/serialise round
+# trip. Named so a failure says WHICH shape moved rather than just "bytes
+# differ".
+FRONTMATTER_SHAPES = {
+    "inline-array": "---\ntags: [alpha, beta, gamma]\n---\n",
+    "quoted-scalar": '---\ntitle: "Quoted: with colon"\nstatus: \'single\'\n---\n',
+    "comment": "---\ntags:\n  - a\n# a trailing comment\nreviewed: 2026-08-23\n---\n",
+    "irregular-space": "---\ntags:\n    - deep\n    - indent\nkey:    spaced\n---\n",
+    "nested-map": "---\nmeta:\n  author: todd\n  nested:\n    deeper: true\n---\n",
+    "empty-value": "---\nalias:\ntags:\n  - has-empty-sibling\n---\n",
+    "date-scalar": "---\ncreated: 2026-08-23\nupdated: 2026-08-23T09:28:41Z\n---\n",
+    "numeric-string": '---\nversion: "1.20"\nbuild: 007\n---\n',
+    "blank-lines": "---\ntags:\n  - a\n\n\nreviewed: 2026-08-23\n---\n",
+    "no-frontmatter": "",
+}
+
+# The second echo shape, folded in from what was test_99: a rewrite with
+# BYTE-IDENTICAL content. It exercises the same "engine sees its own write come
+# back" path but with nothing for the codec to normalise, so it isolates
+# suppression that keys on content equality from suppression that keys on
+# round-trip stability. Cheap to carry here — it reuses this test's vault pass
+# instead of paying for another one.
+IDENTICAL_ECHO = "identical-bytes"
+
+
+@pytest.mark.asyncio
+async def test_sync_leaves_disk_bytes_untouched(
+    vault_a, cdp_a, api_sync, sync_vault_id
+):
+    run = uuid.uuid4().hex[:12]
+    prefix = f"Roundtrip-{run}"
+
+    arm_room_starts()
+    rooms_before = read_room_starts()
+
+    await cdp_a.evaluate(SET_BLOCKED.format("true"))
+
+    written: dict[str, str] = {}
+    shapes = {**FRONTMATTER_SHAPES, IDENTICAL_ECHO: "---\ntags:\n  - stable\n---\n"}
+    for name, fm in shapes.items():
+        body = "\n".join(f"line {j} of {name}" for j in range(40))
+        rel = f"{prefix}/{name}.md"
+        written[rel] = f"{fm}\n# {name}\n\n{body}\n"
+        write_note(vault_a, rel, written[rel])
+
+    expected = len(shapes)
+    deadline = time.monotonic() + 60
+    indexed = 0
+    while time.monotonic() < deadline:
+        indexed = await cdp_a.evaluate(
+            f"app.vault.getFiles().filter(f => f.path.startsWith('{prefix}/')).length"
+        )
+        if isinstance(indexed, int) and indexed >= expected:
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Obsidian indexed only {indexed}/{expected} files")
+
+    await cdp_a.accept_sync_gate()
+
+    started = time.monotonic()
+    landed = 0
+    while time.monotonic() < started + CONVERGE_BOUND_S:
+        await cdp_a.evaluate(SET_BLOCKED.format("false"))
+        await cdp_a.trigger_full_sync()
+        manifest = api_sync.get_manifest()
+        landed = sum(1 for n in manifest["notes"] if n["path"].startswith(prefix))
+        if landed >= expected:
+            break
+        time.sleep(2)
+    assert landed >= expected, f"sync landed only {landed}/{expected}"
+
+    # Second echo shape: rewrite one file with its OWN bytes. Nothing for the
+    # codec to normalise, so anything this forks is a suppression gap rather
+    # than a round-trip artefact.
+    identical_rel = f"{prefix}/{IDENTICAL_ECHO}.md"
+    Path(vault_a, identical_rel).write_text(written[identical_rel], encoding="utf-8")
+
+    # Give both write-backs and the modify events they trigger time to land.
+    time.sleep(10)
+
+    rewritten = {
+        rel: Path(vault_a, rel).read_text(encoding="utf-8")
+        for rel in written
+        if Path(vault_a, rel).read_text(encoding="utf-8") != written[rel]
+    }
+    lineages = read_lineages(sync_vault_id)
+    rooms = read_room_starts() - rooms_before
+    print(
+        f"\ntest_100 rewritten-on-disk={sorted(rewritten)} | {lineages} | rooms: {rooms}"
+    )
+
+    # The rewrite is the TRIGGER, and it is expected — see the module docstring.
+    # Asserted only to the extent that it must still be happening, because a run
+    # where nothing was rewritten never exercised the path this test exists for
+    # and would pass vacuously.
+    assert rewritten, (
+        "no file was rewritten, so this run never exercised the write-back echo "
+        "that the lineage assertion below is fencing. Did the frontmatter codec "
+        "start round-tripping byte-for-byte? If so this fixture needs a new "
+        "round-trip-hostile shape."
+    )
+
+    assert lineages.multi_client == 0, (
+        f"frontmatter normalisation forked a lineage: {lineages}. The engine's "
+        "own write-back fired a modify with genuinely different bytes, and "
+        "handleModify skips its recently-flushed guard for CRDT notes — so the "
+        "echo reached applyLocalEdit, which re-set the frontmatter map and "
+        f"minted this device as a second client. Rooms: {rooms}."
+    )

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -36,7 +36,21 @@ PUSH_TIME_BOUND_S = 120
 # and `crdt_msg` is what calls `ensure_room`. The headroom above 0 covers a note
 # open in the editor during the run and any seed that falls back to the
 # `crdt_msg` path (`seeded: false`, e.g. an ADOPT) — both allocate legitimately.
+#
+# Bounds `crdt_msg`-driven allocation ONLY (handshake is asserted separately
+# below). The local 0 did not hold in CI, which measured 544 HANDSHAKE rooms for
+# the same 1,000 notes — enrolment, not cold sends. Bounding the total at 8 would
+# therefore have asserted that #1409 is fully fixed when only its `crdt_msg` half
+# is; the split keeps a real fence on the part that IS fixed instead of a red X
+# on the part that is not.
 ROOM_ALLOC_BOUND = 8
+
+# Enrolment-driven rooms, the OPEN half of #1409. Recorded as a ratchet, not a
+# target: 544/1000 was the CI measurement on 2026-08-23. It exists so a change
+# that makes enrolment worse still fails, while the known O(N) baseline does not
+# spend every run red. TIGHTEN THIS as #1409's enrolment work lands; a run that
+# comes in far under it means the bound is stale, not that nothing happened.
+HANDSHAKE_ROOM_RATCHET = 700
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
@@ -161,12 +175,18 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
         # be counted, and the drain means residency would already have shed it.
         rooms = read_room_starts() - rooms_before
         print(f"\ntest_77 rooms allocated for {NOTE_COUNT} notes: {rooms}")
-        assert rooms.total <= ROOM_ALLOC_BOUND, (
+        cold_rooms = rooms.edit + rooms.create_batch + rooms.unknown
+        assert cold_rooms <= ROOM_ALLOC_BOUND, (
             f"bulk first sync of {NOTE_COUNT} notes allocated {rooms} — expected "
-            f"<= {ROOM_ALLOC_BOUND} (#1409: rooms are for notes open in an editor, "
-            "not for imported files). The per-source split names the path that "
-            "regressed; `unknown` means an allocation site shipped without a "
-            "source tag."
+            f"<= {ROOM_ALLOC_BOUND} rooms from the crdt_msg paths (#1409: rooms "
+            "are for notes open in an editor, not for imported files). The "
+            "per-source split names the path that regressed; `unknown` means an "
+            "allocation site shipped without a source tag."
+        )
+        assert rooms.handshake <= HANDSHAKE_ROOM_RATCHET, (
+            f"enrolment opened {rooms.handshake} handshake rooms for "
+            f"{NOTE_COUNT} notes, past the {HANDSHAKE_ROOM_RATCHET} ratchet. This "
+            "is #1409's open half — the ratchet only fails when it gets WORSE."
         )
     finally:
         await _cleanup_bulk_residue(vault_a, cdp_a, api_sync)

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -1,11 +1,18 @@
-"""Test 77: 1k-note bulk first sync lands via crdt_create_batch in bounded time.
+"""Test 77: a 1k-note bulk first sync lands in bounded time, and does not
+allocate a CRDT room per note.
 
-CRDT single-push-path migration: pushGenesisBatch sends notes through the
-WS `crdt_create_batch` op in chunks, not POST /notes/batch (removed) — a
-1,000-note first sync is a handful of socket round-trips instead of 1,000.
-The duration bound is deliberately generous for CI noise but far below
-what the per-note path costs (1,000 paced requests), so a silent fallback
-to per-note pushes fails this test.
+Push path: `pushPartitioned` -> `pushFile` -> socket-native `crdt_create`,
+one bounded per-file work unit each (the `crdt_create_batch` RPC this test
+was originally written against was retired in the Relay-pattern rewrite, in
+favour of per-file failure isolation). The duration bound is deliberately
+generous for CI noise but far below what a REST per-note fallback costs
+(1,000 paced requests), so a silent regression to that path fails here.
+
+The room-allocation bound is the #1409 acceptance criterion. A room is a
+live-collaboration actor; an import has no collaborators, so genesis content
+is seeded detached (#1424) and rooms should be allocated only for notes
+actually open in an editor. Importing a 1,700-file vault once allocated
+~1,700 rooms and took prod's BEAM from 757 to 2,744 processes (2026-08-18).
 """
 
 import shutil
@@ -13,10 +20,23 @@ import time
 
 import pytest
 
+from helpers.room_probe import arm_room_starts, read_room_starts
 from helpers.vault import write_note
 
 NOTE_COUNT = 1000
 PUSH_TIME_BOUND_S = 120
+
+# Rooms this sync may allocate. The criterion is O(open editors), not O(N) —
+# the bound is a small constant on purpose, so a per-note regression fails by
+# two orders of magnitude rather than by a tuning argument. Raising this is
+# only correct alongside a reason a first sync needs more live actors.
+#
+# MEASURED 0 locally on 0.18.0 (2026-08-20, 1,000 notes): with the genesis body
+# riding `crdt_create` (#1424 + plugin #452) the import never sends a `crdt_msg`,
+# and `crdt_msg` is what calls `ensure_room`. The headroom above 0 covers a note
+# open in the editor during the run and any seed that falls back to the
+# `crdt_msg` path (`seeded: false`, e.g. an ADOPT) — both allocate legitimately.
+ROOM_ALLOC_BOUND = 8
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
@@ -63,6 +83,12 @@ async def _cleanup_bulk_residue(vault_a, cdp_a, api_sync) -> None:
 @pytest.mark.asyncio
 async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
     try:
+        # Arm BEFORE the gate work: the counter is cumulative per node and the
+        # measured window is a delta, so arming early only widens what is
+        # attributed to this test — it can never under-count the sync.
+        arm_room_starts()
+        rooms_before = read_room_starts()
+
         # Close the sync gate FIRST: every raw write below fires the vault
         # watcher, and an open gate turns that into 1,000 debounced single-note
         # auto-pushes — a request storm that exhausts the rate budget and
@@ -129,6 +155,18 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
             f"bulk first sync converged only {bulk_count}/{NOTE_COUNT} notes in "
             f"{elapsed:.1f}s (bound {PUSH_TIME_BOUND_S}s) — did the plugin fall "
             "back to per-note pushes or stall?"
+        )
+
+        # Read AFTER convergence: a room allocated by the tail of the sync must
+        # be counted, and the drain means residency would already have shed it.
+        rooms = read_room_starts() - rooms_before
+        print(f"\ntest_77 rooms allocated for {NOTE_COUNT} notes: {rooms}")
+        assert rooms.total <= ROOM_ALLOC_BOUND, (
+            f"bulk first sync of {NOTE_COUNT} notes allocated {rooms} — expected "
+            f"<= {ROOM_ALLOC_BOUND} (#1409: rooms are for notes open in an editor, "
+            "not for imported files). The per-source split names the path that "
+            "regressed; `unknown` means an allocation site shipped without a "
+            "source tag."
         )
     finally:
         await _cleanup_bulk_residue(vault_a, cdp_a, api_sync)

--- a/e2e/tests/test_97_first_sync_single_lineage.py
+++ b/e2e/tests/test_97_first_sync_single_lineage.py
@@ -1,0 +1,143 @@
+"""Test 97: a first sync must leave ONE Yjs lineage per note, not two.
+
+The 2026-08-23 defect. A real vault ("health local test v10", 316 notes) synced
+into a fresh server vault and every stored note came out holding TWO Yjs
+clients, each with a clock equal to half the final character count — the whole
+document inserted twice, once per client. Server bytes were exactly 2x the file
+on disk. Disk was never wrong.
+
+Three properties made it nearly invisible, and each one is why this test is
+shaped the way it is:
+
+  * Opening a note converged it back to 1x. `Visit Notes Log (Revere Health).md`
+    went 67,630 -> 33,833 bytes the moment it was viewed in the web app, so
+    anything a human inspects has already healed by the time they look.
+  * The two insertions do not always land end-to-end. Where they interleaved the
+    text was still 2x but not a clean `X+X`, so a "first half == second half"
+    check reported 17 of 60 doubled when the true answer was 224 of 316.
+  * The plugin reported success. Note count, room count and seed outcomes were
+    all exactly as expected; only the doc STRUCTURE was wrong.
+
+So the assertion is structural — count lineages, not bytes, and read it from the
+server rather than from any client that could have healed it. `lineage_probe`
+carries the rationale for reading the state vector's leading varint.
+
+Deliberately small (40 notes): this pins a correctness property that reproduced
+at 100% of notes, not a throughput bound. test_77 owns the bulk-timing bound and
+its 1,000-note fixture, which cannot run inside the 120s CDP evaluate cap on a
+loaded dev box (see docs/context/local-crdt-e2e-repro.md).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from helpers.lineage_probe import read_lineages
+from helpers.room_probe import arm_room_starts, read_room_starts
+from helpers.seed_probe import arm_seeds, read_seeds
+from helpers.vault import write_note
+
+NOTE_COUNT = 15
+# Must stay well under pytest.ini's 180s timeout. Equal to it, the loop
+# can never reach its own assertion — pytest-timeout kills the test first
+# and reports a generic timeout instead of "converged only N/M".
+CONVERGE_BOUND_S = 90
+
+SET_BLOCKED = (
+    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+)
+
+
+@pytest.mark.asyncio
+async def test_first_sync_leaves_one_lineage_per_note(
+    vault_a, cdp_a, api_sync, sync_vault_id
+):
+    run = uuid.uuid4().hex[:12]
+    prefix = f"Lineage-{run}"
+
+    # Close the gate before touching disk, for the same reason test_77 does: each
+    # raw write fires the vault watcher, and an open gate turns 40 writes into 40
+    # debounced single-note pushes, which is a DIFFERENT code path from the bulk
+    # first sync this test is about.
+    arm_room_starts()
+    arm_seeds()
+    rooms_before = read_room_starts()
+    seeds_before = read_seeds()
+
+    await cdp_a.evaluate(SET_BLOCKED.format("true"))
+
+    # Sizes vary deliberately. The production sample doubled notes from 17 KB to
+    # 68 KB, and a fixture of uniform tiny notes is exactly the shape that let
+    # this ship — a small note's two lineages can merge into a single run and
+    # hide the structure that a larger one exposes.
+    # Frontmatter on purpose. The doubling has a frontmatter-only variant —
+    # `hasHistory` is body-only, so a note with an empty body but existing
+    # history reported false and got its ORDER_KEY doubled (sync.ts's
+    # applyCrdtCreateAck comment). The first doubled note recovered from the
+    # reporter's vault had its YAML block repeated inside ONE `---` fence, so a
+    # body-only fixture cannot see that shape at all.
+    for i in range(NOTE_COUNT):
+        body = "\n".join(f"line {j} of note {i} in {run}" for j in range(i * 12 + 10))
+        fm = f"---\ntags:\n  - lineage\n  - n{i}\nreviewed: 2026-08-23\n---\n\n"
+        write_note(vault_a, f"{prefix}/N{i:03d}.md", f"{fm}# Note {i}\n\n{body}\n")
+
+    deadline = time.monotonic() + 60
+    indexed = 0
+    while time.monotonic() < deadline:
+        indexed = await cdp_a.evaluate(
+            f"app.vault.getFiles().filter(f => f.path.startsWith('{prefix}/')).length"
+        )
+        if isinstance(indexed, int) and indexed >= NOTE_COUNT:
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Obsidian indexed only {indexed}/{NOTE_COUNT} files")
+
+    await cdp_a.accept_sync_gate()
+
+    started = time.monotonic()
+    deadline = started + CONVERGE_BOUND_S
+    landed = 0
+    while time.monotonic() < deadline:
+        await cdp_a.evaluate(SET_BLOCKED.format("false"))
+        await cdp_a.trigger_full_sync()
+        manifest = api_sync.get_manifest()
+        landed = sum(1 for n in manifest["notes"] if n["path"].startswith(prefix))
+        if landed >= NOTE_COUNT:
+            break
+        time.sleep(2)
+
+    assert landed >= NOTE_COUNT, (
+        f"only {landed}/{NOTE_COUNT} notes converged in "
+        f"{time.monotonic() - started:.1f}s — the lineage assertion below would "
+        "be measuring a partial sync"
+    )
+
+    # Read from the SERVER. A client-side read would be answered by the very doc
+    # whose lineage is in question, and viewing a note is what heals it.
+    lineages = read_lineages(sync_vault_id)
+    # Printed, and the note total asserted, because `multi_client == 0` is
+    # satisfied vacuously by an empty vault.
+    # Room split alongside the lineage count. The production run that corrupted
+    # showed 213 edit-class rooms for 316 notes — one cold `crdt_msg` per note on
+    # top of the roomless genesis seeds. That cold send is the suspected carrier
+    # of the second lineage, so if this run shows edit=0 the scenario is missing
+    # the precondition rather than the defect being fixed.
+    rooms = read_room_starts() - rooms_before
+    seeds = read_seeds() - seeds_before
+    print(f"\ntest_97 {lineages} | rooms: {rooms} | {seeds}")
+    assert lineages.notes >= NOTE_COUNT, (
+        f"server holds only {lineages.notes} notes — the lineage assertion "
+        "below would pass vacuously"
+    )
+
+    assert lineages.multi_client == 0, (
+        f"first sync produced {lineages}. Two lineages on one note means the "
+        "device never adopted the genesis lineage the server stored and later "
+        "shipped its own disk-seeded copy as a second full insertion — the "
+        "server then holds the document twice while disk holds it once. See "
+        "sync.ts applyCrdtCreateAck's genesis-adopt guard."
+    )

--- a/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
+++ b/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
@@ -32,6 +32,7 @@ import uuid
 
 import pytest
 
+from helpers.billing import grant_vault_headroom
 from helpers.lineage_probe import read_lineages
 from helpers.vault import write_note
 
@@ -73,10 +74,15 @@ async def _converge(cdp, api, prefix, expected):
 
 @pytest.mark.asyncio
 async def test_resync_into_fresh_vault_keeps_one_lineage(
-    vault_a, cdp_a, api_sync, sync_vault_id
+    vault_a, cdp_a, api_sync, sync_vault_id, sync_user
 ):
     run = uuid.uuid4().hex[:12]
     prefix = f"Resync-{run}"
+
+    # Opt in to a second vault for THIS user only. Free caps `vaults_cap` at
+    # 1, and lifting it globally in TEST_USER_OVERRIDES broke
+    # test_32_vault_api_key_isolation, which asserts Free blocks exactly this.
+    grant_vault_headroom(sync_user[0])
 
     await cdp_a.evaluate(SET_BLOCKED.format("true"))
 

--- a/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
+++ b/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
@@ -1,0 +1,164 @@
+"""Test 98: re-syncing the SAME local vault into a FRESH server vault must not
+double the content.
+
+This is the workflow that produced the 2026-08-23 corruption. The reporter's
+words: "I create a new vault for every test." The local Obsidian vault stays put
+across those runs, so the device keeps its IndexedDB Y.Docs and its NoteIdMap,
+while the server side starts empty every time.
+
+test_97 covers the clean case — a first sync from a device that has never seen
+these notes — and it PASSES. The defect needs the asymmetry this test creates:
+
+    device:  already holds a lineage for every path
+    server:  brand new vault, knows nothing
+
+That asymmetry is what makes the genesis gate's "does this device have history"
+question answer TRUE while the server still needs a full body, and it is the
+only material difference between the passing e2e and the failing real run.
+
+Related prior art, same asymmetry, different symptom: the cross-vault id re-mint
+in `do_bare_insert` (writes global, reads vault-scoped) — see
+docs/context/crdt-wrong-mint-cross-file-overwrite.md.
+
+Asserts on lineage COUNT, not bytes, for the reasons in `lineage_probe`: the two
+insertions sometimes interleave rather than concatenate, and viewing a note
+heals it.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from helpers.lineage_probe import read_lineages
+from helpers.vault import write_note
+
+NOTE_COUNT = 10
+# Must stay well under pytest.ini's 180s timeout. Equal to it, the loop
+# can never reach its own assertion — pytest-timeout kills the test first
+# and reports a generic timeout instead of "converged only N/M".
+CONVERGE_BOUND_S = 90
+
+SET_BLOCKED = (
+    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+)
+
+# Re-point the running plugin at a different server vault WITHOUT touching the
+# local vault directory — the device's docs and id map must survive, because
+# their survival is the precondition under test.
+# One expression returning a STRING: the CDP helper serialises objects to `{{}}`,
+# which silently reads as "the re-point did nothing".
+REPOINT = (
+    "(async () => {{ const p = app.plugins.plugins['engram-vault-sync']; "
+    'p.settings.vaultId = "{vault_id}"; await p.saveSettings(); '
+    'p.api.setVaultId("{vault_id}"); return String(p.settings.vaultId); }})()'
+)
+
+
+async def _converge(cdp, api, prefix, expected):
+    started = time.monotonic()
+    landed = 0
+    while time.monotonic() < started + CONVERGE_BOUND_S:
+        await cdp.evaluate(SET_BLOCKED.format("false"))
+        await cdp.trigger_full_sync()
+        manifest = api.get_manifest()
+        landed = sum(1 for n in manifest["notes"] if n["path"].startswith(prefix))
+        if landed >= expected:
+            break
+        time.sleep(2)
+    return landed
+
+
+@pytest.mark.asyncio
+async def test_resync_into_fresh_vault_keeps_one_lineage(
+    vault_a, cdp_a, api_sync, sync_vault_id
+):
+    run = uuid.uuid4().hex[:12]
+    prefix = f"Resync-{run}"
+
+    await cdp_a.evaluate(SET_BLOCKED.format("true"))
+
+    # Mixed sizes: the production doubling ran from 17 KB to 68 KB per note, and
+    # two lineages over a very short note can merge into one run and hide the
+    # structure a larger note exposes.
+    # Frontmatter included: the doubling has a frontmatter-only variant (see
+    # test_97's fixture comment), and the reporter's first recovered example was
+    # a duplicated YAML block, not a duplicated body.
+    for i in range(NOTE_COUNT):
+        body = "\n".join(f"line {j} of note {i} in {run}" for j in range(i * 12 + 10))
+        fm = f"---\ntags:\n  - resync\n  - n{i}\nreviewed: 2026-08-23\n---\n\n"
+        write_note(vault_a, f"{prefix}/N{i:03d}.md", f"{fm}# Note {i}\n\n{body}\n")
+
+    deadline = time.monotonic() + 60
+    indexed = 0
+    while time.monotonic() < deadline:
+        indexed = await cdp_a.evaluate(
+            f"app.vault.getFiles().filter(f => f.path.startsWith('{prefix}/')).length"
+        )
+        if isinstance(indexed, int) and indexed >= NOTE_COUNT:
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Obsidian indexed only {indexed}/{NOTE_COUNT} files")
+
+    await cdp_a.accept_sync_gate()
+
+    # --- sync #1: establishes device-side lineage for every path --------------
+    landed = await _converge(cdp_a, api_sync, prefix, NOTE_COUNT)
+    assert landed >= NOTE_COUNT, f"first sync landed only {landed}/{NOTE_COUNT}"
+
+    first = read_lineages(sync_vault_id)
+    assert first.multi_client == 0, (
+        f"the FIRST sync already doubled: {first}. That is test_97's scenario, "
+        "so fix that before reading anything into this test."
+    )
+
+    # --- swap the server vault, keep the device exactly as it is --------------
+    fresh_client = f"resync-{run}"
+    resp, status = api_sync.register_vault(f"e2e-resync-{run}", fresh_client)
+    fresh_vault = resp.get("vault", resp) if isinstance(resp, dict) else {}
+    fresh_id = fresh_vault.get("id") or fresh_vault.get("vault_id")
+    assert fresh_id, f"could not register a fresh vault (status={status}): {resp}"
+    assert fresh_id != sync_vault_id, "register returned the SAME vault — not a re-sync"
+
+    # await_promise: cdp.evaluate defaults to False, which hands back the
+    # unresolved Promise and serialises to `{}` — indistinguishable from a
+    # re-point that silently did nothing.
+    got = await cdp_a.evaluate(REPOINT.format(vault_id=fresh_id), await_promise=True)
+    assert got == fresh_id, f"plugin did not re-point (settings.vaultId={got!r})"
+
+    # --- sync #2: same disk, same device docs, empty server vault -------------
+    # Restored in `finally`: `obsidian_a`/`vault_a` are SESSION-scoped, so a
+    # plugin left pointing at this throwaway vault silently redirects every
+    # later test in the worker — they then sync into a vault their fixtures
+    # never read and report "landed 0/N" with no hint why.
+    try:
+        api_fresh = api_sync.with_vault(fresh_id)
+        landed2 = await _converge(cdp_a, api_fresh, prefix, NOTE_COUNT)
+        assert landed2 >= NOTE_COUNT, (
+            f"re-sync landed only {landed2}/{NOTE_COUNT} into the fresh vault — "
+            "the lineage assertion below would be measuring a partial sync"
+        )
+
+        second = read_lineages(fresh_id)
+        # Printed, not just asserted: a lineage count of 0/0 satisfies
+        # `multi_client == 0` vacuously, so the note total has to be visible in
+        # the run output for the pass to mean anything.
+        print(f"\ntest_98 vault1={first} | fresh vault={second}")
+        assert second.notes >= NOTE_COUNT, (
+            f"the fresh vault only holds {second.notes} notes — the re-sync did "
+            "not land, so the lineage assertion below would pass vacuously"
+        )
+
+        assert second.multi_client == 0, (
+            f"re-syncing an unchanged vault into a fresh server vault produced "
+            f"{second}. Two lineages means the server holds the document twice "
+            "while disk holds it once; the client cannot see it because opening "
+            "a note converges it back down."
+        )
+    finally:
+        await cdp_a.evaluate(
+            REPOINT.format(vault_id=sync_vault_id), await_promise=True
+        )

--- a/lib/engram/links.ex
+++ b/lib/engram/links.ex
@@ -42,6 +42,12 @@ defmodule Engram.Links do
   @note_exts ~w(.md .canvas)
   @backlinks_limit 200
 
+  # Rows per `insert_all` statement. See replace_links/4: 17 binds per row
+  # against the protocol's 65535 cap leaves room for 3855, so 2000 is a
+  # deliberate half-margin — a new optional column must not silently re-arm
+  # the overflow.
+  @insert_chunk 2000
+
   @doc """
   Lowercased basename with `.md`/`.canvas` stripped (other extensions kept).
   Obsidian link resolution is case-insensitive and matches on basename
@@ -125,7 +131,17 @@ defmodule Engram.Links do
         skip_tenant_check: true
       )
 
-      if rows != [], do: Repo.insert_all(NoteLink, rows, skip_tenant_check: true)
+      # Chunked, not one statement: the wire protocol caps a query at 65535 bind
+      # parameters, and a NoteLink row binds up to 17 of them (13 base + the
+      # optional alias/anchor envelopes). One MOC-style note with a few thousand
+      # wikilinks therefore overflows the limit, and Postgrex answers that by
+      # KILLING the connection ("can not handle N parameters"), not by returning
+      # a query error — so a single oversized note costs a pooled connection and
+      # takes the whole extraction down with it. Observed on a real vault at
+      # 145792 params (8576 links). @insert_chunk keeps the worst case at 34k.
+      rows
+      |> Enum.chunk_every(@insert_chunk)
+      |> Enum.each(&Repo.insert_all(NoteLink, &1, skip_tenant_check: true))
     end)
 
     :ok

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -859,11 +859,14 @@ defmodule EngramWeb.CrdtChannel do
   # makes the plugin stamp its local body as the synced baseline and stop, so a
   # skipped checkpoint would silently lose the file with no later bind to replay
   # from. Every `false` path falls back to the client's existing crdt_msg seed.
-  defp maybe_seed_detached(_user, _vault, _note, nil), do: false
+  defp maybe_seed_detached(_user, _vault, _note, nil) do
+    seed_outcome(:no_b64)
+    false
+  end
 
   defp maybe_seed_detached(user, vault, %{id: note_id} = note, b64) when is_binary(b64) do
-    with {:ok, frame} <- decode_frame(b64),
-         :ok <- guard_frame(frame),
+    with {:ok, frame} <- decode_genesis_frame(b64),
+         :ok <- guard_genesis_frame(frame),
          # CRDT projects to `notes.content` for MARKDOWN only — `checkpoint/5`
          # routes a non-`.md` doc to `do_structural_checkpoint`, which never
          # touches content. A `.canvas` genesis frame therefore projects
@@ -873,8 +876,8 @@ defmodule EngramWeb.CrdtChannel do
          # and stops. Unreachable today only because the plugin gates `.md`
          # client-side; the server's contract must not depend on that (#1409).
          # Same `.md` test CrdtDeliver and CrdtCheckpoint already use.
-         true <- markdown_path?(note.path),
-         {:ok, {:sync, {:sync_update, update}}} <- Yex.Sync.message_decode(frame),
+         :ok <- require_markdown(note.path),
+         {:ok, update} <- take_sync_update(frame),
          # Two writers, one document: a room holds the doc in memory and would
          # later checkpoint over anything written behind its back. CheckpointNote
          # snoozes on this exact condition (checkpoint_note.ex:50); a channel
@@ -889,15 +892,90 @@ defmodule EngramWeb.CrdtChannel do
          # window on its own — a room merely starting never bumps `notes.version`,
          # only a COMMITTED checkpoint does. That window is closed AFTER the
          # write instead, by `evict_racing_room/1` below (#1409).
-         nil <- CrdtRegistry.lookup(note_id),
-         {:ok, doc} <- apply_detached(update) do
-      seed_detached(user, vault, note_id, doc)
+         :ok <- require_room_free(note_id),
+         {:ok, doc} <- apply_genesis_update(update) do
+      result = seed_detached(user, vault, note_id, doc)
+      seed_outcome(if result, do: :seeded, else: :write_declined)
+      result
     else
-      _ -> false
+      # Every arm here means "the client falls back to its crdt_msg seed", and
+      # THAT is what allocates a room per imported note (#1409). A bare
+      # `_ -> false` made all of them indistinguishable, so a 70%-fallback rate
+      # could be measured but never explained.
+      #
+      # Each step returns a DISTINCT reason atom rather than a bare
+      # `{:error, _}`, so this one arm still attributes precisely. Three of the
+      # underlying calls (decode, guard, apply) all answer `{:error, _}` and
+      # would otherwise collapse into one bucket — a malformed frame, a crafted
+      # state vector and a NIF apply failure are a client bug, an attack and a
+      # server fault respectively, and lumping them answers none of the
+      # questions you would ask next.
+      #
+      # Tagged tuples as `with` placeholders would be the obvious way to do
+      # this; credo forbids them (Credo.Check.Refactor.WithClauses), so the
+      # distinction lives in the step functions instead.
+      {:error, reason} ->
+        seed_outcome(reason)
+        false
     end
   end
 
-  defp maybe_seed_detached(_user, _vault, _note, _b64), do: false
+  defp maybe_seed_detached(_user, _vault, _note, _b64) do
+    seed_outcome(:b64_not_binary)
+    false
+  end
+
+  # `with` steps for maybe_seed_detached/4. Each maps its underlying call onto a
+  # reason atom unique to THAT step — the whole point of the split. Thin on
+  # purpose: the reasoning for each check stays at the call site above.
+  defp decode_genesis_frame(b64) do
+    case decode_frame(b64) do
+      {:ok, frame} -> {:ok, frame}
+      _ -> {:error, :frame_decode_failed}
+    end
+  end
+
+  defp guard_genesis_frame(frame) do
+    case guard_frame(frame) do
+      :ok -> :ok
+      _ -> {:error, :frame_unsafe}
+    end
+  end
+
+  defp require_markdown(path) do
+    if markdown_path?(path), do: :ok, else: {:error, :not_markdown}
+  end
+
+  defp take_sync_update(frame) do
+    case Yex.Sync.message_decode(frame) do
+      {:ok, {:sync, {:sync_update, update}}} -> {:ok, update}
+      _ -> {:error, :not_sync_update}
+    end
+  end
+
+  defp require_room_free(note_id) do
+    if CrdtRegistry.lookup(note_id) == nil, do: :ok, else: {:error, :room_already_exists}
+  end
+
+  defp apply_genesis_update(update) do
+    case apply_detached(update) do
+      {:ok, doc} -> {:ok, doc}
+      _ -> {:error, :apply_failed}
+    end
+  end
+
+  # Why a genesis body did or did not get seeded roomlessly.
+  #
+  # `reason` is a small CLOSED SET OF ATOMS and nothing else rides along. An
+  # earlier revision passed the raw error term as a `detail` key with a comment
+  # saying it must never become a tag — but nothing enforced that, and any
+  # handler doing `inspect(meta)` would have leaked it. These terms are exactly
+  # the class line 418 of this module warns about ("error_kind/1, never
+  # inspect(reason)"): they can embed a wrapped DEK or a provider response body.
+  # The per-step tags above carry the diagnostic value the term used to.
+  defp seed_outcome(reason) when is_atom(reason) do
+    :telemetry.execute([:engram, :crdt, :genesis_seed], %{count: 1}, %{reason: reason})
+  end
 
   defp markdown_path?(path), do: is_binary(path) and String.ends_with?(path, ".md")
 

--- a/test/engram/links_test.exs
+++ b/test/engram/links_test.exs
@@ -639,6 +639,67 @@ defmodule Engram.LinksTest do
     end
   end
 
+  describe "replace_links/4 statement sizing" do
+    @tag timeout: 120_000
+    test "a note with more links than one statement can bind still persists all of them",
+         %{user: user, vault: vault} do
+      source = Engram.Fixtures.insert_note!(user, vault, %{path: "MOC.md"})
+
+      # 5_000 edges x 17 binds = 85_000 parameters — past the protocol's 65535
+      # cap. Every edge carries BOTH optional envelopes so the row hits its
+      # widest column count; a version of this test without alias/anchor binds
+      # only 13 per row and would pass against the unchunked insert.
+      #
+      # Pre-fix this did not fail the assertion below, it KILLED the pooled
+      # connection ("Postgrex.Protocol disconnected: postgresql protocol can
+      # not handle 85000 parameters"), so the failure mode to watch for on a
+      # regression is a connection error, not a count mismatch.
+      parsed =
+        for i <- 0..4999 do
+          %{
+            target: "Target #{i}",
+            alias: "alias #{i}",
+            anchor: "anchor #{i}",
+            link_type: "wikilink",
+            position: i
+          }
+        end
+
+      :ok = Links.replace_links(user, vault, source.id, parsed)
+
+      {:ok, count} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.aggregate(from(l in NoteLink, where: l.source_note_id == ^source.id), :count)
+        end)
+
+      assert count == 5_000
+    end
+
+    test "replacing links is still last-writer-wins across the chunk boundary",
+         %{user: user, vault: vault} do
+      source = Engram.Fixtures.insert_note!(user, vault, %{path: "MOC.md"})
+
+      wide = for i <- 0..2_499, do: parsed_link("Target #{i}", i)
+      :ok = Links.replace_links(user, vault, source.id, wide)
+
+      # A chunked insert must not turn the delete+insert into a partial update:
+      # the second call spans fewer chunks than the first, and every row from
+      # the first must be gone.
+      :ok = Links.replace_links(user, vault, source.id, [parsed_link("Only", 0)])
+
+      {:ok, edges} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.all(from(l in NoteLink, where: l.source_note_id == ^source.id))
+        end)
+
+      assert length(edges) == 1
+    end
+  end
+
+  defp parsed_link(target, position) do
+    %{target: target, alias: nil, anchor: nil, link_type: "wikilink", position: position}
+  end
+
   # Counts SELECTs against the candidate tables (notes/attachments) issued on
   # this process while `fun` runs.
   defp count_candidate_queries(fun) do

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -135,6 +135,98 @@ defmodule EngramWeb.CrdtChannelTest do
     end
   end
 
+  # The `genesis_seed` telemetry is how a fallback rate gets ATTRIBUTED — the
+  # 2026-08-20 investigation could measure "70% of notes still open a room" but
+  # not why, until these reasons existed. An instrument nobody tests reports
+  # zeros when it breaks, and zeros read as "no declines", which is the same
+  # vacuously-green failure the room-start probe was built to avoid. So the
+  # instrument gets its own coverage.
+  describe "genesis_seed telemetry" do
+    setup do
+      test_pid = self()
+      handler = "genesis-seed-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:engram, :crdt, :genesis_seed],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:genesis_seed, meta, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+      :ok
+    end
+
+    test "a bodyless create reports :no_b64", %{socket: socket} do
+      ref =
+        push(socket, "crdt_create", %{"doc_id" => Ecto.UUID.generate(), "path" => "Notes/a.md"})
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, %{reason: :no_b64}, %{count: 1}}
+    end
+
+    test "a body-bearing create reports :seeded", %{socket: socket} do
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/b.md",
+          "b64" => frame_for_content("body")
+        })
+
+      assert_reply ref, :ok, %{seeded: true}
+      assert_receive {:genesis_seed, %{reason: :seeded}, %{count: 1}}
+    end
+
+    test "a non-markdown path reports :not_markdown, not a frame error", %{socket: socket} do
+      # `.canvas` rides these same creates but CRDT projects to notes.content
+      # for markdown only. Distinguishing it from a malformed frame is the whole
+      # reason the steps are tagged.
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/board.canvas",
+          "b64" => frame_for_content("body")
+        })
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, %{reason: :not_markdown}, _}
+    end
+
+    test "a malformed body reports :frame_decode_failed", %{socket: socket} do
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/c.md",
+          "b64" => "!!!not base64!!!"
+        })
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, %{reason: :frame_decode_failed}, _}
+    end
+
+    test "metadata carries ONLY the reason atom — never a payload-derived term", %{
+      socket: socket
+    } do
+      # These error terms are the class this module's line ~418 warns about
+      # ("error_kind/1, never inspect(reason)"): they can embed a wrapped DEK or
+      # a provider response body. A `detail` key shipped here once; nothing
+      # stopped a handler from `inspect`ing it into a log.
+      ref =
+        push(socket, "crdt_create", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Notes/d.md",
+          "b64" => "!!!not base64!!!"
+        })
+
+      assert_reply ref, :ok, %{seeded: false}
+      assert_receive {:genesis_seed, meta, _}
+      assert Map.keys(meta) == [:reason]
+      assert is_atom(meta.reason)
+    end
+  end
+
   describe "crdt_create with b64 (detached genesis seed)" do
     test "persists the body and creates NO room", %{socket: socket, user: user, vault: vault} do
       id = Ecto.UUID.generate()


### PR DESCRIPTION
Supersedes #1449, #1453 and #1454 (all closed in favour of this one).

Pairs with plugin PR engram-app/Engram-obsidian#464, which carries the actual client fix. This PR is the backend half: the telemetry that made the bug attributable, the e2e fence that reproduces it, and one independent server bug found along the way.

## The defect

A real vault synced into a fresh server vault and **every note was stored twice** — server bytes exactly 2x the file on disk. Disk was never wrong. 224 of 316 notes held two Yjs clients, each with a full copy.

Root cause is client-side (#464): `applyFrontmatterInto` replaced the frontmatter ORDER array unconditionally, so re-seeding identical content still minted ops — which makes the writing device a *new client* on the doc, i.e. a second lineage. It fires on a first sync because the engine's own write-back reformats YAML, Obsidian reports that as a real edit, and `handleModify` deliberately skips its echo guard for CRDT notes.

## Why it stayed invisible

Three properties, each of which shaped the tests:

- **Opening a note healed it.** One file went 67,630 → 33,833 bytes the moment it was viewed in the web app. Anything a human inspects has already converged.
- **The copies don't always concatenate.** Where they interleaved, text was still 2x but not a clean `X+X` — a "first half == second half" check reported 17 of 60 doubled when the truth was 224 of 316.
- **Every summary signal read healthy.** Note count, room count and seed outcomes all matched. Only the doc *structure* was wrong.

So the assertion is structural — count Yjs clients, read from the server, never from a client that could have healed it.

## Contents

| commit | what |
|---|---|
| `f3714f1a` | test_77 bounds room allocation on a bulk first sync |
| `b659479a` | `genesis_seed` telemetry — why a body was not seeded roomlessly |
| `b285d0d8` | e2e lineage fence: `test_97`/`98`/`100` + `lineage_probe`/`seed_probe` |
| `fa1fa669` | context doc, including the failed approaches |
| `5ce1ce89` | **independent bug:** `note_links` insert exceeded Postgres' 65535 bind-parameter cap |

`test_100` is the reproduction: **7 of 11 notes doubled with 7 edit-class rooms** against the unfixed plugin, **0 and 0** with it.

### The independent one (`5ce1ce89`)

Unrelated to the doubling, found while reading logs during the investigation. `replace_links/4` built one `insert_all` for every edge; a note with ~8,576 wikilinks asked for 145,792 parameters. Postgrex answers that by **killing the connection**, not by returning an error — so one oversized note cost a pooled connection (of 10) on every extraction, and 41 jobs had already discarded. Now chunked at 2000 rows. Happy to split this back out if you'd rather review it alone.

## Two traps worth review attention

- **`seed_probe` exists because zero is ambiguous.** `test_97` measured zero rooms — the number reported both when the roomless path works perfectly *and* when the notes never touched the CRDT create path at all. Only a seed count separates them.
- **`test_98` restores `settings.vaultId` in a `finally`.** `obsidian_a` is session-scoped; a plugin left pointing at a throwaway vault silently redirects every later test in the worker. That surfaced as `test_100` reporting "landed 0/11" with no hint why.
- **`CONVERGE_BOUND_S = 90`, under `pytest.ini`'s 180s.** Equal to it, the loop can never reach its own assertion — pytest-timeout kills the test first and reports a generic timeout.

## Verification

`format` + `credo --strict` + `dialyzer` clean. `links_test` + `crdt_channel_test`: 122 pass. Full local CRDT e2e down to the 4 documented headless-Chromium `Locator.click` failures that fail on this box regardless of the change.

Refs #1409