### PR TITLE
fix(oban): scope crdt_checkpoint 6 to the worker, not every node

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -98,21 +98,22 @@ config :engram, Oban,
     # Overflow lane for CRDT unbind checkpoints under a reconnect storm (see
     # Engram.Notes.CheckpointGate + Engram.Workers.CheckpointNote).
     #
-    # The two halves of this path now live on DIFFERENT NODES. The inline gate
-    # (CheckpointGate, default 3) runs wherever the room is — a web node. This
-    # lane runs only where queues are enabled — the worker. So the old "inline
-    # 3 + lane 3 = 6 connections" arithmetic no longer describes any single
-    # pool: a web node spends 3 on this path, the worker spends what is set
-    # here, and neither sees the other's.
+    # 3 is the UNSPLIT default and this file is where the unsplit default lives.
+    # A node with no ENGRAM_NODE_ROLE runs the inline gate (CheckpointGate, 3)
+    # AND this lane, both against one pool, so the pair costs 6 connections
+    # there. That is the number POOL_SIZE 15 was budgeted around.
     #
-    # 6, not 3. Cluster-wide overflow capacity used to be 2 web nodes x 3 = 6
-    # concurrent jobs. Pinning the lane to one worker would have quietly halved
-    # it to 3, doubling drain time for exactly the reconnect storm this lane
-    # exists to absorb. 6 on the single worker restores the capacity the
-    # cluster actually had, and now states it as ONE explicit number instead of
-    # a per-node limit that silently scaled with desired_count.
+    # The dedicated worker raises this to 6 in config/runtime.exs, under the
+    # ENGRAM_NODE_ROLE=worker arm — NOT here. It can afford to: it never binds
+    # a room so it never runs the inline gate, and its pool is 25. Raising it
+    # here instead would put 6 + 3 = 9 on every unsplit node's pool of 15,
+    # which with embed at 5 is the 2026-07-09 exhaustion shape. ObanQueueConfigTest
+    # holds the 1..3 ceiling on this value as a tripwire.
     #
-    # It fits the worker pool: its queues sum to 20 of POOL_SIZE 25.
+    # Why the worker gets 6 and not 3: cluster-wide overflow capacity used to be
+    # 2 web nodes x 3 = 6 concurrent jobs. Consolidating the lane onto one
+    # worker at 3 would have quietly halved it, doubling drain time for exactly
+    # the reconnect storm this lane exists to absorb.
     #
     # These are ABSOLUTE limits — do NOT scale them with POOL_SIZE. They are
     # the backpressure that bounds a fan-out storm (2026-07-09), and raising
@@ -129,7 +130,7 @@ config :engram, Oban,
     # engram-infra (main/envs/prod/ecs.tf) and nothing there points back here,
     # so a copy in this repo would silently go stale — the same cross-file rot
     # that made the original 10 a leftover rather than a decision.
-    crdt_checkpoint: 6,
+    crdt_checkpoint: 3,
     default: 1
   ],
   plugins: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -735,11 +735,29 @@ if config_env() == :prod do
           config :engram, Oban, queues: false
 
         "worker" ->
-          # No Oban change — a worker runs the config/config.exs list. Recorded
-          # anyway because DECLARING a role is what tells the boot check this is
-          # a split fleet, and the unclustered *worker* is the node that can
+          # Recorded because DECLARING a role is what tells the boot check this
+          # is a split fleet, and the unclustered *worker* is the node that can
           # actually corrupt data (see Application.warn_if_split_fleet_unclustered/0).
           config :engram, :node_role, :worker
