### PR TITLE
fix(indexing): move the index-cap sweeps off the request path

### DIFF
--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -7,6 +7,7 @@ defmodule Engram.Billing do
   """
 
   import Ecto.Query
+
   alias Engram.Billing.EntitlementCache
   alias Engram.Billing.LimitKeys
   alias Engram.Billing.PlanCache
@@ -15,6 +16,7 @@ defmodule Engram.Billing do
   alias Engram.Logger.Metadata
   alias Engram.Paddle.Client
   alias Engram.Repo
+  alias Engram.Workers.IndexCapMaintenance
 
   require Logger
 
@@ -718,7 +720,14 @@ defmodule Engram.Billing do
               # Nulls both index hashes; ReconcileEmbeddings rebuilds the notes
               # sparse-only on its next tick and the dense points go with the
               # replace. See IndexCap.revoke_dense_index/1.
-              _ = Engram.Indexing.IndexCap.revoke_dense_index(user.id)
+              #
+              # ENQUEUED, not inline. This is an unbounded UPDATE over the
+              # user's whole vault, and we are inside a Paddle webhook request:
+              # a 60k-note account made the delivery outlive Paddle's timeout,
+              # so a cancellation that COMMITTED was recorded as a failed
+              # delivery and retried. Only fires on a real downgrade — `user`
+              # is nil unless prev_tier was paid.
+              _ = IndexCapMaintenance.enqueue(user.id, :revoke_dense)
             end
 
             {:ok, updated}

--- a/lib/engram/workers/delete_note_index.ex
+++ b/lib/engram/workers/delete_note_index.ex
@@ -11,9 +11,9 @@ defmodule Engram.Workers.DeleteNoteIndex do
   use Oban.Worker, queue: :indexing, max_attempts: 3
 
   alias Engram.Indexing
-  alias Engram.Indexing.IndexCap
   alias Engram.Links
   alias Engram.Notes.Enqueue
+  alias Engram.Workers.IndexCapMaintenance
   alias Engram.Workers.RebindNoteLinks
 
   @impl Oban.Worker
@@ -60,7 +60,12 @@ defmodule Engram.Workers.DeleteNoteIndex do
         # Deleting a note frees an indexed-note slot. The note that inherits it
         # already carries a stamped embed_hash from the pass that skipped it, so
         # nothing would ever re-index it. No-op for uncapped tiers.
-        _ = IndexCap.backfill_freed_slots(user_id)
+        #
+        # ENQUEUED, not inline. The sweep is whole-vault, and this worker runs
+        # once per DELETED note — a 5,000-note folder delete ran it 5,000 times
+        # over the same rows. The job is unique per (user, kind) over a 2-minute
+        # window, so a delete burst collapses to one sweep after it settles.
+        _ = IndexCapMaintenance.enqueue(user_id, :backfill_slots)
 
         :ok
 

--- a/lib/engram/workers/index_cap_maintenance.ex
+++ b/lib/engram/workers/index_cap_maintenance.ex
@@ -1,0 +1,58 @@
+defmodule Engram.Workers.IndexCapMaintenance do
+  @moduledoc """
+  Moves the two bulk index-cap sweeps off the request path.
+
+  Both were previously inline, and both are O(the user's whole vault):
+
+    * `:revoke_dense` — after a downgrade, drop every dense vector the user is
+      no longer entitled to. Ran synchronously inside the Paddle webhook, where
+      a 60k-note UPDATE can outlive the webhook timeout and get the delivery
+      recorded as failed even though the cancellation committed.
+
+    * `:backfill_slots` — after a delete frees a capped slot, re-open the note
+      that inherits it. Ran once per DELETED note, so a 5,000-note folder
+      delete ran it 5,000 times over the same rows.
+
+  `unique` collapses a burst to one job per user per kind: the work is
+  idempotent and whole-vault, so running it once after the burst is both
+  cheaper and more correct than running it per row. `states: :incomplete` means
+  a *completed* job does not block a later one, so a second delete an hour on
+  still gets its backfill.
+  """
+
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 3,
+    unique: [keys: [:user_id, :kind], period: 120, states: :incomplete]
+
+  alias Engram.Indexing.IndexCap
+
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.minutes(10)
+
+  @doc """
+  Enqueue a sweep. Never raises — the callers are a webhook handler and a
+  delete worker, and neither should fail because a follow-up sweep could not
+  be queued.
+  """
+  @spec enqueue(Ecto.UUID.t(), :revoke_dense | :backfill_slots) :: :ok
+  def enqueue(user_id, kind)
+      when is_binary(user_id) and kind in [:revoke_dense, :backfill_slots] do
+    %{user_id: user_id, kind: Atom.to_string(kind)}
+    |> new()
+    |> Oban.insert()
+    |> case do
+      {:ok, _job} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "kind" => "revoke_dense"}}) do
+    IndexCap.revoke_dense_index(user_id)
+  end
+
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "kind" => "backfill_slots"}}) do
+    IndexCap.backfill_freed_slots(user_id)
+  end
+end

--- a/test/engram/workers/index_cap_maintenance_test.exs
+++ b/test/engram/workers/index_cap_maintenance_test.exs
@@ -1,0 +1,127 @@
+defmodule Engram.Workers.IndexCapMaintenanceTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Billing.OverrideCache
+  alias Engram.Billing.UserLimitOverride
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Engram.Workers.IndexCapMaintenance
+
+  defp cap!(user, n) do
+    Repo.insert!(%UserLimitOverride{
+      user_id: user.id,
+      key: "indexed_notes_cap",
+      value: %{"v" => n},
+      reason: "test",
+      set_by: "test"
+    })
+
+    OverrideCache.evict(user.id)
+    :ok
+  end
+
+  describe "enqueue/2" do
+    test "a burst of deletes collapses to ONE sweep per user" do
+      # The whole point of moving this off the delete path: the sweep is
+      # whole-vault, so running it once per deleted note re-scanned the same
+      # rows 5,000 times for a 5,000-note folder delete.
+      user = insert(:user)
+
+      for _ <- 1..25, do: :ok = IndexCapMaintenance.enqueue(user.id, :backfill_slots)
+
+      assert [_only_one] = all_enqueued(worker: IndexCapMaintenance)
+    end
+
+    test "the two kinds do not collapse into each other" do
+      user = insert(:user)
+
+      :ok = IndexCapMaintenance.enqueue(user.id, :backfill_slots)
+      :ok = IndexCapMaintenance.enqueue(user.id, :revoke_dense)
+
+      assert length(all_enqueued(worker: IndexCapMaintenance)) == 2
+    end
+
+    test "two users do not collapse into each other" do
+      a = insert(:user)
+      b = insert(:user)
+
+      :ok = IndexCapMaintenance.enqueue(a.id, :revoke_dense)
+      :ok = IndexCapMaintenance.enqueue(b.id, :revoke_dense)
+
+      assert length(all_enqueued(worker: IndexCapMaintenance)) == 2
+    end
+  end
+
+  describe "perform/1" do
+    test "revoke_dense nulls both index hashes for the user's live notes" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+
+      note =
+        insert(:note,
+          user: user,
+          vault: vault,
+          content_hash: "abc",
+          embed_hash: "abc",
+          dense_indexed_hash: "abc"
+        )
+
+      assert :ok = perform_job(IndexCapMaintenance, %{user_id: user.id, kind: "revoke_dense"})
+
+      assert %Note{embed_hash: nil, dense_indexed_hash: nil} =
+               Repo.get!(Note, note.id, skip_tenant_check: true)
+    end
+
+    test "revoke_dense does not touch another user's notes" do
+      # Both sweeps are skip_tenant_check bulk update_alls, so the user_id
+      # predicate is the ONLY thing keeping them in one tenant.
+      user = insert(:user)
+      other = insert(:user)
+
+      mine =
+        insert(:note, user: user, content_hash: "a", embed_hash: "a", dense_indexed_hash: "a")
+
+      theirs =
+        insert(:note, user: other, content_hash: "b", embed_hash: "b", dense_indexed_hash: "b")
+
+      assert :ok = perform_job(IndexCapMaintenance, %{user_id: user.id, kind: "revoke_dense"})
+
+      assert %Note{dense_indexed_hash: nil} = Repo.get!(Note, mine.id, skip_tenant_check: true)
+      assert %Note{dense_indexed_hash: "b"} = Repo.get!(Note, theirs.id, skip_tenant_check: true)
+    end
+
+    test "backfill_slots re-opens an in-cap note that a delete freed a slot for" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      :ok = cap!(user, 5)
+
+      note =
+        insert(:note,
+          user: user,
+          vault: vault,
+          content_hash: "abc",
+          embed_hash: "abc",
+          created_at: ~U[2026-01-01 00:00:00Z]
+        )
+
+      assert :ok = perform_job(IndexCapMaintenance, %{user_id: user.id, kind: "backfill_slots"})
+
+      # Nulling embed_hash is what puts it back in the reconcile cron's query.
+      assert %Note{embed_hash: nil} = Repo.get!(Note, note.id, skip_tenant_check: true)
+    end
+
+    test "backfill_slots does not touch another user's notes" do
+      user = insert(:user)
+      other = insert(:user)
+      :ok = cap!(user, 5)
+      :ok = cap!(other, 5)
+
+      theirs = insert(:note, user: other, content_hash: "b", embed_hash: "b")
+
+      assert :ok = perform_job(IndexCapMaintenance, %{user_id: user.id, kind: "backfill_slots"})
+
+      assert %Note{embed_hash: "b"} = Repo.get!(Note, theirs.id, skip_tenant_check: true)
+    end
+  end
+end


### PR DESCRIPTION
Both index-cap sweeps were inline, and both are O(the user's whole vault).

`revoke_dense_index/1` ran synchronously inside the Paddle webhook. A 60k-note
account made that a 60k-row UPDATE on the request, which can outlive Paddle's
webhook timeout — so a cancellation that COMMITTED got recorded as a failed
delivery and retried.

`backfill_freed_slots/1` ran once per DELETED note, over the same whole-vault
rows each time. A 5,000-note folder delete ran it 5,000 times.

Both now enqueue `IndexCapMaintenance`, unique per (user, kind) over a
2-minute window: the work is idempotent and whole-vault, so running it once
after a burst is both cheaper and more correct than per-row. `states:
:incomplete` keeps a COMPLETED job from blocking a later one, so a second
delete an hour on still gets its backfill.

`enqueue/2` never raises. The callers are a webhook handler and a delete
worker; neither should fail because a follow-up sweep could not be queued.

Tests cover the collapse (25 enqueues -> 1 job), that the two kinds and two
users do not collapse into each other, and cross-tenant isolation on both
sweeps — they are `skip_tenant_check` bulk `update_all`s, so the `user_id`
predicate is the only thing keeping them in one tenant, and nothing pinned
that before.

Closes #1508
Refs #1509

Note #1509 is only partly addressed: this removes the per-delete repetition,
but `backfill_freed_slots/1` still cannot distinguish "skipped for the cap"
from "legitimately parses to zero chunks", so an empty note still costs one
wasted re-index per delete burst. That needs a stored marker rather than
inferring intent from an absent chunk row.

---

Local: 4899 tests / 0 failures, credo clean, dialyzer passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTroEXqCfFBz6YyEtH5bEC