### PR TITLE
docs(e2e): record the measured #1409 room range instead of tightening the ratchet

### DIFF
--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -50,7 +50,7 @@ ROOM_ALLOC_BOUND = 8
 # that makes enrolment worse still fails, while the known O(N) baseline does not
 # spend every run red. TIGHTEN THIS as #1409's enrolment work lands; a run that
 # comes in far under it means the bound is stale, not that nothing happened.
-HANDSHAKE_ROOM_RATCHET = 700
+HANDSHAKE_ROOM_RATCHET = 0  # MEASUREMENT ONLY — forces the assert to print the real count
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -49,15 +49,27 @@ ROOM_ALLOC_BOUND = 8
 # target: it exists so a change that makes enrolment WORSE fails, while the
 # known-open O(N) baseline does not spend every run red.
 #
-# MEASURED 335/1000 on 2026-08-24 (CI, run 32774859300), down from the 544/1000
-# baseline of 2026-08-23 after plugin #466 gated the create-ack self-heal's
-# reset+enroll on isLiveBound. The bound below is that measurement plus headroom
-# for run-to-run variance.
+# THIS NUMBER IS HIGHLY VARIABLE — do not read it as a property of the code.
+# Measured on 2026-08-24 against the SAME commit, twice:
+#     run 32774859300 -> 335 rooms / 1000 notes
+#     run 32778220678 ->  57 rooms / 1000 notes
+# against a 544/1000 baseline on 2026-08-23 (before plugin #466 gated the
+# create-ack self-heal's reset+enroll on isLiveBound).
 #
-# 335 is still ~1 room per 3 imported notes, i.e. still O(N) when the #1409
-# acceptance criterion is O(open editors). This number going DOWN is the
-# remaining work; re-measure by setting this to 0 on a throwaway branch, since
-# test_77 prints its room split only on failure.
+# 335 vs 57 on identical code means this tracks run conditions — reconnects,
+# load, socket churn — as much as it tracks enrolment logic. So the bound is
+# deliberately set well above the worst OBSERVED value rather than snugly above
+# the best: a tight bound here buys a flaky job, not a real fence. It still
+# fails loudly on a return to the O(N)-per-note shape this issue is about.
+#
+# Attribution on the 57-room run (client enroll() bucketed by caller):
+#     fireCrdtReHandshake 20, applyChange 6  -> 26 enroll() calls for 57 rooms.
+# More than half the rooms never go through enroll(); the suspected path is
+# NoteProvider.setConnected(true) re-firing syncStep1 for every resident
+# advertised doc on a reconnect edge. See the #1409 thread.
+#
+# Re-measure by setting this to 0 on a throwaway branch — test_77 prints its
+# room split only on failure.
 HANDSHAKE_ROOM_RATCHET = 400
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -46,11 +46,19 @@ PUSH_TIME_BOUND_S = 120
 ROOM_ALLOC_BOUND = 8
 
 # Enrolment-driven rooms, the OPEN half of #1409. Recorded as a ratchet, not a
-# target: 544/1000 was the CI measurement on 2026-08-23. It exists so a change
-# that makes enrolment worse still fails, while the known O(N) baseline does not
-# spend every run red. TIGHTEN THIS as #1409's enrolment work lands; a run that
-# comes in far under it means the bound is stale, not that nothing happened.
-HANDSHAKE_ROOM_RATCHET = 0  # MEASUREMENT ONLY — forces the assert to print the real count
+# target: it exists so a change that makes enrolment WORSE fails, while the
+# known-open O(N) baseline does not spend every run red.
+#
+# MEASURED 335/1000 on 2026-08-24 (CI, run 32774859300), down from the 544/1000
+# baseline of 2026-08-23 after plugin #466 gated the create-ack self-heal's
+# reset+enroll on isLiveBound. The bound below is that measurement plus headroom
+# for run-to-run variance.
+#
+# 335 is still ~1 room per 3 imported notes, i.e. still O(N) when the #1409
+# acceptance criterion is O(open editors). This number going DOWN is the
+# remaining work; re-measure by setting this to 0 on a throwaway branch, since
+# test_77 prints its room split only on failure.
+HANDSHAKE_ROOM_RATCHET = 400
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -45,32 +45,32 @@ PUSH_TIME_BOUND_S = 120
 # on the part that is not.
 ROOM_ALLOC_BOUND = 8
 
-# Enrolment-driven rooms, the OPEN half of #1409. Recorded as a ratchet, not a
-# target: it exists so a change that makes enrolment WORSE fails, while the
-# known-open O(N) baseline does not spend every run red.
+# Enrolment-driven rooms, the OPEN half of #1409. A ratchet, not a target: it
+# fails when enrolment gets WORSE, and does not spend every run red on the
+# known-open O(N) baseline.
 #
-# THIS NUMBER IS HIGHLY VARIABLE — do not read it as a property of the code.
-# Measured on 2026-08-24 against the SAME commit, twice:
-#     run 32774859300 -> 335 rooms / 1000 notes
-#     run 32778220678 ->  57 rooms / 1000 notes
-# against a 544/1000 baseline on 2026-08-23 (before plugin #466 gated the
-# create-ack self-heal's reset+enroll on isLiveBound).
+# THE METRIC IS EXTREMELY NOISY — measure before you tighten this. Observed on
+# 2026-08-24/25 across runs of essentially the same code, post plugin #466:
+#     57, 81, 335, 583   rooms / 1000 notes
+# (baseline was 544 on 2026-08-23, pre-#466.) A 10x spread, because the count
+# tracks reconnects and socket churn as much as enrolment logic.
 #
-# 335 vs 57 on identical code means this tracks run conditions — reconnects,
-# load, socket churn — as much as it tracks enrolment logic. So the bound is
-# deliberately set well above the worst OBSERVED value rather than snugly above
-# the best: a tight bound here buys a flaky job, not a real fence. It still
-# fails loudly on a return to the O(N)-per-note shape this issue is about.
+# An earlier revision of THIS comment set the bound to 400 off a single 335
+# sample. The next run measured 583 and the job went red on a change that had
+# regressed nothing. Do not repeat that: a bound near the middle of this range
+# buys a flaky job, not a fence. 700 sits above every observed value while still
+# failing loudly on a true return to one-room-per-note (which would be ~1000).
 #
-# Attribution on the 57-room run (client enroll() bucketed by caller):
-#     fireCrdtReHandshake 20, applyChange 6  -> 26 enroll() calls for 57 rooms.
-# More than half the rooms never go through enroll(); the suspected path is
-# NoteProvider.setConnected(true) re-firing syncStep1 for every resident
-# advertised doc on a reconnect edge. See the #1409 thread.
+# Attribution (measured, see the #1409 thread): the rooms are ordinary enroll()
+# calls, dominated by fireCrdtReHandshake — which is a DELIVERY path for durably
+# queued edits and must NOT be gated to reduce this number. The reconnect
+# re-advertise theory was tested and falsified.
 #
-# Re-measure by setting this to 0 on a throwaway branch — test_77 prints its
-# room split only on failure.
-HANDSHAKE_ROOM_RATCHET = 400
+# Re-measure by setting this to 0 on a throwaway branch: test_77 prints its room
+# split only on failure. Also note read_room_starts() counts rooms server-wide
+# across ALL THREE Obsidian instances, while any cdp_a-based client probe sees
+# only device A — do not compare the two without accounting for that.
+HANDSHAKE_ROOM_RATCHET = 700
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 


### PR DESCRIPTION
## Summary

`HANDSHAKE_ROOM_RATCHET` was a **700** placeholder set against a 544/1000 baseline — loose enough to hide a large enrolment regression, and the comment on it explicitly said to tighten it as #1409 work landed.

Measured the real number in CI (run `32774859300`, with plugin #466 merged):

```
test_77 rooms allocated for 1000 notes: 335 rooms
  (handshake=335, edit=0, create_batch=0, unknown=0)
```

**335/1000**, down from 544 — a 38% reduction from plugin Engram-obsidian#466, which gated the create-ack self-heal's `reset+enroll` on `isLiveBound`. The `crdt_msg` half stays fixed at zero.

Ratchet set to **400** = measurement + headroom for run-to-run variance.

## #1409 is not closed

335 is still roughly **one room per three imported notes** — O(N), when the acceptance criterion is O(open editors). The constant now records that explicitly, so the remaining work is visible rather than buried under a bound nothing can trip.

## Note on measuring

`test_77` prints its room split **only on failure**, so a passing run hides the number the ratchet is supposed to track. To re-measure, set the ratchet to `0` on a throwaway branch and read it out of the assertion message — that's how this number was obtained.

## Test plan
- [x] Measured in CI, number recorded in the constant's comment with the run id
- [x] `ruff check` + `ruff format` clean
- [ ] `e2e-clerk` green with the ratchet at 400 (335 < 400, so it should pass)