### PR TITLE
test(e2e): bound peak room residency; record the room-metric evidence

### DIFF
--- a/docs/context/crdt-room-lifetime-and-drain.md
+++ b/docs/context/crdt-room-lifetime-and-drain.md
@@ -1,6 +1,26 @@
 # CRDT room lifetime — why `auto_exit` is not enough, and why an idle room is DRAINED, not stopped
 
-_Last verified: 2026-08-15_
+_Last verified: 2026-08-15. **SUPERSEDED IN PART 2026-08-18/23, see update below — do not trust
+this doc's "prod today" claims below without reading the update first.**_
+
+> **Update 2026-08-24:** the "Only drain-ENABLED rooms are tracked... prod today, where nothing
+> sets `idle_exit_ms`" claim below (and the identical claim in "Constraints this puts on #1150")
+> is **no longer true**. PR #1413 (`perf(sync): fix the CPU + room-residency causes of the
+> bulk-upload incident`, merged 2026-08-18, same day as the 757→2744-process incident this doc
+> already describes) flipped `CrdtCheckpointTimer`'s `idle_exit_ms` default from `nil` (opt-in,
+> armed only in CI) to **`@default_idle_exit_ms` = 300_000 ms (5 min), ON by default in every
+> environment** — see the "Idle drain" section of that module's moduledoc, which now says
+> outright: *"It used to be opt-in and nil by default... A residency bound that defaults off is
+> unbound in exactly the fleets that need it most."* Deployed to prod via `release-v0.19.0`
+> (tag `4a3b8bfc`, engram-infra#1041, 2026-08-23T09:26 UTC) — confirmed live: prod
+> `engram_prom_ex_beam_stats_process_count` has held flat (~745-760 per task) for the following
+> day with no runaway growth, and `engram_prom_ex_crdt_room_drain_total` shows real drain activity
+> (~73 `requested` + ~35 `lru_evicted` per day against ~119/day `room_start{source="handshake"}` —
+> roughly balanced, not accumulating). Rooms DO now auto-close in prod. The mechanism described
+> below (drain-then-`auto_exit`, never a hard kill) is otherwise unchanged and still accurate —
+> only the "off by default in prod" framing is stale. `CRDT_IDLE_EXIT_MS` (`ci/compose.yml`) still
+> separately overrides the window for CI/e2e and is CI-gated (silent no-op in a real task
+> definition) — that part of this doc is still correct.
 
 **TL;DR:** A `SharedDoc` room only exits when its **last observer leaves** (`auto_exit`). That
 bounds a *note* room, which is observed only while the note is open. It does **not** bound a

--- a/e2e/helpers/residency_probe.py
+++ b/e2e/helpers/residency_probe.py
@@ -1,0 +1,41 @@
+"""Sample CRDT room RESIDENCY — how many rooms are alive at one instant.
+
+The companion to `room_probe`, which counts rooms ALLOCATED. Those two answer
+different questions, and since the idle drain shipped they can differ by orders
+of magnitude:
+
+  * ALLOCATION is the #1409 acceptance claim ("an import must not open a room
+    per note"). It is cumulative and cannot be missed by sampling.
+  * RESIDENCY is what actually costs memory. `CrdtCheckpointTimer`'s idle drain
+    defaults ON (300s) in every environment as of 2026-08-18, and `ci/compose.yml`
+    shortens it further, so an allocated room is released long before a test ends.
+
+`room_probe`'s docstring rightly warns that a SINGLE residency sample taken
+after the fact proves nothing — a room-per-note burst comes and goes between two
+samples. This module exists to be polled CONTINUOUSLY across the window instead,
+so the caller can keep a running PEAK. A peak sampled every second across the
+whole import cannot be dodged by a burst the way one trailing sample can.
+
+Counts children of `Engram.Notes.CrdtDocSupervisor` (the same enumeration
+`DataCase.stop_crdt_rooms/0` uses). Node-local: rooms are `:global`, so on a
+multi-node cluster this undercounts. CI is single-node, which is the only place
+this runs.
+"""
+
+from __future__ import annotations
+
+from helpers.backend_rpc import backend_rpc
+
+# ONE logical Elixir line — `bin/engram rpc` takes the expression as a single
+# argv (same constraint room_probe.py documents).
+_PROBE = (
+    "IO.puts(length(DynamicSupervisor.which_children(Engram.Notes.CrdtDocSupervisor)))"
+)
+
+
+def read_resident_rooms() -> int:
+    """Rooms alive on the backend node RIGHT NOW. Raises if the probe misfires."""
+    out = backend_rpc(_PROBE)
+    line = out.strip().splitlines()[-1]
+    assert line.isdigit(), f"residency probe returned {line!r}"
+    return int(line)

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -20,6 +20,7 @@ import time
 
 import pytest
 
+from helpers.residency_probe import read_resident_rooms
 from helpers.room_probe import arm_room_starts, read_room_starts
 from helpers.vault import write_note
 
@@ -45,12 +46,51 @@ PUSH_TIME_BOUND_S = 120
 # on the part that is not.
 ROOM_ALLOC_BOUND = 8
 
-# Enrolment-driven rooms, the OPEN half of #1409. Recorded as a ratchet, not a
-# target: 544/1000 was the CI measurement on 2026-08-23. It exists so a change
-# that makes enrolment worse still fails, while the known O(N) baseline does not
-# spend every run red. TIGHTEN THIS as #1409's enrolment work lands; a run that
-# comes in far under it means the bound is stale, not that nothing happened.
+# Enrolment-driven rooms, the OPEN half of #1409. A ratchet, not a target: it
+# fails when enrolment gets WORSE, and does not spend every run red on the
+# known-open O(N) baseline.
+#
+# THE METRIC IS EXTREMELY NOISY — measure before you tighten this. Observed on
+# 2026-08-24/25 across runs of essentially the same code, post plugin #466:
+#     57, 81, 335, 583   rooms / 1000 notes
+# (baseline was 544 on 2026-08-23, pre-#466.) A 10x spread, because the count
+# tracks reconnects and socket churn as much as enrolment logic.
+#
+# An earlier revision of THIS comment set the bound to 400 off a single 335
+# sample. The next run measured 583 and the job went red on a change that had
+# regressed nothing. Do not repeat that: a bound near the middle of this range
+# buys a flaky job, not a fence. 700 sits above every observed value while still
+# failing loudly on a true return to one-room-per-note (which would be ~1000).
+#
+# Attribution (measured, see the #1409 thread): the rooms are ordinary enroll()
+# calls, dominated by fireCrdtReHandshake — which is a DELIVERY path for durably
+# queued edits and must NOT be gated to reduce this number. The reconnect
+# re-advertise theory was tested and falsified.
+#
+# Re-measure by setting this to 0 on a throwaway branch: test_77 prints its room
+# split only on failure. Also note read_room_starts() counts rooms server-wide
+# across ALL THREE Obsidian instances, while any cdp_a-based client probe sees
+# only device A — do not compare the two without accounting for that.
 HANDSHAKE_ROOM_RATCHET = 700
+
+# Peak CONCURRENT rooms during the import. This is the bound that maps to
+# MEMORY, and it is the one #1409's incident was actually about: on 2026-08-18 a
+# 1.7k-file import left ~2000 rooms RESIDENT and took prod from 757 to 2744
+# processes.
+#
+# Unlike the allocation ratchet above (10x run-to-run spread), residency is
+# tight and stable: MEASURED 4 for 1000 notes on 2026-08-24, twice — once with
+# CI's 5s idle drain and once with the drain set to prod's 300s. It did not move,
+# because a note room exits on `auto_exit` when its last OBSERVER leaves, not on
+# the idle timer; the timer is a backstop for the per-vault index room, which is
+# observed for a whole session. Enrolment being gated to live-bound notes is what
+# lets observers leave promptly.
+#
+# 32 is ~8x the observed peak: a real regression to one-resident-room-per-note
+# would blow past it by two orders of magnitude, while normal churn stays far
+# under. If this ever fails, check whether something started enrolling idle notes
+# again — that is exactly the 2026-08-18 shape.
+PEAK_RESIDENT_ROOM_BOUND = 32
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
@@ -153,9 +193,14 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
         started = time.monotonic()
         deadline = started + PUSH_TIME_BOUND_S
         bulk_count = 0
+        # Sampled on EVERY pass, not once at the end: room_probe's docstring is
+        # right that a single trailing sample cannot see a burst come and go.
+        # A running peak across the whole import cannot be dodged that way.
+        peak_resident = read_resident_rooms()
         while time.monotonic() < deadline:
             await cdp_a.evaluate(SET_BLOCKED.format("false"))
             await cdp_a.trigger_full_sync()
+            peak_resident = max(peak_resident, read_resident_rooms())
             manifest = api_sync.get_manifest()
             bulk_count = sum(
                 1 for n in manifest["notes"] if n["path"].startswith("Bulk/")
@@ -163,6 +208,7 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
             if bulk_count >= NOTE_COUNT:
                 break
             time.sleep(2)
+            peak_resident = max(peak_resident, read_resident_rooms())
         elapsed = time.monotonic() - started
 
         assert bulk_count >= NOTE_COUNT, (
@@ -174,6 +220,7 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
         # Read AFTER convergence: a room allocated by the tail of the sync must
         # be counted, and the drain means residency would already have shed it.
         rooms = read_room_starts() - rooms_before
+        print(f"\ntest_77 peak resident rooms: {peak_resident}")
         print(f"\ntest_77 rooms allocated for {NOTE_COUNT} notes: {rooms}")
         cold_rooms = rooms.edit + rooms.create_batch + rooms.unknown
         assert cold_rooms <= ROOM_ALLOC_BOUND, (
@@ -182,6 +229,13 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
             "are for notes open in an editor, not for imported files). The "
             "per-source split names the path that regressed; `unknown` means an "
             "allocation site shipped without a source tag."
+        )
+        assert peak_resident <= PEAK_RESIDENT_ROOM_BOUND, (
+            f"peak {peak_resident} CONCURRENT rooms during the import, past the "
+            f"{PEAK_RESIDENT_ROOM_BOUND} bound. This is the memory-shaped half of "
+            "#1409 (2026-08-18: ~2000 resident rooms, 757 -> 2744 processes). A "
+            "note room exits on auto_exit when its last observer leaves, so a "
+            "climb here means something is enrolling — and holding — idle notes."
         )
         assert rooms.handshake <= HANDSHAKE_ROOM_RATCHET, (
             f"enrolment opened {rooms.handshake} handshake rooms for "


### PR DESCRIPTION
Combines **#1457 + #1461 + #1462** into one CI run — all three are backend test/docs-only and none ship code.

---

## 1. Bound PEAK CONCURRENT rooms (was #1462)

#1409's incident was a **memory** event: ~2000 rooms **resident**, prod 757 → 2744 processes. `test_77` only bounded **allocation**, which since the idle drain shipped no longer implies memory.

```
PEAK RESIDENT rooms during import: 4     (1000 notes)
```

Measured **twice** — at CI's 5s idle drain *and* at prod's **300s**. Identical. Not luck: a note room exits on **`auto_exit` when its last observer leaves**, not on the idle timer (that backstops the per-vault index room, observed for a whole session). Enrolment being gated to live-bound notes (#1424, plugin #466) is what lets observers leave — that, not the drain, is what resolved the 2026-08-18 shape.

Adds `e2e/helpers/residency_probe.py`, sampled on **every pass** of the convergence loop; `room_probe`'s docstring is right that one trailing sample cannot see a burst. Bound = 32, ~8x observed.

## 2. Record the allocation ratchet's measured range (was #1461)

**Ratchet stays 700.** I tried tightening it to 400 off a single 335-room sample; the next run measured 583 and went red on a change that regressed nothing.

```
57, 81, 335, 583   rooms / 1000 notes     (10x spread)
```

The comment now carries the range, the attribution (ordinary `enroll()` calls dominated by `fireCrdtReHandshake` — a **delivery path that must NOT be gated**, see Engram-obsidian#469), and the falsified reconnect-re-advertise theory, so none of it gets re-derived.

## 3. Correct the room-lifetime doc (was #1457)

It claimed prod runs with no idle drain bound. #1413 flipped the default ON (300s) on 2026-08-18, live in prod since 2026-08-23 — confirmed against prod telemetry (flat process count, balanced drain requests/releases).

---

## Test plan
- [x] Residency measured 4/1000 at both drain windows
- [x] `ruff check` + `ruff format --check` clean on the touched files
- [x] Diff confined to 3 files (an accidental `ruff format e2e/` touched 70+ files and was reverted)
- [ ] `e2e-clerk` green with the new residency assertion

Closes #1457, closes #1461, closes #1462.