### PR TITLE
fix(oban): survive worker replacement; keep overflow capacity after the split

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -62,6 +62,25 @@ config :engram, Oban,
   # of the source-less BEGIN/COMMIT/SELECT staging churn with no fresh-insert
   # latency cost.
   stage_interval: :timer.seconds(5),
+  # How long Oban waits for executing jobs to finish after SIGTERM before it
+  # stops the producers out from under them. Oban's default is 15s, which was
+  # survivable when every node ran queues and a replacement was rare. With the
+  # dedicated worker service (ENGRAM_NODE_ROLE=worker) every deploy replaces
+  # the ONE node executing jobs, so the default runs on every release.
+  #
+  # An embed job spends most of its life blocked on the Voyage API and routinely
+  # exceeds 15s. Cut short, it stays `executing` in the DB with a dead owner and
+  # nothing retries it until Oban.Plugins.Lifeline's rescue_after fires — 60
+  # minutes by default. That is an hour of a note having no embedding, and it
+  # looks exactly like "the queue is not draining".
+  #
+  # 45s, not more: the ECS container stopTimeout is 90s and the ALB
+  # deregistration_delay is 60s (engram-infra main/envs/prod/{ecs,alb}.tf).
+  # Oban's grace and the endpoint drain are siblings in the supervision tree,
+  # so assume they can serialize — 45 keeps the worst case under the 90s
+  # SIGKILL with room for BEAM teardown. On a web node this costs nothing:
+  # queues: false means there is nothing executing to wait for.
+  shutdown_grace_period: :timer.seconds(45),
   queues: [
     # The 2026-07-03 OOM crash-loop was NOT caused by embed concurrency — it was
     # the Lingua language-detector loading ~945 MB of full-accuracy n-gram models
@@ -77,10 +96,23 @@ config :engram, Oban,
     cleanup: 1,
     indexing: 2,
     # Overflow lane for CRDT unbind checkpoints under a reconnect storm (see
-    # Engram.Notes.CheckpointGate + Engram.Workers.CheckpointNote). Combined
-    # peak DB-connection budget on this path is inline (CheckpointGate default
-    # 3) + this lane (3) = 6 connections; excess unbind checkpoints wait in
-    # Postgres, not on the pool.
+    # Engram.Notes.CheckpointGate + Engram.Workers.CheckpointNote).
+    #
+    # The two halves of this path now live on DIFFERENT NODES. The inline gate
+    # (CheckpointGate, default 3) runs wherever the room is — a web node. This
+    # lane runs only where queues are enabled — the worker. So the old "inline
+    # 3 + lane 3 = 6 connections" arithmetic no longer describes any single
+    # pool: a web node spends 3 on this path, the worker spends what is set
+    # here, and neither sees the other's.
+    #
+    # 6, not 3. Cluster-wide overflow capacity used to be 2 web nodes x 3 = 6
+    # concurrent jobs. Pinning the lane to one worker would have quietly halved
+    # it to 3, doubling drain time for exactly the reconnect storm this lane
+    # exists to absorb. 6 on the single worker restores the capacity the
+    # cluster actually had, and now states it as ONE explicit number instead of
+    # a per-node limit that silently scaled with desired_count.
+    #
+    # It fits the worker pool: its queues sum to 20 of POOL_SIZE 25.
     #
     # These are ABSOLUTE limits — do NOT scale them with POOL_SIZE. They are
     # the backpressure that bounds a fan-out storm (2026-07-09), and raising
@@ -97,7 +129,7 @@ config :engram, Oban,
     # engram-infra (main/envs/prod/ecs.tf) and nothing there points back here,
     # so a copy in this repo would silently go stale — the same cross-file rot
     # that made the original 10 a leftover rather than a decision.
-    crdt_checkpoint: 3,
+    crdt_checkpoint: 6,
     default: 1
   ],
   plugins: [

--- a/lib/engram/notes/checkpoint_gate.ex
+++ b/lib/engram/notes/checkpoint_gate.ex
@@ -32,9 +32,17 @@ defmodule Engram.Notes.CheckpointGate do
   """
   use GenServer
 
-  # Kept comfortably under POOL_SIZE (default 10) so inline checkpoints + the
-  # crdt_checkpoint Oban lane (concurrency 3) + ungated room binds still leave
-  # the pool headroom for REST/search/embed. Configurable via
+  # Kept comfortably under POOL_SIZE so inline checkpoints + ungated room binds
+  # still leave the pool headroom for REST/search/embed.
+  #
+  # This gate and its overflow lane no longer share a pool. The gate runs
+  # wherever the room is bound (a web node); the `crdt_checkpoint` Oban lane
+  # runs only where queues are enabled (the worker, ENGRAM_NODE_ROLE). So this
+  # limit is 3 connections on a WEB node's pool and the lane's 6 is 6 on the
+  # WORKER's — do not add them together when budgeting either pool. See the
+  # crdt_checkpoint entry in config/config.exs.
+  #
+  # Configurable via
   # `:checkpoint_inline_limit` so the test env can raise it out of the way
   # (many async tests spin real rooms that share this process-global gate).
   @default_limit 3


### PR DESCRIPTION
Follow-up to #1485. Two consequences of the web/worker split that only bite once the dedicated worker service is real, so neither showed up in that PR's tests.

## `shutdown_grace_period` was never configured

Oban's default is 15s. That was survivable when every node ran queues and a replacement was rare. With `ENGRAM_NODE_ROLE=worker` every deploy replaces the **one** node executing jobs, so the default now runs on every release.

An embed job spends most of its life blocked on the Voyage API and routinely exceeds 15s. Cut short, it stays `executing` in the DB with a dead owner and nothing retries it until `Oban.Plugins.Lifeline`'s `rescue_after` fires — 60 minutes by default. That is an hour of a note having no embedding, and from the outside it looks exactly like "the queue is not draining".

Set to 45s. The ECS container `stopTimeout` is 90s and the ALB `deregistration_delay` is 60s; Oban's grace and the endpoint drain are siblings in the supervision tree, so 45 keeps the worst case under the SIGKILL even if they serialize. Costs nothing on a web node — `queues: false` means there is nothing executing to wait for.

## `crdt_checkpoint` 3 → 6

The inline `CheckpointGate` and this overflow lane used to share a node and a pool, so the old comment's "inline 3 + lane 3 = 6 connections" described a real per-node budget. They are now on **different nodes** — the gate runs where the room is bound (web), the lane runs where queues are enabled (worker) — so that arithmetic describes no single pool.

The capacity question matters more. The lane ran on *both* web nodes: 2 × 3 = 6 concurrent overflow checkpoints cluster-wide. Pinning it to one worker at 3 would have quietly halved that, doubling drain time for exactly the reconnect storm the lane exists to absorb. 6 on the single worker restores the capacity the cluster actually had, and states it as one explicit number instead of a per-node limit that silently scaled with `desired_count`.

Fits the worker pool: its queues now sum to 20 of `POOL_SIZE` 25.

## Verification

- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` — clean
- `mix dialyzer` — passed (6 skips, 0 unnecessary)
- `oban_queue_config_test`, `crdt_checkpoint_backpressure_test`, `crdt_checkpoint_test` — 35 tests, 0 failures

Paired infra change in engram-infra `feat/oban-worker-service` (corrects the `POOL_SIZE` arithmetic comment to match the new sum). Doc update in engram-workspace `docs/worker-split-connection-budget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp