### PR TITLE
fix(folders): web delete of a populated folder removes its contents

### DIFF
--- a/frontend/e2e/tree-ops-sync.spec.ts
+++ b/frontend/e2e/tree-ops-sync.spec.ts
@@ -439,6 +439,55 @@ test.describe("web tree ops sync (web to web)", () => {
 		await ctxB.close();
 	});
 
+	// Regression (web delete of a populated folder reverted after ~1s): a folder
+	// that exists ONLY because notes live under it has no marker row — the
+	// server derives it from those notes' paths, and the tree gives it a
+	// `syn:` id. The sibling test above calls `createFolder` first, so its
+	// folder always had a marker and always took the id-keyed cascade; nothing
+	// covered the derived shape every Obsidian-created folder actually has.
+	// The marker-only delete removed nothing, so the folder re-derived from the
+	// note still inside it on the next refetch and came straight back.
+	test("delete DERIVED (marker-less) non-empty folder stays deleted", async ({
+		browser,
+		baseURL,
+	}) => {
+		const email = `e2e-tree-delderiv-${Date.now()}@test.com`;
+		const token = await registerAndLogin(baseURL!, email);
+		const vault = await createVault(baseURL!, token, `treedelderiv-${Date.now()}`);
+		// No createFolder — "Derived" exists only as a prefix of this note's path.
+		await upsertNote(baseURL!, token, vault.id, "Derived/inside.md", "inside body\n");
+		const { id: anchorId } = await upsertNote(baseURL!, token, vault.id, "anchor.md", "anchor\n");
+
+		const ctxA = await browser.newContext();
+		const pageA = await ctxA.newPage();
+		const ctxB = await browser.newContext();
+		const pageB = await ctxB.newPage();
+		await signInForNote(pageA, email, vault.id, anchorId);
+		await signInForNote(pageB, email, vault.id, anchorId);
+
+		await expect(row(pageA, "Derived")).toBeVisible({ timeout: 10_000 });
+		await expect(row(pageB, "Derived")).toBeVisible({ timeout: 10_000 });
+
+		await openContextMenu(pageA, "Derived");
+		await pickAction(pageA, "Delete");
+		await confirmDelete(pageA);
+
+		await expect(row(pageA, "Derived")).toHaveCount(0, { timeout: 10_000 });
+		await expect(row(pageB, "Derived")).toHaveCount(0, { timeout: 10_000 });
+
+		// The reported symptom was a REVERT, not a failed delete: the optimistic
+		// drop looked correct, then the refetch re-derived the folder. Reload so
+		// the assertion reads the SERVER's answer with no optimistic state in
+		// front of it — that is the only way this test can fail on a marker-only
+		// delete, and the reason the two assertions above are not enough.
+		await pageA.reload();
+		await expect(row(pageA, "anchor")).toBeVisible({ timeout: 10_000 });
+		await expect(row(pageA, "Derived")).toHaveCount(0);
+
+		await ctxA.close();
+		await ctxB.close();
+	});
+
 	test("delete EMPTY folder propagates to a second tab", async ({ browser, baseURL }) => {
 		const email = `e2e-tree-delef-${Date.now()}@test.com`;
 		const token = await registerAndLogin(baseURL!, email);

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -546,6 +546,12 @@ describe("useDeleteFolder", () => {
 		expect(del).toHaveBeenCalledWith("/folders/my%20folder/sub?recursive=true");
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folderNotes", "42"] });
+		// A folder holding only attachments is synthesized from the attachments
+		// cache, not from /api/folders. Skip this and the recursive delete removes
+		// the attachment server-side while the stale cache keeps re-deriving the
+		// folder — the same revert this hook exists to stop.
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["attachments", "42"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folder-notes-by-id", "42"] });
 	});
 
 	it("surfaces backend errors as ApiError", async () => {

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -543,7 +543,7 @@ describe("useDeleteFolder", () => {
 			await result.current.mutateAsync({ path: "my folder/sub" });
 		});
 
-		expect(del).toHaveBeenCalledWith("/folders/my%20folder/sub");
+		expect(del).toHaveBeenCalledWith("/folders/my%20folder/sub?recursive=true");
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folderNotes", "42"] });
 	});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2247,6 +2247,13 @@ export function useDeleteFolder() {
 			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
+			// synthesizeFolders builds rows from TWO sources: /api/folders and the
+			// attachments cache. A folder holding only attachments has no row in
+			// the former, so without this the recursive delete removes the
+			// attachment server-side while the stale cache keeps re-deriving the
+			// folder — the same revert this hook exists to stop.
+			qc.invalidateQueries({ queryKey: ["attachments", vaultId] });
+			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 		},
 	});
 }

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2196,7 +2196,12 @@ export function useDeleteFolder() {
 		{ path: string },
 		DeleteFolderContext
 	>({
-		mutationFn: ({ path }) => api.del<{ deleted: boolean }>(`/folders/${encodePathSegments(path)}`),
+		// recursive=true: this hook only ever deletes a DERIVED folder (one with no
+		// marker row of its own). Without it the server clears a marker that was
+		// never there, deletes nothing, and the folder re-derives from the notes
+		// still inside it the moment we refetch.
+		mutationFn: ({ path }) =>
+			api.del<{ deleted: boolean }>(`/folders/${encodePathSegments(path)}?recursive=true`),
 		onMutate: async ({ path }) => {
 			// Coarse: drop the folder entry + its own folderNotes cache. We
 			// don't chase descendant folderNotes entries — the user will

--- a/lib/engram/folders.ex
+++ b/lib/engram/folders.ex
@@ -9,11 +9,15 @@ defmodule Engram.Folders do
   **batch-delete**, and **batch-move** (REST + MCP) — routes through here so no
   caller can forget the attachment leg.
 
-  The marker-only single DELETE (`DELETE /api/folders/:path`) intentionally does
-  NOT route through here: it calls `Notes.delete_folder_marker/3`, which removes
-  just the folder marker and deletes no content — the notes AND attachments under
-  that path stay live. With nothing deleted, there is nothing to cascade, so a
-  coordinator hop would be a no-op.
+  `DELETE /api/folders/:path` picks one of two paths. Without `recursive=true`
+  it stays marker-only — `Notes.delete_folder_marker/3` removes just the folder
+  marker and deletes no content, so the notes AND attachments under that path
+  stay live; with nothing deleted there is nothing to cascade and a coordinator
+  hop would be a no-op. That is the shape the Obsidian plugin pushes, because
+  Obsidian sends its own per-note deletes alongside the folder delete. With
+  `recursive=true` (what the web app sends) it routes through `delete/4` here,
+  because a folder with no marker of its own — one the server only derives from
+  the paths of the notes inside it — cannot be removed any other way.
 
   Consistency is atomic across BOTH tables: each op wraps the notes leg and the
   attachment leg in a single `Repo.transaction` (the legs' own

--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -169,9 +169,13 @@ defmodule EngramWeb.FoldersController do
       path: [in: :path, type: :string, required: true, description: "Folder path"],
       recursive: [
         in: :query,
-        type: :boolean,
+        type: :string,
         required: false,
-        description: "Delete the folder's contents too (default false: marker only)"
+        description:
+          "\"true\" also deletes every note and attachment under the path. Omit for " <>
+            "marker-only. Declared as a string, not a boolean, because nothing casts " <>
+            "query params here — a value this does not recognize would silently no-op " <>
+            "a destructive call."
       ]
     ],
     responses: [no_content: "Deleted (empty body)"]
@@ -182,12 +186,19 @@ defmodule EngramWeb.FoldersController do
     vault = conn.assigns.current_vault
     folder = Enum.map_join(path_segments, "/", &URI.decode/1)
 
-    if params["recursive"] == "true" do
+    if truthy?(params["recursive"]) do
       delete_recursive(conn, user, vault, folder)
     else
       delete_marker_only(conn, user, vault, folder)
     end
   end
+
+  # Accept the spellings a real client actually sends. An unrecognized value
+  # falls through to marker-only and answers 204 having deleted nothing, so
+  # being strict here buys a silent no-op on a destructive endpoint.
+  defp truthy?(v) when is_binary(v), do: String.downcase(v) in ~w(true 1 yes)
+  defp truthy?(true), do: true
+  defp truthy?(_), do: false
 
   # Most folders have no marker row of their own — the server derives them from
   # the paths of the notes inside. Clearing a marker that was never there
@@ -196,13 +207,14 @@ defmodule EngramWeb.FoldersController do
   # contents, which is the only thing that actually removes a derived folder.
   defp delete_recursive(conn, user, vault, folder) do
     case Folders.delete(user, vault, folder, recursive: true) do
-      # ponytail: 0/0 means "nothing was removed" OR "an empty marker was cleared" --
-      # Folders.delete cannot tell us apart. Stay silent: a phantom folders.batch
-      # delete makes the plugin drop a live local folder, and the callers that
-      # pass recursive=true are deleting folders that HAVE content.
-      {:ok, %{notes: 0, attachments: 0}} ->
-        send_resp(conn, 204, "")
-
+      # Broadcast on every success, including 0/0. `Folders.delete/4` reports
+      # content counts only, so 0/0 cannot distinguish "nothing was there" from
+      # "a nested empty marker was cleared" — and a broadcast on the former
+      # costs nothing. The plugin's `folders.batch` handler ignores the payload
+      # entirely: it re-polls GET /folders/explicit and trashes only a folder
+      # the server no longer lists AND that is empty on disk (see
+      # `syncExplicitFolders` in plugin/src/sync.ts). A phantom event is one
+      # extra GET, not a lost local folder.
       {:ok, _counts} ->
         BatchOps.broadcast_batch(user, vault, "folders.batch", %{op: "delete", folder: folder})
         send_resp(conn, 204, "")
@@ -211,7 +223,7 @@ defmodule EngramWeb.FoldersController do
         send_resp(conn, 204, "")
 
       {:error, :root_delete_refused} ->
-        conn |> put_status(422) |> json(%{error: "folder must not be empty"})
+        conn |> put_status(422) |> json(%{error: "Refusing to delete the vault root."})
 
       {:error, reason} ->
         conn |> put_status(500) |> json(%{error: format_error(reason)})

--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -161,17 +161,64 @@ defmodule EngramWeb.FoldersController do
     summary: "Delete a folder by path",
     description:
       "Removes the folder marker for the given path. Idempotent — deleting a non-existent or " <>
-        "never-encrypted folder still returns 204.",
+        "never-encrypted folder still returns 204. Pass `recursive=true` to also delete every " <>
+        "note and attachment under the path — required to remove a folder that has no marker " <>
+        "of its own (one the server only derives from the paths of the notes inside it).",
     tags: ["Folders"],
-    parameters: [path: [in: :path, type: :string, required: true, description: "Folder path"]],
+    parameters: [
+      path: [in: :path, type: :string, required: true, description: "Folder path"],
+      recursive: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description: "Delete the folder's contents too (default false: marker only)"
+      ]
+    ],
     responses: [no_content: "Deleted (empty body)"]
   )
 
-  def delete(conn, %{"path" => path_segments}) do
+  def delete(conn, %{"path" => path_segments} = params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
     folder = Enum.map_join(path_segments, "/", &URI.decode/1)
 
+    if params["recursive"] == "true" do
+      delete_recursive(conn, user, vault, folder)
+    else
+      delete_marker_only(conn, user, vault, folder)
+    end
+  end
+
+  # Most folders have no marker row of their own — the server derives them from
+  # the paths of the notes inside. Clearing a marker that was never there
+  # deletes nothing, so the folder re-derives from those same notes on the very
+  # next list and the client watches it come back. `recursive: true` deletes the
+  # contents, which is the only thing that actually removes a derived folder.
+  defp delete_recursive(conn, user, vault, folder) do
+    case Folders.delete(user, vault, folder, recursive: true) do
+      # ponytail: 0/0 means "nothing was removed" OR "an empty marker was cleared" --
+      # Folders.delete cannot tell us apart. Stay silent: a phantom folders.batch
+      # delete makes the plugin drop a live local folder, and the callers that
+      # pass recursive=true are deleting folders that HAVE content.
+      {:ok, %{notes: 0, attachments: 0}} ->
+        send_resp(conn, 204, "")
+
+      {:ok, _counts} ->
+        BatchOps.broadcast_batch(user, vault, "folders.batch", %{op: "delete", folder: folder})
+        send_resp(conn, 204, "")
+
+      {:error, :no_dek} ->
+        send_resp(conn, 204, "")
+
+      {:error, :root_delete_refused} ->
+        conn |> put_status(422) |> json(%{error: "folder must not be empty"})
+
+      {:error, reason} ->
+        conn |> put_status(500) |> json(%{error: format_error(reason)})
+    end
+  end
+
+  defp delete_marker_only(conn, user, vault, folder) do
     # Idempotent: treat :no_dek (user never encrypted anything) as "nothing to delete".
     case Notes.delete_folder_marker(user, vault, folder) do
       {:ok, :deleted} ->

--- a/openapi.json
+++ b/openapi.json
@@ -4112,12 +4112,12 @@
             }
           },
           {
-            "description": "Delete the folder's contents too (default false: marker only)",
+            "description": "\"true\" also deletes every note and attachment under the path. Omit for marker-only. Declared as a string, not a boolean, because nothing casts query params here — a value this does not recognize would silently no-op a destructive call.",
             "in": "query",
             "name": "recursive",
             "required": false,
             "schema": {
-              "type": "boolean",
+              "type": "string",
               "x-struct": null,
               "x-validate": null
             }

--- a/openapi.json
+++ b/openapi.json
@@ -4097,7 +4097,7 @@
     "/api/folders/*path": {
       "delete": {
         "callbacks": {},
-        "description": "Removes the folder marker for the given path. Idempotent — deleting a non-existent or never-encrypted folder still returns 204.",
+        "description": "Removes the folder marker for the given path. Idempotent — deleting a non-existent or never-encrypted folder still returns 204. Pass `recursive=true` to also delete every note and attachment under the path — required to remove a folder that has no marker of its own (one the server only derives from the paths of the notes inside it).",
         "operationId": "folders-delete",
         "parameters": [
           {
@@ -4107,6 +4107,17 @@
             "required": true,
             "schema": {
               "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Delete the folder's contents too (default false: marker only)",
+            "in": "query",
+            "name": "recursive",
+            "required": false,
+            "schema": {
+              "type": "boolean",
               "x-struct": null,
               "x-validate": null
             }

--- a/test/engram_web/controllers/folders_create_delete_test.exs
+++ b/test/engram_web/controllers/folders_create_delete_test.exs
@@ -136,6 +136,17 @@ defmodule EngramWeb.FoldersCreateDeleteTest do
       }
     end
 
+    test "recursive=1 cascades too (an unrecognized value would silently no-op)", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, child} = Engram.Notes.upsert_note(user, vault, %{path: "Derived/a.md"})
+
+      assert response(delete(conn, ~p"/api/folders/Derived?recursive=1"), 204)
+      assert {:error, :not_found} = Engram.Notes.get_note_by_id(user, vault, child.id)
+    end
+
     test "without recursive, a populated folder keeps its notes", %{
       conn: conn,
       user: user,

--- a/test/engram_web/controllers/folders_create_delete_test.exs
+++ b/test/engram_web/controllers/folders_create_delete_test.exs
@@ -108,5 +108,43 @@ defmodule EngramWeb.FoldersCreateDeleteTest do
 
       refute_receive %Phoenix.Socket.Broadcast{event: "folders.batch"}, 100
     end
+
+    test "recursive=true deletes a marker-less folder's notes", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, child} = Engram.Notes.upsert_note(user, vault, %{path: "Derived/a.md"})
+
+      assert response(delete(conn, ~p"/api/folders/Derived?recursive=true"), 204)
+      assert {:error, :not_found} = Engram.Notes.get_note_by_id(user, vault, child.id)
+    end
+
+    test "recursive=true broadcasts folders.batch delete", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, _} = Engram.Notes.upsert_note(user, vault, %{path: "Derived/a.md"})
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      delete(conn, ~p"/api/folders/Derived?recursive=true")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "folders.batch",
+        payload: %{op: "delete", folder: "Derived"}
+      }
+    end
+
+    test "without recursive, a populated folder keeps its notes", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, child} = Engram.Notes.upsert_note(user, vault, %{path: "Derived/a.md"})
+
+      assert response(delete(conn, ~p"/api/folders/Derived"), 204)
+      assert {:ok, _} = Engram.Notes.get_note_by_id(user, vault, child.id)
+    end
   end
 end


### PR DESCRIPTION
## What

`DELETE /api/folders/*path` only cleared the folder **marker** row. Most folders have no marker of their own — the server derives them from the paths of the notes inside — so the web app's delete removed nothing, the folder re-derived on the next refetch, and no note deletes ever reached the plugin. Reported as "delete a populated folder in the web app, it disappears for about a second then comes back, and never reaches Obsidian."

Adds `?recursive=true`, routing through `Engram.Folders.delete/4` (the same cascade the id-keyed `POST /folders/batch-delete` already runs), and points `useDeleteFolder` at it.

Marker-only stays the default. The plugin depends on it: `handleFolderDelete` fires only for folders in its `explicitFolders` set, and Obsidian pushes its own per-note deletes alongside the folder delete, so a recursive default would let the server delete notes the plugin deliberately kept.

## Why the tests missed it

The existing `delete non-empty folder propagates to a second tab` spec calls `createFolder` first, so its folder always had a marker and always took the id-keyed cascade. Nothing built a folder the way real usage does. The new spec skips that call — `Derived/` exists only as a prefix of a note path — and asserts through a `page.reload()`, because the symptom was a revert that only the server's answer exposes. Verified red on the marker-only delete (tab B keeps the folder, 23 polls) and green with the recursive delete.

## Review round

Five findings, all verified against the code and fixed in `48a33ef1`:

1. **The revert was still live for attachment-only folders.** `synthesizeFolders` builds rows from two sources — `/api/folders` and the attachments cache — and `onSettled` never invalidated the second. A folder holding only `Assets/pic.png` deleted server-side and popped straight back.
2. **The 0/0 branch stayed silent on a justification that does not hold.** The plugin's `folders.batch` handler ignores the payload, re-polls `/folders/explicit`, and trashes only a folder the server no longer lists that is also empty on disk — a phantom event is one extra GET, not a lost local folder. Meanwhile the guard swallowed a real delete: a nested empty marker reports `notes: 0`.
3. **`type: :boolean` declared while matching the literal `"true"`.** Nothing casts query params here, so `?recursive=1` answered 204 having deleted nothing — a silent no-op on a destructive endpoint. Declared as a string (matching the `?raw` convention) and accepts `true`/`1`/`yes`.
4. `:root_delete_refused` rendered "folder must not be empty", which reads as the opposite of what it means.
5. `Engram.Folders`' moduledoc still claimed the single DELETE never routes through the coordinator.

## Verification

```
51 tests, 0 failures    backend folder + MCP suites
120 passed              frontend unit
9 passed, 2 failed      tree-ops-sync.spec.ts
credo · dialyzer · tsc · biome   clean
openapi.json            no drift
```

Both e2e failures are rename tests and both fail identically on a pristine `origin/main` checkout in the same worktree — `rename folder` dies on `Protocol error (Runtime.callFunctionOn): session closed`, the local headless-Chromium issue in `docs/context/headless-chromium-no-raf-playwright.md`. All four folder-delete specs pass, including the new one.

Also hand-verified against a real vault: `recursive => "true"` reached the controller, 5 notes soft-deleted, 5 `note_changed op=delete` broadcasts to a live subscriber, `DELETE 204 in 220ms`, zero errors in the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTroEXqCfFBz6YyEtH5bEC