### PR TITLE
fix(release-notes): scope SCHEMA-IMPACT PRs to the actual release range

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,7 +74,13 @@ jobs:
           PR=$(jq -r '.number' <<<"$RP_PR")
           BASE=$(git tag -l 'release-v*' --sort=-v:refname | head -1)
           [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | head -1)
-          IMPACT=$(bash scripts/generate_schema_impact_notes.sh "$BASE" HEAD || true)
+          # No `|| true` here: the script's own `::error::` + exit 1 on a
+          # gh/git failure is meant to fail CI loud (see its header
+          # comment) rather than silently fall through to "no schema
+          # impact" — that would be the exact failure mode the script
+          # exists to prevent. deploy-prod.yml's caller doesn't swallow it
+          # either; this one shouldn't diverge.
+          IMPACT=$(bash scripts/generate_schema_impact_notes.sh "$BASE" HEAD)
           [ -n "$IMPACT" ] || { echo "no schema impact"; exit 0; }
           CUR=$(gh pr view "$PR" --json body -q .body)
           gh pr edit "$PR" --body "$(printf '%s\n\n%s' "$IMPACT" "$CUR")"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2933,6 +2933,14 @@ jobs:
         # about. Cheap to run here, expensive to discover later.
         run: bash test/scripts/discord_release_notes_test.sh
 
+      - name: SCHEMA-IMPACT notes self-check
+        # Guards scripts/generate_schema_impact_notes.sh (phase/* filtering +
+        # BASE..HEAD range scoping). Its only callers are release-please.yml
+        # and deploy-prod.yml, so a regression is invisible until a release
+        # page either omits a real migration warning or invents one (this
+        # script previously had zero CI coverage at all).
+        run: bash test/scripts/generate_schema_impact_notes_test.sh
+
       - name: BEAM scheduler clamp self-check
         # Guards rel/env.sh's scheduler sizing. It ran in prod for an unknown
         # period doing NOTHING: written for cgroup quotas, but Fargate enforces

--- a/scripts/generate_schema_impact_notes.sh
+++ b/scripts/generate_schema_impact_notes.sh
@@ -26,9 +26,16 @@ else
   # SCHEMA-IMPACT block for a release that actually changes the schema —
   # defeating the entire feature. Surface gh failures via ::error:: so CI
   # fails fast instead of producing a misleading release page.
+  # --sort updated --order desc: the range filter below is now an
+  # INTERSECTION with git log, so a phase-labeled PR missing from this
+  # result silently drops the whole SCHEMA-IMPACT block (git log has no
+  # way to independently notice a PR that gh search failed to return).
+  # `--limit 500` only stays safe if this call is guaranteed newest-first;
+  # make that explicit rather than relying on gh's default sort.
   if ! prs=$(gh search prs --repo "${GITHUB_REPOSITORY:-engram-app/Engram}" \
           --merged \
           --base main \
+          --sort updated --order desc \
           --json number,labels,title \
           --limit 500 2>&1); then
     echo "::error::generate_schema_impact_notes: gh search prs failed — cannot determine phase-labeled PRs in release range. Output: $prs" >&2

--- a/scripts/generate_schema_impact_notes.sh
+++ b/scripts/generate_schema_impact_notes.sh
@@ -11,6 +11,7 @@
 # Test mode:
 #   GH_OUTPUT_OVERRIDE=<json>   — pre-canned PR list (skip gh call)
 #   IRREVERSIBLE_OVERRIDE=true|false — skip git-grep for # rollback-irreversible
+#   MERGED_PR_NUMBERS_OVERRIDE=<space-separated PR numbers> — skip git log range walk
 set -euo pipefail
 
 BASE_SHA="${1:?base sha required}"
@@ -38,7 +39,33 @@ fi
 # Filter to PRs carrying any phase/* label.
 phase_prs=$(echo "$prs" | jq '[.[] | select(.labels[]?.name | startswith("phase/"))]')
 
