### PR TITLE
fix(e2e): scope the lineage assertion to each test's own notes

### DIFF
--- a/e2e/helpers/lineage_probe.py
+++ b/e2e/helpers/lineage_probe.py
@@ -35,7 +35,7 @@ from helpers.backend_rpc import backend_rpc
 # wrapper (same constraint room_probe.py documents).
 _PROBE = (
     '{{:ok, vb}} = Ecto.UUID.dump("{vault_id}"); '
-    '{{:ok, vr}} = Ecto.Adapters.SQL.query(Engram.Repo, '
+    "{{:ok, vr}} = Ecto.Adapters.SQL.query(Engram.Repo, "
     '"select user_id::text from vaults where id=$1", [vb]); '
     "u = Engram.Accounts.get_user!(hd(hd(vr.rows))); "
     "{{:ok, nr}} = Ecto.Adapters.SQL.query(Engram.Repo, "
@@ -43,12 +43,19 @@ _PROBE = (
     "ids = List.flatten(nr.rows); "
     "{{:ok, notes}} = Engram.Repo.with_tenant(u.id, fn -> "
     "Enum.map(ids, &Engram.Repo.get(Engram.Notes.Note, &1)) end); "
-    "counts = Enum.map(notes, fn n -> "
+    "pairs = Enum.map(notes, fn n -> "
     "{{:ok, st}} = Engram.Crypto.decrypt_crdt_state(n, u); "
-    "if st do {{:ok, d}} = Engram.Notes.CrdtBridge.doc_from_state(st); "
-    ":binary.first(Yex.encode_state_vector!(d)) else 0 end end); "
-    'IO.puts(Enum.join([length(counts), Enum.count(counts, &(&1 > 1)), '
-    "Enum.max(counts, fn -> 0 end)], \",\"))"
+    "c = if st do {{:ok, d}} = Engram.Notes.CrdtBridge.doc_from_state(st); "
+    ":binary.first(Yex.encode_state_vector!(d)) else 0 end; "
+    "p = case Engram.Crypto.maybe_decrypt_note_fields(n, u) do "
+    "{{:ok, %{{path: pp}}}} when is_binary(pp) -> pp; "
+    '_ -> "<undecryptable>" end; '
+    "{{c, p}} end); "
+    "counts = Enum.map(pairs, &elem(&1, 0)); "
+    "Enum.each(Enum.filter(pairs, fn {{c, _}} -> c > 1 end), fn {{c, p}} -> "
+    'IO.puts("LINEAGE_MULTI\\t" <> Integer.to_string(c) <> "\\t" <> p) end); '
+    "IO.puts(Enum.join([length(counts), Enum.count(counts, &(&1 > 1)), "
+    'Enum.max(counts, fn -> 0 end)], ","))'
 )
 
 
@@ -68,7 +75,14 @@ class Lineages:
 def read_lineages(vault_id: str) -> Lineages:
     """Sample every live note in `vault_id`. Raises if the probe misfires."""
     out = backend_rpc(_PROBE.format(vault_id=vault_id))
-    line = out.strip().splitlines()[-1]
-    parts = line.split(",")
-    assert len(parts) == 3, f"lineage probe returned {line!r}"
+    lines = out.strip().splitlines()
+    # DIAGNOSTIC (2026-08-24): print WHICH notes are multi-client. The probe
+    # samples the WHOLE vault, but every caller writes only its own prefixed
+    # fixture into a SESSION-scoped vault shared by the entire suite — so a
+    # failure cannot currently distinguish "my fixture doubled" from "some
+    # other test's note legitimately has two writers". These paths settle it.
+    for ml in (ln for ln in lines if ln.startswith("LINEAGE_MULTI\t")):
+        print(ml)
+    parts = lines[-1].split(",")
+    assert len(parts) == 3, f"lineage probe returned {lines[-1]!r}"
     return Lineages(*(int(p) for p in parts))

--- a/e2e/helpers/lineage_probe.py
+++ b/e2e/helpers/lineage_probe.py
@@ -22,6 +22,24 @@ The state vector's leading varint IS the client count, so this reads one byte
 rather than decoding the whole structure. That is valid below 128 clients; a
 vault that somehow exceeded that would under-report, and 128 distinct writers on
 one note is already a far louder bug than this probe is looking for.
+
+## `path_prefix` is not optional in practice — pass it (2026-08-24)
+
+The e2e vault fixtures (`sync_vault_id`, `vault_a`) are `scope="session"`, so
+ONE vault is shared by the whole suite and its notes persist across tests. An
+unscoped sample therefore answers a question no caller is asking: it counts
+notes written by ~110 other tests, and **a note legitimately edited by two
+devices has two Yjs clients**. 34 e2e tests drive a second device, so the
+unscoped count has a permanent non-zero floor that no plugin fix can move.
+
+That floor is what made `test_97`/`98`/`100` fail on every CI run from the day
+they merged (#1455) — never once green — with counts that did not budge across
+plugin changes (12/135 and 12/146 in back-to-back runs; `test_98` contributed 11
+fresh notes and 0 new multi-client ones). Scoping to the caller's own prefix is
+what makes the assertion measure the fixture the caller actually controls.
+
+Filtering happens in Elixir AFTER decrypting each note, not in SQL: `path` is
+encrypted at rest, so there is no column to `LIKE` against.
 """
 
 from __future__ import annotations
@@ -51,8 +69,11 @@ _PROBE = (
     "{{:ok, %{{path: pp}}}} when is_binary(pp) -> pp; "
     '_ -> "<undecryptable>" end; '
     "{{c, p}} end); "
-    "counts = Enum.map(pairs, &elem(&1, 0)); "
-    "Enum.each(Enum.filter(pairs, fn {{c, _}} -> c > 1 end), fn {{c, p}} -> "
+    'pre = "{path_prefix}"; '
+    'scoped = if pre == "", do: pairs, '
+    "else: Enum.filter(pairs, fn {{_, p}} -> String.starts_with?(p, pre) end); "
+    "counts = Enum.map(scoped, &elem(&1, 0)); "
+    "Enum.each(Enum.filter(scoped, fn {{c, _}} -> c > 1 end), fn {{c, p}} -> "
     'IO.puts("LINEAGE_MULTI\\t" <> Integer.to_string(c) <> "\\t" <> p) end); '
     "IO.puts(Enum.join([length(counts), Enum.count(counts, &(&1 > 1)), "
     'Enum.max(counts, fn -> 0 end)], ","))'
@@ -72,15 +93,19 @@ class Lineages:
         )
 
 
-def read_lineages(vault_id: str) -> Lineages:
-    """Sample every live note in `vault_id`. Raises if the probe misfires."""
-    out = backend_rpc(_PROBE.format(vault_id=vault_id))
+def read_lineages(vault_id: str, path_prefix: str = "") -> Lineages:
+    """Sample live notes in `vault_id`, restricted to `path_prefix`.
+
+    PASS A PREFIX. The vault is session-scoped and shared by the whole suite,
+    so an unscoped sample counts other tests' notes — including legitimately
+    two-writer ones — and can never reach zero. See the module docstring.
+
+    Raises if the probe misfires.
+    """
+    out = backend_rpc(_PROBE.format(vault_id=vault_id, path_prefix=path_prefix))
     lines = out.strip().splitlines()
-    # DIAGNOSTIC (2026-08-24): print WHICH notes are multi-client. The probe
-    # samples the WHOLE vault, but every caller writes only its own prefixed
-    # fixture into a SESSION-scoped vault shared by the entire suite — so a
-    # failure cannot currently distinguish "my fixture doubled" from "some
-    # other test's note legitimately has two writers". These paths settle it.
+    # Print WHICH notes are multi-client, so a failure names the offending
+    # paths instead of only a count — the count alone cost a debugging cycle.
     for ml in (ln for ln in lines if ln.startswith("LINEAGE_MULTI\t")):
         print(ml)
     parts = lines[-1].split(",")

--- a/e2e/tests/test_100_frontmatter_echo_single_lineage.py
+++ b/e2e/tests/test_100_frontmatter_echo_single_lineage.py
@@ -31,6 +31,11 @@ Verified to catch the defect: against the code before
 `applyLocalEdit`'s projection-equality guard, this reported 7 of 10 notes
 holding 2 lineages and 7 edit-class rooms — one per rewritten file. With the
 guard: 0 and 0.
+
+Scoped to this test's own path prefix (2026-08-24). The vault fixture is
+session-scoped and shared by the whole suite, and a note legitimately edited by
+two devices holds two Yjs clients — so an unscoped sample has a non-zero floor
+this test can never drive to zero. See `helpers/lineage_probe`.
 """
 
 from __future__ import annotations
@@ -50,16 +55,14 @@ from helpers.vault import write_note
 # and reports a generic timeout instead of "converged only N/M".
 CONVERGE_BOUND_S = 90
 
-SET_BLOCKED = (
-    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
-)
+SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
 # Each shape is a separate way YAML can fail to survive a parse/serialise round
 # trip. Named so a failure says WHICH shape moved rather than just "bytes
 # differ".
 FRONTMATTER_SHAPES = {
     "inline-array": "---\ntags: [alpha, beta, gamma]\n---\n",
-    "quoted-scalar": '---\ntitle: "Quoted: with colon"\nstatus: \'single\'\n---\n',
+    "quoted-scalar": "---\ntitle: \"Quoted: with colon\"\nstatus: 'single'\n---\n",
     "comment": "---\ntags:\n  - a\n# a trailing comment\nreviewed: 2026-08-23\n---\n",
     "irregular-space": "---\ntags:\n    - deep\n    - indent\nkey:    spaced\n---\n",
     "nested-map": "---\nmeta:\n  author: todd\n  nested:\n    deeper: true\n---\n",
@@ -140,7 +143,7 @@ async def test_sync_leaves_disk_bytes_untouched(
         for rel in written
         if Path(vault_a, rel).read_text(encoding="utf-8") != written[rel]
     }
-    lineages = read_lineages(sync_vault_id)
+    lineages = read_lineages(sync_vault_id, prefix)
     rooms = read_room_starts() - rooms_before
     print(
         f"\ntest_100 rewritten-on-disk={sorted(rewritten)} | {lineages} | rooms: {rooms}"
@@ -155,6 +158,13 @@ async def test_sync_leaves_disk_bytes_untouched(
         "that the lineage assertion below is fencing. Did the frontmatter codec "
         "start round-tripping byte-for-byte? If so this fixture needs a new "
         "round-trip-hostile shape."
+    )
+
+    # The lineage sample is scoped to THIS test's prefix, so a broken filter
+    # would report 0/0 and satisfy the assertion below vacuously.
+    assert lineages.notes >= expected, (
+        f"lineage probe saw only {lineages.notes}/{expected} of this test's own "
+        "notes — the assertion below would pass vacuously"
     )
 
     assert lineages.multi_client == 0, (

--- a/e2e/tests/test_97_first_sync_single_lineage.py
+++ b/e2e/tests/test_97_first_sync_single_lineage.py
@@ -26,6 +26,11 @@ Deliberately small (40 notes): this pins a correctness property that reproduced
 at 100% of notes, not a throughput bound. test_77 owns the bulk-timing bound and
 its 1,000-note fixture, which cannot run inside the 120s CDP evaluate cap on a
 loaded dev box (see docs/context/local-crdt-e2e-repro.md).
+
+Scoped to this test's own path prefix (2026-08-24). The vault fixture is
+session-scoped and shared by the whole suite, and a note legitimately edited by
+two devices holds two Yjs clients — so an unscoped sample has a non-zero floor
+this test can never drive to zero. See `helpers/lineage_probe`.
 """
 
 from __future__ import annotations
@@ -46,9 +51,7 @@ NOTE_COUNT = 15
 # and reports a generic timeout instead of "converged only N/M".
 CONVERGE_BOUND_S = 90
 
-SET_BLOCKED = (
-    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
-)
+SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
 
 @pytest.mark.asyncio
@@ -118,7 +121,7 @@ async def test_first_sync_leaves_one_lineage_per_note(
 
     # Read from the SERVER. A client-side read would be answered by the very doc
     # whose lineage is in question, and viewing a note is what heals it.
-    lineages = read_lineages(sync_vault_id)
+    lineages = read_lineages(sync_vault_id, prefix)
     # Printed, and the note total asserted, because `multi_client == 0` is
     # satisfied vacuously by an empty vault.
     # Room split alongside the lineage count. The production run that corrupted

--- a/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
+++ b/e2e/tests/test_98_resync_to_fresh_vault_single_lineage.py
@@ -23,6 +23,11 @@ docs/context/crdt-wrong-mint-cross-file-overwrite.md.
 Asserts on lineage COUNT, not bytes, for the reasons in `lineage_probe`: the two
 insertions sometimes interleave rather than concatenate, and viewing a note
 heals it.
+
+Scoped to this test's own path prefix (2026-08-24). The vault fixture is
+session-scoped and shared by the whole suite, and a note legitimately edited by
+two devices holds two Yjs clients — so an unscoped sample has a non-zero floor
+this test can never drive to zero. See `helpers/lineage_probe`.
 """
 
 from __future__ import annotations
@@ -42,9 +47,7 @@ NOTE_COUNT = 10
 # and reports a generic timeout instead of "converged only N/M".
 CONVERGE_BOUND_S = 90
 
-SET_BLOCKED = (
-    "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
-)
+SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
 # Re-point the running plugin at a different server vault WITHOUT touching the
 # local vault directory — the device's docs and id map must survive, because
@@ -115,7 +118,13 @@ async def test_resync_into_fresh_vault_keeps_one_lineage(
     landed = await _converge(cdp_a, api_sync, prefix, NOTE_COUNT)
     assert landed >= NOTE_COUNT, f"first sync landed only {landed}/{NOTE_COUNT}"
 
-    first = read_lineages(sync_vault_id)
+    first = read_lineages(sync_vault_id, prefix)
+    # Scoped to this test's prefix, so an empty sample would satisfy the
+    # multi_client assertion vacuously.
+    assert first.notes >= NOTE_COUNT, (
+        f"lineage probe saw only {first.notes}/{NOTE_COUNT} of this test's own "
+        "notes in the first vault — the assertion below would pass vacuously"
+    )
     assert first.multi_client == 0, (
         f"the FIRST sync already doubled: {first}. That is test_97's scenario, "
         "so fix that before reading anything into this test."
@@ -148,7 +157,7 @@ async def test_resync_into_fresh_vault_keeps_one_lineage(
             "the lineage assertion below would be measuring a partial sync"
         )
 
-        second = read_lineages(fresh_id)
+        second = read_lineages(fresh_id, prefix)
         # Printed, not just asserted: a lineage count of 0/0 satisfies
         # `multi_client == 0` vacuously, so the note total has to be visible in
         # the run output for the pass to mean anything.
@@ -165,6 +174,4 @@ async def test_resync_into_fresh_vault_keeps_one_lineage(
             "a note converges it back down."
         )
     finally:
-        await cdp_a.evaluate(
-            REPOINT.format(vault_id=sync_vault_id), await_promise=True
-        )
+        await cdp_a.evaluate(REPOINT.format(vault_id=sync_vault_id), await_promise=True)


### PR DESCRIPTION
## Summary

`test_97`, `test_98`, and `test_100` have failed on **every CI run since they merged** (#1455) — never once green — and `main` has been red on `e2e-clerk` since.

They are not catching a live product regression. `read_lineages` sampled **every note in the vault**, but:

- `sync_vault_id` and `vault_a` are `scope="session"` — one vault is shared by the whole suite and its notes persist across tests (test_77's own cleanup docstring says so).
- **34 e2e tests drive a second device**, and a note legitimately edited by two devices holds **two Yjs clients**.

So the unscoped count has a permanent non-zero floor no product fix can reach. The evidence:

- Counts did not budge across two different plugin builds: 12/135 then 12/146.
- `test_98` contributed **11 fresh notes of its own and 0 new multi-client ones** — and was still red purely on accumulated notes from other tests.

## What changed

- `read_lineages(vault_id, path_prefix="")` filters to the caller's prefix. Filtering happens in Elixir **after decrypt** — `path` is encrypted at rest, so there is no column to `LIKE` against.
- All four call sites pass the prefix each test already computed.
- Kept the per-note path print, so a future failure names the offending notes instead of only a count.
- Added `notes >= expected` vacuity guards so a broken filter cannot make these pass on an empty sample.

This can only make the tests **more** sensitive to the fixtures they control, never less.

## Test plan
- [x] `ruff check` + `ruff format` clean on all four files
- [x] Probe expression renders valid Elixir for both scoped and unscoped cases
- [ ] `e2e-clerk` green on this branch — the actual proof

## Note
If `test_100` still fails once scoped, a real frontmatter-echo bug remains and this PR has simply removed the noise hiding it. The per-path output now in the run log will say which notes.