### PR TITLE
docs: remove redundant tagline from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 ![Engram — your notes are your AI's memory, synced everywhere and read by your AI](assets/vault-banner.gif)
 
-**Your notes are your AI's memory.**
-
 MCP-native · semantic + keyword search · real-time sync · self-hostable · source-available · Elixir/Phoenix
 
 [![MCP](https://img.shields.io/badge/MCP-native-8A2BE2)](https://modelcontextprotocol.io)


### PR DESCRIPTION
Supersedes #1464 — identical diff, on a branch CI will actually run.

The banner image's alt text already opens with "your notes are your AI's memory", so the bold line directly under it says the same sentence twice on screen for anyone browsing with images off.

## Why re-cut instead of merging #1464

CI here is `push`-triggered on conventional branch prefixes only (`feat/**`, `fix/**`, `docs/**`, …) — there is no `pull_request` trigger. `Rasbandit-patch-1` matches no prefix, so `lint`, `ci`, and `unit-tests` never report on it. Those are exactly the three contexts `protect-main` marks required, so that PR sits at `mergeStateStatus: BLOCKED` with nothing to un-block it. Renaming its branch would have closed the PR, so this is a fresh branch carrying the same two-line deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTroEXqCfFBz6YyEtH5bEC