+
+          # The ONLY queue that differs from the unsplit default, and it belongs
+          # here rather than in config/config.exs because it is only safe on a
+          # node shaped like this one. A worker never binds a CRDT room, so it
+          # never runs the inline CheckpointGate (3) that a web or unsplit node
+          # spends alongside this lane — and its POOL_SIZE is 25, not 15. Both
+          # halves of that are what make 6 affordable.
+          #
+          # 6 restores the capacity the cluster already had: the lane used to run
+          # on BOTH web nodes (2 x 3), so consolidating it onto one worker at 3
+          # would have halved overflow throughput for exactly the reconnect storm
+          # the lane exists to absorb.
+          #
+          # Partial `queues:` overrides deep-merge into the base keyword list
+          # (Config merges nested keyword lists), so the other eight queues are
+          # untouched. ObanQueueConfigTest pins that behaviour — if it ever
+          # became a wholesale replace, the worker would boot with
+          # crdt_checkpoint as its only queue and embedding would stop.
+          config :engram, Oban, queues: [crdt_checkpoint: 6]
 
         "" ->
           :ok

--- a/lib/engram/notes/checkpoint_gate.ex
+++ b/lib/engram/notes/checkpoint_gate.ex
@@ -35,12 +35,16 @@ defmodule Engram.Notes.CheckpointGate do
   # Kept comfortably under POOL_SIZE so inline checkpoints + ungated room binds
   # still leave the pool headroom for REST/search/embed.
   #
-  # This gate and its overflow lane no longer share a pool. The gate runs
-  # wherever the room is bound (a web node); the `crdt_checkpoint` Oban lane
-  # runs only where queues are enabled (the worker, ENGRAM_NODE_ROLE). So this
-  # limit is 3 connections on a WEB node's pool and the lane's 6 is 6 on the
-  # WORKER's — do not add them together when budgeting either pool. See the
-  # crdt_checkpoint entry in config/config.exs.
+  # Whether this gate and its overflow lane share a pool depends on the role:
+  #
+  #   * UNSPLIT node (no ENGRAM_NODE_ROLE) — runs both. 3 here + the lane's
+  #     default 3 = 6 connections on one pool. This is what prod runs today.
+  #   * SPLIT fleet — the gate runs where the room is bound (web, queues off),
+  #     the lane runs on the worker (which never binds a room, so never reaches
+  #     this gate). 3 on a web pool, 6 on the worker's. Do NOT add them.
+  #
+  # That is why the lane's 6 lives in config/runtime.exs under the worker arm
+  # and not in config/config.exs — see the crdt_checkpoint entry in both.
   #
   # Configurable via
   # `:checkpoint_inline_limit` so the test env can raise it out of the way

--- a/test/engram/oban_queue_config_test.exs
+++ b/test/engram/oban_queue_config_test.exs
@@ -46,6 +46,55 @@ defmodule Engram.ObanQueueConfigTest do
              "see docs/context/lingua-language-detection-memory.md."
   end
 
+  # Tripwire against sizing crdt_checkpoint for the WRONG node.
+  #
+  # This lane is the overflow for CRDT unbind checkpoints; the inline half is
+  # Engram.Notes.CheckpointGate. On a split fleet they live on different nodes,
+  # so the worker can afford a big lane (it never runs the gate, and its pool is
+  # larger). But config/config.exs is the DEFAULT — it is what an unsplit node
+  # runs, and an unsplit node runs BOTH. There the two stack on one pool:
+  #
+  #     sum(queues) + CheckpointGate.limit()  must fit POOL_SIZE
+  #
+  # A value tuned for the worker landing here is exactly how you rebuild the
+  # 2026-07-09 pool-exhaustion loop on every node that has no role set. Raise
+  # the lane for the worker in config/runtime.exs (the ENGRAM_NODE_ROLE=worker
+  # arm), never here.
+  test "crdt_checkpoint default is sized for a node that ALSO runs the inline gate" do
+    lane = configured_queue_limit(:crdt_checkpoint)
+
+    assert is_integer(lane) and lane >= 1 and lane <= 3,
+           "crdt_checkpoint default should be 1..3 (got #{inspect(lane)}).\n" <>
+             "This is the default every UNSPLIT node runs, and an unsplit node also\n" <>
+             "runs the inline CheckpointGate — the two stack on one pool. If you are\n" <>
+             "raising this for the dedicated worker, do it in config/runtime.exs\n" <>
+             "under the ENGRAM_NODE_ROLE=worker arm instead."
+  end
+
+  # The whole point of the runtime override is that it raises ONE queue without
+  # dropping the other eight. Config deep-merges nested keyword lists, but that
+  # is a language guarantee this config leans on hard enough to pin down: get it
+  # wrong and the worker silently boots with crdt_checkpoint as its ONLY queue,
+  # and embeds stop for everyone.
+  test "a partial queues override merges into the base list rather than replacing it" do
+    base = Application.fetch_env!(:engram, Oban)
+
+    merged =
+      Config.__merge__(
+        [engram: [{Oban, base}]],
+        engram: [{Oban, [queues: [crdt_checkpoint: 6]]}]
+      )
+
+    queues = merged[:engram][Oban][:queues]
+
+    assert Keyword.get(queues, :crdt_checkpoint) == 6
+    assert Keyword.get(queues, :embed) == configured_queue_limit(:embed)
+
+    assert Enum.sort(Keyword.keys(queues)) ==
+             Enum.sort(Keyword.keys(Application.fetch_env!(:engram, Oban)[:queues])),
+           "the override dropped or added a queue — the worker would boot with the wrong set"
+  end
+
   defp configured_queue_limit(queue) do
     Application.fetch_env!(:engram, Oban)[:queues] |> Keyword.get(queue)
   end


### PR DESCRIPTION
Fixes a regression I shipped in #1487. **0.21.0 is tagged but not yet in prod** — the engram-infra image-bump PR (engram-app/engram-infra#1068) is still open, so this can go out as 0.21.1 before anything lands.

## What went wrong

#1487 raised `crdt_checkpoint` 3 → 6 in `config/config.exs`. That file is the **unsplit default** — what a node with no `ENGRAM_NODE_ROLE` runs, which is every node in prod today. And an unsplit node runs the inline `CheckpointGate` as well as the lane.

```
before:  CheckpointGate 3 + lane 3 = 6 connections
after:   CheckpointGate 3 + lane 6 = 9 connections
         ...on POOL_SIZE 15, with embed already holding 5
```

That is the 2026-07-09 pool-exhaustion shape, on the exact queue that incident was about. Low probability — the lane is overflow-only and sits empty in steady state — but it fills precisely during the reconnect storm it exists to absorb, which is when you least want to be 9-deep on a 15 pool.

## Why 6 was right for the worker and wrong here

The worker never binds a CRDT room, so it never reaches the inline gate, and its `POOL_SIZE` is 25 rather than 15. Both of those are what make 6 affordable, and neither is true of an unsplit node. So 6 moves to the `ENGRAM_NODE_ROLE=worker` arm of `config/runtime.exs`, and the default returns to 3.

The reason the worker gets 6 rather than 3 is unchanged: the lane used to run on **both** web nodes (2 × 3 = 6 concurrent overflow jobs cluster-wide), so consolidating it onto one worker at 3 would have halved that.

## Tripwires

Written first, both confirmed failing before the fix:

- **`crdt_checkpoint` 1..3 ceiling** on the `config.exs` value, mirroring the existing `embed` 1..8 ceiling. The failure message names the correct place to raise it. Verified it rejects 6.
- **A partial `queues:` override must deep-merge**, not replace. The worker arm sets `queues: [crdt_checkpoint: 6]` and relies on Config merging nested keyword lists to leave the other eight queues alone. If that ever became a wholesale replace, the worker would boot with `crdt_checkpoint` as its only queue and embedding would stop fleet-wide — silently, since nothing else would error.

## Also

Corrects the `CheckpointGate` doc comment, which #1487 rewrote to claim the gate and the lane "no longer share a pool". True on a split fleet, false on the unsplit one that is actually running.

## Verification

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer` — clean. `oban_queue_config_test` + both checkpoint suites: 37 tests, 0 failures.

## Unrelated question this raised, now answered

#1485 removed the `crdt_create_batch` channel handler. A browser holding cached SPA JS that still calls it hits the channel's catch-all `handle_in/3`, which replies `{:error, %{reason: "bad_frame"}}` — no process crash, no socket drop. A stale tab fails note creation until reload. Bounded, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp