### PR TITLE
fix(promex): stop web nodes publishing an Oban gauge they cannot observe

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,6 +41,10 @@ config :engram, :trust_cf_connecting_ip, false
 # Grafana dashboard uploads (managed via Terraform-as-code, not runtime).
 config :engram, Engram.PromEx,
   manual_metrics_start_delay: :no_delay,
+  # Overridden per node role in config/runtime.exs — a web node
+  # (`ENGRAM_NODE_ROLE=web`, `queues: false`) drops
+  # `:oban_queue_poll_metrics` because it cannot observe queue depth and
+  # PromEx `last_value` gauges never expire. See Engram.PromEx.drop_metrics_groups/1.
   drop_metrics_groups: [],
   grafana: :disabled,
   metrics_server: :disabled

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -734,6 +734,21 @@ if config_env() == :prod do
           config :engram, :node_role, :web
           config :engram, Oban, queues: false
 
+          # `queues: false` leaves this node unable to observe queue depth, and
+          # PromEx's `:oban_queue_poll_metrics` are `last_value` gauges that
+          # never expire — so a poller with nothing to poll does not go quiet,
+          # it freezes and serves its final sample forever. Prod 2026-08-28:
+          # web published a 494-job embed backlog for 40+ minutes against an
+          # empty queue, and every dashboard and alert that selects
+          # `max by (queue)` across roles read that copy instead of the
+          # worker's live one. Absent beats wrong. See #1497.
+          # Literal, NOT a call to Engram.PromEx.drop_metrics_groups/1. This file
+          # is evaluated by a Config.Provider during release boot, before any
+          # application starts; calling into app code there is a boot-crash risk
+          # for no gain. PromExObanPollGroupTest asserts this literal and that
+          # function stay in agreement.
+          config :engram, Engram.PromEx, drop_metrics_groups: [:oban_queue_poll_metrics]
+
         "worker" ->
           # Recorded because DECLARING a role is what tells the boot check this
           # is a split fleet, and the unclustered *worker* is the node that can

--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -65,7 +65,12 @@ defmodule Engram.PromEx do
   # exception) stay registered on every role: they are emitted by execution
   # rather than polled, so a web node simply produces none and no series
   # appears. There is nothing to go stale.
-  @spec drop_metrics_groups(map()) :: [atom()]
+  # Narrow on purpose. `[atom()]` is a supertype of what this can actually
+  # return and dialyzer rejects it as `contract_supertype`. Naming the one group
+  # also makes the spec the shortest accurate description of the policy: today
+  # exactly one group is ever dropped, and widening it is a deliberate edit
+  # rather than something that happens by accident.
+  @spec drop_metrics_groups(map()) :: [:oban_queue_poll_metrics]
   def drop_metrics_groups(env \\ System.get_env()) do
     case env
          |> Map.get("ENGRAM_NODE_ROLE")

--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -39,4 +39,41 @@ defmodule Engram.PromEx do
 
   @impl true
   def dashboards, do: []
+
+  # PromEx metric groups this node must NOT publish, given its role.
+  #
+  # `:oban_queue_poll_metrics` polls Postgres for per-queue job counts and
+  # records them as `last_value` gauges. `last_value` does not expire: once a
+  # node writes a sample it is served on every scrape until that node writes a
+  # new one. So a poller that stops does not go quiet — it FREEZES, and keeps
+  # asserting a number that was true once.
+  #
+  # `ENGRAM_NODE_ROLE=web` sets `queues: false` (config/runtime.exs), which is
+  # exactly that state: no queues to poll, nothing to refresh the gauge, and a
+  # stale sample published forever. Measured in prod 2026-08-28 — web nodes
+  # served available=136 / scheduled=358 / executing=5 for over 40 minutes
+  # while the database held ZERO embed jobs in those states. The worker, the
+  # only node still running queues, correctly reported 0. Dashboards and the
+  # `oban-no-consumer` alert select `max by (queue)` across roles, so they took
+  # the frozen web copy and read a 494-job backlog on an empty queue. See #1497.
+  #
+  # A queueless node has no business publishing a number it cannot observe.
+  # Dropping the group makes the series ABSENT rather than wrong, which a
+  # dashboard renders as a gap and an alert can treat as no-data — both honest.
+  #
+  # Only the poll group is dropped. The Oban event metrics (job start/stop/
+  # exception) stay registered on every role: they are emitted by execution
+  # rather than polled, so a web node simply produces none and no series
+  # appears. There is nothing to go stale.
+  @spec drop_metrics_groups(map()) :: [atom()]
+  def drop_metrics_groups(env \\ System.get_env()) do
+    case env
+         |> Map.get("ENGRAM_NODE_ROLE")
+         |> to_string()
+         |> String.trim()
+         |> String.downcase() do
+      "web" -> [:oban_queue_poll_metrics]
+      _ -> []
+    end
+  end
 end

--- a/test/engram/prom_ex_oban_poll_group_test.exs
+++ b/test/engram/prom_ex_oban_poll_group_test.exs
@@ -1,0 +1,75 @@
+defmodule Engram.PromExObanPollGroupTest do
+  # Guard: a node that runs no Oban queues must not PUBLISH Oban queue-length
+  # metrics.
+  #
+  # PromEx's `:oban_queue_poll_metrics` group polls Postgres for per-queue
+  # counts and records them as `last_value` gauges. `last_value` never expires:
+  # once a node writes a sample, that sample is served on every scrape until the
+  # node writes a new one. A poller that stops therefore does not go quiet — it
+  # freezes, and keeps asserting a number that was true once.
+  #
+  # `ENGRAM_NODE_ROLE=web` sets `queues: false`, which is exactly that state.
+  # Measured in prod 2026-08-28: web nodes served
+  # available=136 / scheduled=358 / executing=5 for 40+ minutes while the
+  # database held ZERO embed jobs in those states. It read as a wedged queue and
+  # cost a live incident investigation. See #1497.
+  #
+  # The fix is to drop the group on a queueless node rather than let it publish
+  # a number it cannot observe. These tests pin the two halves that make that
+  # true: the config key PromEx actually reads, and the role gate that sets it.
+  use ExUnit.Case, async: true
+
+  @poll_group :oban_queue_poll_metrics
+
+  describe "queueless nodes" do
+    test "the web role drops the Oban queue-poll metrics group" do
+      dropped = drop_groups_for(%{"ENGRAM_NODE_ROLE" => "web"})
+
+      assert @poll_group in dropped,
+             "a web node runs `queues: false` and cannot observe queue depth, but it would\n" <>
+               "still publish #{inspect(@poll_group)}. PromEx gauges are `last_value`, so the\n" <>
+               "final sample it writes is scraped forever — see #1497.\n" <>
+               "Got drop_metrics_groups: #{inspect(dropped)}"
+    end
+  end
+
+  describe "nodes that DO run queues" do
+    test "the worker role keeps the group — it is the only node that can observe queue depth" do
+      dropped = drop_groups_for(%{"ENGRAM_NODE_ROLE" => "worker"})
+
+      refute @poll_group in dropped,
+             "the worker executes every queue; dropping its poller would leave NO node\n" <>
+               "publishing queue depth at all, which is worse than a stale one."
+    end
+
+    test "an unset role keeps the group — self-host and dev run queues on every node" do
+      dropped = drop_groups_for(%{})
+
+      refute @poll_group in dropped,
+             "an unset ENGRAM_NODE_ROLE means a single unsplit node running all queues.\n" <>
+               "It observes them correctly and must keep publishing."
+    end
+  end
+
+  # config/runtime.exs cannot call this function: it is evaluated by a
+  # Config.Provider during release boot, before any application starts, so
+  # calling app code from it is a boot-crash risk. It therefore carries the
+  # LITERAL list, and this test is what stops the two drifting apart — a
+  # duplicated constant with nothing checking it is how the stale gauge comes
+  # back with the policy function still looking correct.
+  test "config/runtime.exs drops exactly what the policy function says, for the web role" do
+    source = File.read!(Path.join(__DIR__, "../../config/runtime.exs"))
+
+    expected = drop_groups_for(%{"ENGRAM_NODE_ROLE" => "web"})
+    literal = "drop_metrics_groups: #{inspect(expected)}"
+
+    assert source =~ literal,
+           "config/runtime.exs must set `#{literal}` in the ENGRAM_NODE_ROLE=web branch.\n" <>
+             "Engram.PromEx.drop_metrics_groups/1 returns #{inspect(expected)}, but runtime.exs\n" <>
+             "does not contain that literal — the policy and the thing that applies it have\n" <>
+             "drifted, and a web node will publish a gauge it cannot observe. See #1497."
+  end
+
+  # The policy itself, as a pure function of the environment.
+  defp drop_groups_for(env), do: Engram.PromEx.drop_metrics_groups(env)
+end


### PR DESCRIPTION
Fixes #1497. Source-level fix for the stale queue gauge; engram-app/engram-infra#1077 is the alert-side mitigation.

## The bug

`:oban_queue_poll_metrics` polls Postgres for per-queue counts and records them as `last_value` gauges. **`last_value` never expires** — once a node writes a sample, it is served on every scrape until that node writes a new one.

`ENGRAM_NODE_ROLE=web` sets `queues: false`. That node now has nothing to poll, so its poller does not go quiet — it freezes, and keeps asserting a number that was true once.

Measured in prod 2026-08-28, 40+ minutes after the fact:

```promql
max by (role, state) (engram_prom_ex_oban_queue_length_count{queue="embed"})
  {role="web"}     available=136  scheduled=358  executing=5   ← frozen at 07:45
  {role="worker"}  available=0    scheduled=0    executing=0   ← correct
```

Ground truth over the bastion at the same moment: zero embed jobs in any of those states. The last one completed at 07:45:39.

Dashboards and `oban-no-consumer` select `max by (queue)` with no role filter, so they took the max across roles — the frozen web copy — and displayed a 494-job backlog on an empty queue. It read as a wedged production queue and cost a live incident investigation into an outage that had already resolved.

## The fix

Drop the group on the web role. **Absent beats wrong**: a dashboard renders a gap, an alert can treat it as no-data, and neither is misled.

Only the *poll* group is dropped. Oban's event metrics (job start/stop/exception) stay registered on every role — they are emitted by execution rather than polled, so a web node simply produces none and no series appears. There is nothing there to go stale.

## Why runtime.exs carries a literal

`config/runtime.exs` is evaluated by a `Config.Provider` during release boot, before any application starts. Calling `Engram.PromEx.drop_metrics_groups/1` from there is a boot-crash risk for no benefit, so it sets `[:oban_queue_poll_metrics]` directly.

That duplicates a constant, which is how this bug comes back while the policy function still looks correct — so a test asserts the two agree by reading `runtime.exs`. I verified the guard fails when the literal is changed:

```
$ sed -i 's/\[:oban_queue_poll_metrics\]/[]/' config/runtime.exs
4 tests, 1 failure
```

## Tests

Four guards, all confirmed red before the fix:

- web drops the poll group
- **worker keeps it** — dropping the worker's poller would leave no node publishing queue depth at all, which is worse than a stale one
- unset role keeps it — self-host and dev run queues on every node
- runtime.exs literal matches the policy function

## Verification

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` clean. `prom_ex_oban_poll_group_test` + `oban_queue_config_test`: 8 tests, 0 failures.

## Note on the broader class

This is the second time the split has broken a metric that assumed every node is an observer — the first was the `oban-no-consumer` zero-fill, already documented in `grafana_alerts.tf`. Worth a sweep of the remaining Oban panels; they still read the stale series until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp