### PR TITLE
test(e2e): bound PEAK CONCURRENT rooms during a bulk import

### DIFF
--- a/e2e/helpers/residency_probe.py
+++ b/e2e/helpers/residency_probe.py
@@ -1,0 +1,41 @@
+"""Sample CRDT room RESIDENCY — how many rooms are alive at one instant.
+
+The companion to `room_probe`, which counts rooms ALLOCATED. Those two answer
+different questions, and since the idle drain shipped they can differ by orders
+of magnitude:
+
+  * ALLOCATION is the #1409 acceptance claim ("an import must not open a room
+    per note"). It is cumulative and cannot be missed by sampling.
+  * RESIDENCY is what actually costs memory. `CrdtCheckpointTimer`'s idle drain
+    defaults ON (300s) in every environment as of 2026-08-18, and `ci/compose.yml`
+    shortens it further, so an allocated room is released long before a test ends.
+
+`room_probe`'s docstring rightly warns that a SINGLE residency sample taken
+after the fact proves nothing — a room-per-note burst comes and goes between two
+samples. This module exists to be polled CONTINUOUSLY across the window instead,
+so the caller can keep a running PEAK. A peak sampled every second across the
+whole import cannot be dodged by a burst the way one trailing sample can.
+
+Counts children of `Engram.Notes.CrdtDocSupervisor` (the same enumeration
+`DataCase.stop_crdt_rooms/0` uses). Node-local: rooms are `:global`, so on a
+multi-node cluster this undercounts. CI is single-node, which is the only place
+this runs.
+"""
+
+from __future__ import annotations
+
+from helpers.backend_rpc import backend_rpc
+
+# ONE logical Elixir line — `bin/engram rpc` takes the expression as a single
+# argv (same constraint room_probe.py documents).
+_PROBE = (
+    "IO.puts(length(DynamicSupervisor.which_children(Engram.Notes.CrdtDocSupervisor)))"
+)
+
+
+def read_resident_rooms() -> int:
+    """Rooms alive on the backend node RIGHT NOW. Raises if the probe misfires."""
+    out = backend_rpc(_PROBE)
+    line = out.strip().splitlines()[-1]
+    assert line.isdigit(), f"residency probe returned {line!r}"
+    return int(line)

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -20,6 +20,7 @@ import time
 
 import pytest
 
+from helpers.residency_probe import read_resident_rooms
 from helpers.room_probe import arm_room_starts, read_room_starts
 from helpers.vault import write_note
 
@@ -51,6 +52,25 @@ ROOM_ALLOC_BOUND = 8
 # spend every run red. TIGHTEN THIS as #1409's enrolment work lands; a run that
 # comes in far under it means the bound is stale, not that nothing happened.
 HANDSHAKE_ROOM_RATCHET = 700
+
+# Peak CONCURRENT rooms during the import. This is the bound that maps to
+# MEMORY, and it is the one #1409's incident was actually about: on 2026-08-18 a
+# 1.7k-file import left ~2000 rooms RESIDENT and took prod from 757 to 2744
+# processes.
+#
+# Unlike the allocation ratchet above (10x run-to-run spread), residency is
+# tight and stable: MEASURED 4 for 1000 notes on 2026-08-24, twice — once with
+# CI's 5s idle drain and once with the drain set to prod's 300s. It did not move,
+# because a note room exits on `auto_exit` when its last OBSERVER leaves, not on
+# the idle timer; the timer is a backstop for the per-vault index room, which is
+# observed for a whole session. Enrolment being gated to live-bound notes is what
+# lets observers leave promptly.
+#
+# 32 is ~8x the observed peak: a real regression to one-resident-room-per-note
+# would blow past it by two orders of magnitude, while normal churn stays far
+# under. If this ever fails, check whether something started enrolling idle notes
+# again — that is exactly the 2026-08-18 shape.
+PEAK_RESIDENT_ROOM_BOUND = 32
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
@@ -153,9 +173,14 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
         started = time.monotonic()
         deadline = started + PUSH_TIME_BOUND_S
         bulk_count = 0
+        # Sampled on EVERY pass, not once at the end: room_probe's docstring is
+        # right that a single trailing sample cannot see a burst come and go.
+        # A running peak across the whole import cannot be dodged that way.
+        peak_resident = read_resident_rooms()
         while time.monotonic() < deadline:
             await cdp_a.evaluate(SET_BLOCKED.format("false"))
             await cdp_a.trigger_full_sync()
+            peak_resident = max(peak_resident, read_resident_rooms())
             manifest = api_sync.get_manifest()
             bulk_count = sum(
                 1 for n in manifest["notes"] if n["path"].startswith("Bulk/")
@@ -163,6 +188,7 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
             if bulk_count >= NOTE_COUNT:
                 break
             time.sleep(2)
+            peak_resident = max(peak_resident, read_resident_rooms())
         elapsed = time.monotonic() - started
 
         assert bulk_count >= NOTE_COUNT, (
@@ -174,6 +200,7 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
         # Read AFTER convergence: a room allocated by the tail of the sync must
         # be counted, and the drain means residency would already have shed it.
         rooms = read_room_starts() - rooms_before
+        print(f"\ntest_77 peak resident rooms: {peak_resident}")
         print(f"\ntest_77 rooms allocated for {NOTE_COUNT} notes: {rooms}")
         cold_rooms = rooms.edit + rooms.create_batch + rooms.unknown
         assert cold_rooms <= ROOM_ALLOC_BOUND, (
@@ -182,6 +209,13 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
             "are for notes open in an editor, not for imported files). The "
             "per-source split names the path that regressed; `unknown` means an "
             "allocation site shipped without a source tag."
+        )
+        assert peak_resident <= PEAK_RESIDENT_ROOM_BOUND, (
+            f"peak {peak_resident} CONCURRENT rooms during the import, past the "
+            f"{PEAK_RESIDENT_ROOM_BOUND} bound. This is the memory-shaped half of "
+            "#1409 (2026-08-18: ~2000 resident rooms, 757 -> 2744 processes). A "
+            "note room exits on auto_exit when its last observer leaves, so a "
+            "climb here means something is enrolling — and holding — idle notes."
         )
         assert rooms.handshake <= HANDSHAKE_ROOM_RATCHET, (
             f"enrolment opened {rooms.handshake} handshake rooms for "


### PR DESCRIPTION
## The gap this closes

#1409's incident was a **memory** event: a 1.7k-file import left ~2000 rooms **resident** and took prod from 757 to 2744 processes. `test_77` only bounded **allocation** — and since the idle drain shipped, allocation no longer implies memory.

Worse, allocation turned out to be unusable as a fence. Measured across runs of essentially the same code:

```
57, 81, 335, 583   rooms / 1000 notes
```

A 10x spread (it tracks reconnects and socket churn). I tried tightening the ratchet to 400 off one sample; the next run hit 583 and went red on a change that regressed nothing. See #1461.

## Residency is the number that matters, and it's stable

```
PEAK RESIDENT rooms during import: 4     (1000 notes)
```

Measured **twice** — once at CI's 5s idle drain, once with the drain set to prod's **300s**. It did not move.

That is not luck. A note room exits on **`auto_exit`, when its last observer leaves** — not on the idle timer. The timer is a backstop for the per-vault *index* room, which is observed for a whole session. Enrolment being gated to live-bound notes (#1424, plugin #466) is what lets observers leave promptly, and *that* — not the drain — is what actually resolved the 2026-08-18 shape.

I nearly reported the first `4` as proof the drain obsoleted #1409. It wasn't: CI drains 60x faster than prod, so that number had to be re-measured at the prod window before it meant anything.

## What's added

- `e2e/helpers/residency_probe.py` — counts live children of `CrdtDocSupervisor`. Sampled on **every pass** of the convergence loop, never once at the end: `room_probe`'s docstring is right that a single trailing sample cannot see a burst come and go.
- `PEAK_RESIDENT_ROOM_BOUND = 32` — ~8x the observed peak. A regression to one resident room per note misses by two orders of magnitude; normal churn stays far under.

The allocation ratchet stays at 700 and is unchanged here.

## Test plan
- [x] Measured 4/1000 at both the CI and prod drain windows
- [x] `ruff check` + `ruff format` clean
- [ ] `e2e-clerk` green with the new assertion