### PR TITLE
feat(billing): publish indexed_notes_cap; normalize the -1 sentinel once

### DIFF
--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -272,13 +272,25 @@ defmodule Engram.Billing do
       # plugin reads `attachments_all_types`.
       attachments_text_only: not all_types?,
       max_file_bytes: numeric_limit(user, :max_file_bytes),
-      attachment_bytes_cap: numeric_limit(user, :attachment_bytes_cap)
+      attachment_bytes_cap: numeric_limit(user, :attachment_bytes_cap),
+      # How many notes this plan indexes for search. The plugin pairs it with
+      # its own vault file count to tell the user "Searching 2,000 of 4,312
+      # notes" — a capped note that silently returns nothing reads as broken
+      # search, and the capped-out notes are the user's NEWEST.
+      indexed_notes_cap: numeric_limit(user, :indexed_notes_cap)
     }
   end
 
   defp numeric_limit(user, key) do
     case effective_limit(user, key) do
       :unlimited -> nil
+      # -1 is this codebase's "unlimited" sentinel — check_limit/3 documents it
+      # and normalize_capability/2 already maps it to nil. Passing it through as
+      # a literal -1 means every client has to know the convention, and one that
+      # does not inverts the limit: a cap of -1 reads as "nothing is allowed" on
+      # the most permissive plan. Same class as attachments_text_only blocking
+      # self-host attachments. Normalise it here, once.
+      n when is_integer(n) and n < 0 -> nil
       n when is_integer(n) -> n
       _ -> nil
     end

--- a/test/engram/billing_plan_state_unlimited_test.exs
+++ b/test/engram/billing_plan_state_unlimited_test.exs
@@ -22,6 +22,35 @@ defmodule Engram.BillingPlanStateUnlimitedTest do
 
       assert state.max_file_bytes == nil
       assert state.attachment_bytes_cap == nil
+      assert state.indexed_notes_cap == nil
+    end
+  end
+
+  describe "plan_state/1 numeric limits" do
+    test "free carries the real indexed-note cap" do
+      state = Billing.plan_state(insert(:user))
+      assert state.indexed_notes_cap == 2_000
+    end
+
+    test "a negative override serializes to nil, not to a literal negative cap" do
+      user = insert(:user)
+
+      Engram.Repo.insert!(%Engram.Billing.UserLimitOverride{
+        user_id: user.id,
+        key: "indexed_notes_cap",
+        value: %{"v" => -1},
+        reason: "test",
+        set_by: "test"
+      })
+
+      Engram.Billing.OverrideCache.evict(user.id)
+
+      # -1 is the "unlimited" sentinel. Passing it through would make every
+      # client responsible for knowing that, and a client that does not invert
+      # the limit: "-1 notes indexed" reads as nothing searchable on the MOST
+      # permissive setting. Same class as attachments_text_only blocking
+      # self-host attachments.
+      assert Billing.plan_state(user).indexed_notes_cap == nil
     end
   end
 end


### PR DESCRIPTION
Follow-up to #1486. Unblocks engram-app/Engram-obsidian#481.

## 1. `plan_state/1` carries `indexed_notes_cap`

The field the Obsidian plugin needs to render, on its search panel:

> Searching 2,000 of 4,312 notes. Upgrade to search everything.

A capped note that silently returns nothing reads as broken search — and because the cap keeps the **oldest** notes, the ones outside it are the user's **newest work**, which is the opposite of what anyone expects.

No new endpoint. It rides the WebSocket plan push the plugin already receives, and the plugin supplies the vault size from its own file list, so the "of 4,312" half costs nothing server-side.

## 2. `numeric_limit/2` normalizes any negative to `nil` — the more important half

`-1` is this codebase's "unlimited" sentinel. `check_limit/3` documents it, and `normalize_capability/2` already collapses it to `null`. But `numeric_limit/2` passed it through as a literal, which made **every client responsible for knowing the convention** — and a client that doesn't know *inverts the limit*: a cap of `-1` reads as "nothing is allowed" on the most permissive setting.

**This is not hypothetical. The same sentinel bit three times in one day:**

| Where | Effect |
|---|---|
| `IndexCap.within_cap?` (#1486) | `rank < -1` → **nothing indexed at all**, on the plan meant to lift the cap. This is what the e2e overrides set. |
| Plugin `parsePlanState` (Engram-obsidian#481) | Needed an explicit `>= 0` guard, or a Pro user is told none of their notes are searchable |
| `numeric_limit/2` | About to hand it to a brand-new client |

It's the same class as `attachments_text_only`, whose inverted polarity silently blocked self-host attachments — the failure the `LimitKeys` moduledoc now warns about at length.

Fixing it at the **serialization boundary** means clients stop needing to know at all. That's the root cause; the three call-site guards were symptoms.

`max_file_bytes` and `attachment_bytes_cap` flow through the same helper. In practice they're unaffected — the plugin already guards with `> 0` — but they now get the correct value rather than one that happens to be defused downstream.

## Verification

- `mix test` → **1 property, 4859 tests, 0 failures** (9 excluded)
- `mix dialyzer` → `Total errors: 6, Skipped: 6, Unnecessary Skips: 0`, passed
- `mix credo --strict` → no issues
- New tests: free carries the real 2,000 cap; a `-1` override serializes to `nil` rather than a literal negative cap; the existing unlimited-path test now asserts the new field too

## Merge order

Merge before engram-app/Engram-obsidian#481. That PR is harmless without this — the field is absent, so the hint stays silent — but it does nothing until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTroEXqCfFBz6YyEtH5bEC