-# Empty? Nothing to emit — caller skips the block entirely.
+# Empty? Nothing to emit — caller skips the block entirely. Also skips the
+# range resolution below, which needs a real commit range.
+if [ "$(echo "$phase_prs" | jq 'length')" -eq 0 ]; then
+  exit 0
+fi
+
+# `gh search prs` has no BASE_SHA..HEAD_SHA range filter — it just returns
+# the most recently merged PRs repo-wide. Left unfiltered, every release's
+# SCHEMA-IMPACT block accumulates the FULL history of phase-labeled PRs
+# (including ones already shipped in prior releases), so every release
+# claims a DB migration forever. Restrict to PRs whose squash-merge commit
+# ("<title> (#NNNN)") actually lands in this release's range.
+if [ -n "${MERGED_PR_NUMBERS_OVERRIDE:-}" ]; then
+  merged_numbers="$MERGED_PR_NUMBERS_OVERRIDE"
+else
+  if ! merged_numbers=$(git log --pretty=%s "$BASE_SHA..$HEAD_SHA" 2>&1); then
+    echo "::error::generate_schema_impact_notes: git log $BASE_SHA..$HEAD_SHA failed — cannot resolve which PRs are actually in this release. Output: $merged_numbers" >&2
+    exit 1
+  fi
+  merged_numbers=$(printf '%s\n' "$merged_numbers" | grep -oP '\(#\K[0-9]+(?=\)$)' || true)
+fi
+
+numbers_json=$(printf '%s\n' $merged_numbers | jq -R 'select(length > 0) | tonumber' | jq -s '.')
+phase_prs=$(echo "$phase_prs" | jq --argjson nums "$numbers_json" \
+  '[.[] | select(.number as $n | $nums | index($n) != null)]')
+
+# Range filter may have zeroed out every PR (all were outside this release).
 if [ "$(echo "$phase_prs" | jq 'length')" -eq 0 ]; then
   exit 0
 fi

--- a/test/scripts/generate_schema_impact_notes_test.sh
+++ b/test/scripts/generate_schema_impact_notes_test.sh
@@ -12,6 +12,7 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 # --- Test 1: phase/expand PR present, all reversible ---
 output=$(GH_OUTPUT_OVERRIDE='[{"number":100,"labels":[{"name":"phase/expand"}],"title":"Add users.timezone column"}]' \
          IRREVERSIBLE_OVERRIDE='false' \
+         MERGED_PR_NUMBERS_OVERRIDE='100' \
          bash "$SCRIPT" abc123 def456)
 
 echo "$output" | grep -q 'SCHEMA-IMPACT'           || fail "Test 1: missing SCHEMA-IMPACT header"
@@ -33,6 +34,7 @@ output_non_phase=$(GH_OUTPUT_OVERRIDE='[{"number":50,"labels":[{"name":"bug"}],"
 # --- Test 4: irreversible migration → rollback hint omitted, IRREVERSIBLE warning emitted ---
 output_irrev=$(GH_OUTPUT_OVERRIDE='[{"number":200,"labels":[{"name":"phase/contract"}],"title":"Drop users.legacy_flag"}]' \
                IRREVERSIBLE_OVERRIDE='true' \
+               MERGED_PR_NUMBERS_OVERRIDE='200' \
                bash "$SCRIPT" abc123 def456)
 
 echo "$output_irrev" | grep -q 'Engram.Release.rollback' && \
@@ -45,7 +47,8 @@ output_multi=$(GH_OUTPUT_OVERRIDE='[
   {"number":100,"labels":[{"name":"phase/expand"}],"title":"Add column"},
   {"number":101,"labels":[{"name":"phase/contract"},{"name":"bug"}],"title":"Drop column"},
   {"number":102,"labels":[{"name":"feature"}],"title":"Unrelated"}
-]' IRREVERSIBLE_OVERRIDE='false' bash "$SCRIPT" abc123 def456)
+]' IRREVERSIBLE_OVERRIDE='false' MERGED_PR_NUMBERS_OVERRIDE='100 101 102' \
+  bash "$SCRIPT" abc123 def456)
 
 echo "$output_multi" | grep -q '#100' || fail "Test 5: missing #100"
 echo "$output_multi" | grep -q '#101' || fail "Test 5: missing #101"
@@ -54,4 +57,26 @@ echo "$output_multi" | grep -q 'phase/expand' || fail "Test 5: missing phase/exp
 echo "$output_multi" | grep -q 'phase/contract' || fail "Test 5: missing phase/contract"
 echo "$output_multi" | grep -q '"bug"' && fail "Test 5: should NOT cite non-phase labels" || true
 
-echo "All tests passed (5)."
+
+# --- Test 6: gh search returns a phase PR from OUTSIDE this release's range
+# (e.g. already shipped in a prior release) → excluded. Regression test for
+# the "every release claims a DB migration" bug: gh search prs has no range
+# filter of its own, so without MERGED_PR_NUMBERS_OVERRIDE filtering, #100
+# and #101 would both appear even though only #101 merged in this range.
+output_range=$(GH_OUTPUT_OVERRIDE='[
+  {"number":100,"labels":[{"name":"phase/expand"}],"title":"Shipped in a prior release"},
+  {"number":101,"labels":[{"name":"phase/expand"}],"title":"Shipped in THIS release"}
+]' IRREVERSIBLE_OVERRIDE='false' MERGED_PR_NUMBERS_OVERRIDE='101' \
+   bash "$SCRIPT" abc123 def456)
+
+echo "$output_range" | grep -q '#101' || fail "Test 6: missing #101 (in range)"
+echo "$output_range" | grep -q '#100' && fail "Test 6: should NOT include #100 (outside range)" || true
+
+# --- Test 7: phase PRs exist but none are in range → empty output ---
+output_range_empty=$(GH_OUTPUT_OVERRIDE='[
+  {"number":100,"labels":[{"name":"phase/expand"}],"title":"Shipped in a prior release"}
+]' IRREVERSIBLE_OVERRIDE='false' MERGED_PR_NUMBERS_OVERRIDE='999' \
+   bash "$SCRIPT" abc123 def456)
+[ -z "$output_range_empty" ] || fail "Test 7: expected empty output when no phase PRs are in range; got: $output_range_empty"
+
+echo "All tests passed (7)."

--- a/test/scripts/generate_schema_impact_notes_test.sh
+++ b/test/scripts/generate_schema_impact_notes_test.sh
@@ -79,4 +79,30 @@ output_range_empty=$(GH_OUTPUT_OVERRIDE='[
    bash "$SCRIPT" abc123 def456)
 [ -z "$output_range_empty" ] || fail "Test 7: expected empty output when no phase PRs are in range; got: $output_range_empty"
 
-echo "All tests passed (7)."
+
+# --- Test 8: real git-log extraction, NO MERGED_PR_NUMBERS_OVERRIDE. Tests
+# 1-7 all set the override, which bypasses the actual `git log` parse —
+# the one piece of new logic that carries real risk (the grep pattern, the
+# `$`-anchor, squash- vs merge-commit shapes). Without this test, a change
+# that silently disabled the range filter entirely would still pass every
+# other test in this file. Uses a real scratch git repo so the regex runs
+# against real commit subjects, not a hand-fed number list.
+tmp_repo="$(mktemp -d)"
+trap 'rm -rf "$tmp_repo"' EXIT
+gc() { git -C "$tmp_repo" -c user.email=test@example.com -c user.name=test "$@"; }
+git -c init.defaultBranch=main -C "$tmp_repo" init -q
+gc commit -q --allow-empty -m "chore: base"
+base_sha=$(git -C "$tmp_repo" rev-parse HEAD)
+gc commit -q --allow-empty -m "feat: in range (#101)"
+gc commit -q --allow-empty -m "chore: direct push, no PR number"
+head_sha=$(git -C "$tmp_repo" rev-parse HEAD)
+
+output_real=$(cd "$tmp_repo" && GH_OUTPUT_OVERRIDE='[
+  {"number":100,"labels":[{"name":"phase/expand"}],"title":"Shipped in a prior release"},
+  {"number":101,"labels":[{"name":"phase/expand"}],"title":"Shipped in THIS release"}
+]' IRREVERSIBLE_OVERRIDE='false' bash "$SCRIPT" "$base_sha" "$head_sha")
+
+echo "$output_real" | grep -q '#101' || fail "Test 8: real git-log extraction missed in-range #101"
+echo "$output_real" | grep -q '#100' && fail "Test 8: real git-log extraction included out-of-range #100" || true
+
+echo "All tests passed (8)."


### PR DESCRIPTION
## Summary
- \`gh search prs --merged --base main\` had no range filter, so every release's SCHEMA-IMPACT block accumulated the FULL history of phase/* labeled PRs instead of just the ones actually in that release — every release since claimed a DB migration (verified: v0.21.1's notes listed 22 PRs back to #736; the real range is just #1488, which isn't even phase-labeled).
- Scopes the phase-labeled PR list to \`BASE_SHA..HEAD_SHA\` via \`git log\`-derived merged PR numbers, intersected with the gh search result.
- Second commit closes gaps a code review caught before push: real (non-overridden) test coverage of the git-log path, wiring the test into CI (it was never run), explicit gh sort ordering (the intersection makes recency load-bearing), and removing a \`|| true\` in release-please.yml that silently swallowed the script's new fail-loud path.

## Test plan
- [x] \`bash test/scripts/generate_schema_impact_notes_test.sh\` — 8/8 pass
- [x] Verified against real history: script now correctly emits nothing for release-v0.21.1 (its only PR, #1488, carries no phase/* label)
- [x] Mutation-killed: broke the git-log regex, confirmed Test 8 catches it (existing tests 1-7 do not, since they bypass git-log via a test override)
- [x] YAML syntax checked for both modified workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2