### PR TITLE
test(e2e): frontmatter round-trip between Obsidian and the web SPA

### DIFF
--- a/e2e/helpers/web_spa.py
+++ b/e2e/helpers/web_spa.py
@@ -103,6 +103,46 @@ class WebSpaPeer:
     async def read(self) -> str:
         return await self._editor().inner_text()
 
+    # --- Properties widget (frontmatter) -----------------------------------
+    #
+    # The SPA edits frontmatter as TYPED PROPERTIES against the doc's
+    # `frontmatter` / `frontmatter_order` / `frontmatter_types` shared types,
+    # not as YAML text in the CodeMirror editor (which is body-only). So a
+    # frontmatter round-trip test cannot go through `append`/`read` — it has to
+    # drive this widget, the way a user does.
+
+    def properties_locator(self):
+        """The properties section, for auto-retrying `expect(...)` asserts."""
+        return self._page.get_by_test_id("note-properties")
+
+    def property_value_locator(self, key: str):
+        """The VALUE field of property `key`. `aria-label` is `"<key> value"`
+        (property-fields.tsx), which is stable across the type variants."""
+        return self._page.get_by_test_id(f"property-row-{key}").get_by_label(f"{key} value")
+
+    async def add_property(self, key: str, value: str) -> None:
+        """Add a property through the real UI flow: Add property -> name ->
+        Enter moves to the value -> Enter commits.
+
+        Enter on the KEY field deliberately does not commit (it focuses the
+        value), so this mirrors the widget's own keyboard contract rather than
+        assuming a single submit.
+        """
+        await self._page.get_by_label("Add property").click()
+        await self._page.get_by_placeholder("Property name").fill(key)
+        await self._page.keyboard.press("Enter")
+        await self._page.get_by_placeholder("Value").fill(value)
+        await self._page.keyboard.press("Enter")
+
+    async def set_property(self, key: str, value: str) -> None:
+        """Overwrite an EXISTING property's value and commit it (blur)."""
+        field = self.property_value_locator(key)
+        await field.fill(value)
+        await field.blur()
+
+    async def remove_property(self, key: str) -> None:
+        await self._page.get_by_label(f"Remove {key}").click()
+
     async def stop(self) -> None:
         try:
             if self._ctx is not None:

--- a/e2e/tests/crdt/test_frontmatter_bidirectional.py
+++ b/e2e/tests/crdt/test_frontmatter_bidirectional.py
@@ -31,6 +31,7 @@ Coverage map, deliberately both directions and both bindings:
 from __future__ import annotations
 
 import os
+import time
 
 import pytest
 from playwright.async_api import expect
@@ -72,6 +73,50 @@ async def _open_in_obsidian(cdp, path: str) -> None:
         await_promise=True,
     )
     assert opened == path, f"failed to live-bind {path} in Obsidian: {opened!r}"
+
+
+async def _close_all_in_obsidian(cdp) -> None:
+    """Detach every markdown leaf — the user's "close the file".
+
+    This is the transition that releases the live binding. `detach()` is what
+    Obsidian's own close button calls, so it fires the same teardown (and the
+    same final save) the reported repro goes through."""
+    left = await cdp.evaluate(
+        """
+        (async () => {
+          app.workspace.getLeavesOfType("markdown").forEach((l) => l.detach());
+          return app.workspace.getLeavesOfType("markdown").length;
+        })()
+        """,
+        await_promise=True,
+    )
+    assert left == 0, f"markdown leaves still open after detach: {left!r}"
+
+
+async def _type_into_open_editor(cdp, path: str, text: str) -> None:
+    """Set the OPEN editor's buffer, which is what typing produces.
+
+    Deliberately not `write_note`: a disk write goes down `routeModify`, the
+    path that already works. The reported bug needs the edit to originate in
+    the bound CodeMirror buffer. `editor.setValue` drives the same CM6
+    transaction pipeline a keystroke does, so `classifyEditSpan` sees it.
+
+    The frontmatter is part of the editor document even though the properties
+    widget renders it as a decoration, so the fenced block belongs in `text`."""
+    got = await cdp.evaluate(
+        """
+        (async () => {
+          const ed = app.workspace.activeEditor;
+          if (!ed || ed.file?.path !== %r) return "not-active";
+          ed.editor.setValue(%r);
+          await app.workspace.activeEditor.save?.();
+          return ed.editor.getValue();
+        })()
+        """
+        % (path, text),
+        await_promise=True,
+    )
+    assert got == text, f"editor buffer did not take the edit for {path}: {got!r}"
 
 
 @pytest.mark.asyncio
@@ -184,3 +229,58 @@ async def test_unparseable_frontmatter_does_not_delete_existing_keys(
         "unparseable YAML deleted the good frontmatter keys; "
         f"file is now:\n{final!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_typed_frontmatter_survives_close_and_reopen(
+    vault_a, cdp_a, api_sync, web, sync_vault_id
+):
+    """[5] Reported 2026-08-29, still failing on 1.24.4-pr.482.g206c5f8.
+
+    The distinguishing shape of this one: the frontmatter DOES reach the web
+    app and stays there, so the server-side Y.Doc holds it. Only the local file
+    loses it, and only across a close/reopen. That rules out ingest (tests 1-3
+    prove the doc receives the keys) and points at the doc -> disk projection
+    that runs when the live binding is released.
+
+    Every earlier test writes frontmatter with `write_note`. That is the disk
+    path, which was never the broken one. This test originates the edit in the
+    bound editor buffer, which is what the user actually does, and is the only
+    way to put the binding teardown on the critical path.
+    """
+    path = "E2E/Crdt/FmCloseReopen.md"
+    write_note(vault_a, path, "---\nkeep: me\n---\n\nbody v1\n")
+    note_id = _note_id(api_sync, path)
+    await _open_in_obsidian(cdp_a, path)
+
+    await web.open_note(note_id, sync_vault_id)
+    await expect(web.property_value_locator("keep")).to_have_value("me", timeout=MS)
+
+    # Type a second key into the OPEN note.
+    await _type_into_open_editor(
+        cdp_a, path, "---\nkeep: me\nstatus: published\n---\n\nbody v1\n"
+    )
+
+    # It reaches the web app. The user confirms this half works, and asserting
+    # it here is what makes the failure below unambiguous: the doc HAS the key
+    # at the moment the file is closed.
+    await expect(web.property_value_locator("status")).to_have_value("published", timeout=MS)
+
+    await _close_all_in_obsidian(cdp_a)
+    await _open_in_obsidian(cdp_a, path)
+
+    # Poll rather than read once: the loss lands on a flush that follows the
+    # unbind, so a single read right after reopen can pass before the damage.
+    # Fail the moment a key disappears, and require it to still be there at the
+    # end of the settle window.
+    deadline = time.monotonic() + CRDT_TIMEOUT
+    while time.monotonic() < deadline:
+        disk = read_note(vault_a, path) or ""
+        assert "keep:" in disk and "status:" in disk, (
+            "frontmatter vanished from disk after close/reopen while the web app "
+            f"still shows it; file is now:\n{disk!r}"
+        )
+        time.sleep(0.5)
+
+    # And the server still agrees, so this was never a delete the user made.
+    await expect(web.property_value_locator("status")).to_have_value("published", timeout=MS)

--- a/e2e/tests/crdt/test_frontmatter_bidirectional.py
+++ b/e2e/tests/crdt/test_frontmatter_bidirectional.py
@@ -1,0 +1,186 @@
+"""Frontmatter round-trip between Obsidian and the web SPA (P0).
+
+Reported 2026-08-29: with a note open in Obsidian, body edits synced instantly
+while frontmatter did not move at all, and closing/reopening the note DELETED
+the frontmatter rather than repairing it.
+
+Frontmatter is not stored in the body Y.Text. It lives in four separate shared
+types (`frontmatter` values, `frontmatter_order`, `frontmatter_raw`,
+`frontmatter_types`), and the three clients implement different subsets:
+
+  SPA     reads AND writes them, observed live (properties widget)
+  server  reads them, projects back to plaintext
+  plugin  WRITES them only, via the disk-save path. Observes nothing.
+
+So every existing test passes: the whole CRDT suite drives body text, and the
+one place frontmatter is asserted (test_100) is a single-device lineage check.
+Nothing exercises frontmatter ACROSS two interfaces, which is exactly where the
+plugin's missing half lives.
+
+These four are the reproduction. They are expected to fail on the current
+build; that is the point of landing them first.
+
+Coverage map, deliberately both directions and both bindings:
+
+  1. obsidian -> web, note CLOSED in Obsidian   (disk-save path, should pass)
+  2. obsidian -> web, note OPEN in Obsidian     (live path drops FM keystrokes)
+  3. web -> obsidian, note OPEN in Obsidian     (no inbound listener at all)
+  4. bad YAML must not delete good keys         (the data-loss path)
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from playwright.async_api import expect
+
+from helpers.latency import DELIVERY_TIMEOUT
+from helpers.vault import read_note, wait_for_content, write_note
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("E2E_ENABLE_CRDT") != "true",
+    reason="CRDT-only suite — set E2E_ENABLE_CRDT=true with a CRDT_ENABLED backend",
+)
+
+CRDT_TIMEOUT = DELIVERY_TIMEOUT
+MS = CRDT_TIMEOUT * 1_000
+
+
+def _note_id(api_sync, path: str) -> str:
+    note = api_sync.wait_for_note(path, timeout=CRDT_TIMEOUT)
+    inner = note.get("note", note) if isinstance(note, dict) else {}
+    nid = inner.get("id") or inner.get("note_id") or inner.get("uuid")
+    assert nid, f"no note id in GET /notes/{path}: {note}"
+    return str(nid)
+
+
+async def _open_in_obsidian(cdp, path: str) -> None:
+    """Live-bind the note in Obsidian's editor (same incantation as
+    test_live_bound_both_ends). Binding is what routes edits through the CM
+    plugin instead of the disk-save path, and it is the reported trigger."""
+    opened = await cdp.evaluate(
+        """
+        (async () => {
+          const f = app.vault.getAbstractFileByPath(%r);
+          if (!f) return "no-file";
+          await app.workspace.getLeaf(false).openFile(f);
+          return app.workspace.activeEditor?.file?.path ?? "no-active";
+        })()
+        """
+        % path,
+        await_promise=True,
+    )
+    assert opened == path, f"failed to live-bind {path} in Obsidian: {opened!r}"
+
+
+@pytest.mark.asyncio
+async def test_obsidian_frontmatter_reaches_web_when_note_is_closed(
+    vault_a, api_sync, web, sync_vault_id
+):
+    """[1] Obsidian -> web with the note CLOSED. The disk-save path
+    (`routeModify` -> `seedContentInto`) owns this, so it is the control: if
+    this fails, frontmatter sync is broken everywhere and not just live."""
+    path = "E2E/Crdt/FmClosed.md"
+    write_note(vault_a, path, "---\nstatus: draft\n---\n\nbody v1\n")
+    note_id = _note_id(api_sync, path)
+
+    await web.open_note(note_id, sync_vault_id)
+    await expect(web.property_value_locator("status")).to_have_value("draft", timeout=MS)
+
+    # Change the value from Obsidian while the note is not open there.
+    write_note(vault_a, path, "---\nstatus: published\n---\n\nbody v1\n")
+    await expect(web.property_value_locator("status")).to_have_value("published", timeout=MS)
+
+
+@pytest.mark.asyncio
+async def test_obsidian_frontmatter_reaches_web_when_note_is_open(
+    vault_a, cdp_a, api_sync, web, sync_vault_id
+):
+    """[2] Obsidian -> web with the note OPEN in Obsidian.
+
+    `classifyEditSpan` returns "frontmatter" for a keystroke inside the block
+    and the live binding drops it, on the premise that another mechanism owns
+    frontmatter. Whether the disk-save path still catches it decides if this is
+    a latency bug or a loss bug — this test is what tells them apart.
+    """
+    path = "E2E/Crdt/FmOpen.md"
+    write_note(vault_a, path, "---\nstatus: draft\n---\n\nbody v1\n")
+    note_id = _note_id(api_sync, path)
+    await _open_in_obsidian(cdp_a, path)
+
+    await web.open_note(note_id, sync_vault_id)
+    await expect(web.property_value_locator("status")).to_have_value("draft", timeout=MS)
+
+    write_note(vault_a, path, "---\nstatus: published\n---\n\nbody v1\n")
+    await expect(web.property_value_locator("status")).to_have_value("published", timeout=MS)
+
+
+@pytest.mark.asyncio
+async def test_web_property_reaches_obsidian_with_note_open(
+    vault_b, cdp_b, api_sync, web, sync_vault_id
+):
+    """[3] web -> obsidian with the note OPEN in Obsidian. The reported bug.
+
+    Nothing in the plugin observes the frontmatter shared types (the live
+    binding observes `text` only, at live-binding.ts:374 and :402), and
+    `wiring.ts:345` skips the disk flush for a bound path because "a remote
+    merge just painted in" — which is true of the body and false of the
+    frontmatter. So a property set in the SPA has no route to an open note.
+    """
+    path = "E2E/Crdt/FmWebToObsidian.md"
+    api_sync.create_note(path, "---\nstatus: draft\n---\n\nbase line.\n")
+    await cdp_b.trigger_full_sync()
+    wait_for_content(vault_b, path, "base line", timeout=CRDT_TIMEOUT)
+
+    await _open_in_obsidian(cdp_b, path)
+
+    note_id = _note_id(api_sync, path)
+    await web.open_note(note_id, sync_vault_id)
+    await web.set_property("status", "published")
+
+    disk = wait_for_content(vault_b, path, "published", timeout=CRDT_TIMEOUT)
+    assert "base line" in disk, f"body lost while delivering frontmatter: {disk!r}"
+
+
+@pytest.mark.asyncio
+async def test_unparseable_frontmatter_does_not_delete_existing_keys(
+    vault_a, api_sync, web, sync_vault_id
+):
+    """[4] The data-loss path, and the reason this is a P0 rather than a sync bug.
+
+    `seedContentInto` collapses two different facts into one:
+
+        const parsed = fmBlock === null ? null : parseFrontmatter(fmBlock);
+        const order  = parsed ? parsed.order  : [];
+        const values = parsed ? parsed.values : {};
+
+    `parsed` is null both when the note HAS NO frontmatter (deleting every key
+    is correct) and when it HAS frontmatter that did not parse (deleting every
+    key destroys the user's properties). `applyFrontmatterInto` then removes
+    every key absent from `values`, the projection emits a body-only note, and
+    the flush writes that over the file on every device.
+
+    Half-typed YAML is invalid constantly, so the trigger is ordinary use. The
+    server does not behave this way — `parse_for_ingest` keeps the good keys and
+    preserves the bad one verbatim in the raws map.
+    """
+    path = "E2E/Crdt/FmBadYaml.md"
+    write_note(vault_a, path, "---\nkeep: me\nalso: here\n---\n\nbody v1\n")
+    note_id = _note_id(api_sync, path)
+
+    await web.open_note(note_id, sync_vault_id)
+    await expect(web.property_value_locator("keep")).to_have_value("me", timeout=MS)
+
+    # A transiently-unparseable block: an unclosed flow sequence. This is what
+    # sits on disk for as long as it takes to type the closing bracket.
+    write_note(vault_a, path, "---\nkeep: me\nalso: here\nbad: [unclosed\n---\n\nbody v1\n")
+
+    # The good keys must survive. Asserting on DISK: the projection is what
+    # overwrites the file, so this is where the loss becomes permanent.
+    wait_for_content(vault_a, path, "body v1", timeout=CRDT_TIMEOUT)
+    final = read_note(vault_a, path) or ""
+    assert "keep:" in final and "also:" in final, (
+        "unparseable YAML deleted the good frontmatter keys; "
+        f"file is now:\n{final!r}"
+    )

--- a/e2e/tests/crdt/test_room_cap_pressure.py
+++ b/e2e/tests/crdt/test_room_cap_pressure.py
@@ -1,0 +1,124 @@
+"""Convergence under resident-room pressure.
+
+The existing CRDT suite converges one or two notes at a time, so it never puts
+more concurrently-diverged cold notes in flight than `CRDT_MAX_RESIDENT_ROOMS`
+(3 in `ci/compose.yml`). A 1,192-note vault on 2026-08-29 did, and stopped
+converging in BOTH directions: 1,125 distinct doc_ids requested a room against a
+cap of 64, residency overshot to 196 with a backlog of 116, and the LRU evicted
+16 rooms at a time while clients were still handshaking them.
+
+The client has an escape hatch for exactly this — `convergeColdNoteRoomFree`
+(sync.ts) reads `crdt_doc_state` and merges without a room. It is gated on
+`!hasUndeliveredOps(noteId)`, which is TRUE for any note whose provider is still
+holding work. So a note that fails to deliver through an evicted room keeps its
+undelivered ops, stays locked out of the room-free path, and asks for another
+room. That is a closed loop, and it is self-reinforcing under pressure.
+
+These tests put more cold notes in flight than the cap and assert every one of
+them lands. They are deliberately about the FLEET, not about any single note:
+one note at a time converges fine today, which is why this class survived.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from helpers.latency import DELIVERY_TIMEOUT
+from helpers.vault import wait_for_content, write_note
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("E2E_ENABLE_CRDT") != "true",
+    reason="CRDT-only suite — set E2E_ENABLE_CRDT=true with a CRDT_ENABLED backend",
+)
+
+CRDT_TIMEOUT = DELIVERY_TIMEOUT
+
+# Ratio to `CRDT_MAX_RESIDENT_ROOMS` (3 in ci/compose.yml) matters more than the
+# absolute count: the 2026-08-29 vault ran ~18x the cap (1,192 notes / 64) and
+# overshot residency to 196 with a 116 backlog, so allocation was outrunning the
+# drain. 12 (4x) was tried first and both tests passed, which is why this is 54.
+FLEET = 54
+
+
+def _fleet_paths(tag: str) -> list[str]:
+    return [f"E2E/Crdt/RoomCap/{tag}{i:02d}.md" for i in range(FLEET)]
+
+
+def _establish_fleet(vault_a, vault_b, api_sync, paths: list[str]) -> None:
+    """Create every path on A and wait until all of them exist on B.
+
+    Written as write-all-then-wait-all rather than per-note establish: the point
+    is to get FLEET notes into a shared base cheaply, and serialising a delivery
+    wait per note triples the setup cost for no extra coverage.
+    """
+    for i, path in enumerate(paths):
+        write_note(vault_a, path, f"base {i}\n")
+    for i, path in enumerate(paths):
+        api_sync.wait_for_note_content(path, f"base {i}", timeout=CRDT_TIMEOUT)
+        wait_for_content(vault_b, path, f"base {i}", timeout=CRDT_TIMEOUT)
+
+
+@pytest.mark.asyncio
+async def test_cold_fleet_larger_than_room_cap_all_converge(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync
+):
+    """[P1] FLEET cold notes diverge at once, FLEET > the resident-room cap.
+    EVERY one must reach B.
+
+    No note is open in an editor, so each one is a cold convergence. If the
+    room-free path is doing its job the cap is irrelevant; if each note needs a
+    room, the cap is exceeded by 4x and the LRU starts evicting rooms that
+    clients are still using.
+
+    Asserts on the whole fleet and reports which paths were lost — a single-note
+    assertion would pass on a partial convergence, which is exactly the shape
+    that shipped.
+    """
+    paths = _fleet_paths("cold")
+    _establish_fleet(vault_a, vault_b, api_sync, paths)
+
+    for i, path in enumerate(paths):
+        write_note(vault_a, path, f"base {i}\nCOLD_FLEET_{i}\n")
+
+    missing = []
+    for i, path in enumerate(paths):
+        try:
+            content = wait_for_content(vault_b, path, f"COLD_FLEET_{i}", timeout=CRDT_TIMEOUT)
+            if f"base {i}" not in content:
+                missing.append(f"{path} (base lost)")
+        except Exception as exc:  # noqa: BLE001 — collect, do not abort the sweep
+            missing.append(f"{path} ({type(exc).__name__})")
+
+    assert not missing, (
+        f"{len(missing)}/{FLEET} cold notes never converged on B under room-cap "
+        f"pressure: {missing}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edits_still_send_after_a_cold_fleet_burst(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync
+):
+    """[P1] After a fleet burst has exhausted the room cap, A can still SEND.
+
+    The 2026-08-29 report was that Obsidian went inert in BOTH directions, not
+    just that it stopped receiving. If undelivered ops pin providers open and the
+    room path is saturated, the send half dies too — so this asserts the sender
+    recovers once the burst has settled, on a note that took part in the burst.
+    """
+    paths = _fleet_paths("send")
+    _establish_fleet(vault_a, vault_b, api_sync, paths)
+
+    for i, path in enumerate(paths):
+        write_note(vault_a, path, f"base {i}\nBURST_{i}\n")
+
+    # Let the burst settle as far as it is going to.
+    target = paths[0]
+    wait_for_content(vault_b, target, "BURST_0", timeout=CRDT_TIMEOUT)
+
+    # A fresh edit, AFTER the pressure event, on a note that was part of it.
+    write_note(vault_a, target, "base 0\nBURST_0\nAFTER_THE_BURST\n")
+    content = wait_for_content(vault_b, target, "AFTER_THE_BURST", timeout=CRDT_TIMEOUT)
+    assert "BURST_0" in content, f"burst edit lost by the follow-up send: {content!r}"


### PR DESCRIPTION
Reproduction suite for engram-app/Engram-obsidian#483. Landed before the fixes,
as the bug report asked.

## Why nothing caught this

The whole CRDT e2e suite drives body text. The one place frontmatter is asserted
(`test_100_frontmatter_echo_single_lineage`) is a single-device lineage check.
Nothing exercised frontmatter across two interfaces, which is exactly where the
plugin's missing half lived.

## The four cases

Both directions and both bindings, because the binding is the variable that
decides the outcome:

| case | unfixed plugin |
|---|---|
| closed, obsidian -> web | PASSED (disk-save path, the control) |
| open, obsidian -> web | FAILED |
| open, web -> obsidian | FAILED |
| bad YAML keeps good keys | PASSED (weak oracle, see below) |

That result corrected the diagnosis. Outbound from an open note was believed to
be merely slow, waiting on the file save. It is never delivered at all:
`handleModify` skips the disk-driven CRDT route while bound (`sync.ts:3594`) and
the live binding drops frontmatter keystrokes (`classifyEditSpan` ->
`"frontmatter"`), so there is no route between them.

Against the fixes on Engram-obsidian#482 all four pass, and the run drops from
332s to 92s because convergence happens instead of timing out.

## Weak oracle, kept deliberately

The bad-YAML test passes on the unfixed plugin: single-device, nothing triggers
a flush, so the deletion happens in the doc and never reaches disk. It is kept
for the shape, not the proof. The real coverage for that defect is
`tests/crdt-note-seed-frontmatter.test.ts` in the plugin, where it is red before
the fix.

## Harness

Driving the SPA needs the properties widget, not the CodeMirror editor — that
editor is body-only, so frontmatter cannot be typed into it. `WebSpaPeer` gains
`add_property` / `set_property` / `remove_property` / `property_value_locator`.

Locally these need `xvfb-run` + `E2E_WEB_HEADED=1`: headless Chromium on the dev
box produces no rAF frames, so every Playwright click times out at sign-in
(`docs/context/headless-chromium-no-raf-playwright.md`). CI runs them headless
without issue.

## Also included

`test_room_cap_pressure.py`, from chasing an earlier theory that convergence
collapses when concurrently-diverged cold notes exceed
`CRDT_MAX_RESIDENT_ROOMS`. It does not — 54 cold notes against a cap of 3 all
converge — so these reproduce nothing. Kept because fleet convergence under cap
pressure had no coverage and every existing test converges one or two notes at a
time. Happy to drop them if that is not wanted.

Refs engram-app/Engram-obsidian#483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp
