### PR TITLE
ci: key bun's cache on a resolved version, and align the build path on 1.4.0

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -279,14 +279,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Pinned like the verify.yml jobs: `latest` defeats setup-bun's cache and
-      # re-downloads ~35 MB every run. This job only shells out to
-      # npm-check-updates, so the bun version is incidental — but a nightly
-      # that silently tracks `latest` is also how a bun bump lands in CI with
-      # no PR behind it.
+      # Resolve latest ourselves like the verify.yml jobs: a literal `latest`
+      # is unkeyable, so setup-bun re-downloads ~35 MB every run instead of
+      # restoring from cache.
+      - name: Resolve latest bun version
+        id: bun
+        run: |
+          set -euo pipefail
+          v=$(curl -sSfL --max-time 20 \
+                -H "Authorization: Bearer ${{ github.token }}" \
+                https://api.github.com/repos/oven-sh/bun/releases/latest \
+              | jq -r '.tag_name' | sed 's/^bun-v//')
+          [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::could not resolve latest bun version (got '$v')"; exit 1; }
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved bun latest -> $v"
+
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ steps.bun.outputs.version }}
 
       - name: Run npm-check-updates and filter to major bumps
         id: scan

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -279,9 +279,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Pinned like the verify.yml jobs: `latest` defeats setup-bun's cache and
+      # re-downloads ~35 MB every run. This job only shells out to
+      # npm-check-updates, so the bun version is incidental — but a nightly
+      # that silently tracks `latest` is also how a bun bump lands in CI with
+      # no PR behind it.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - name: Run npm-check-updates and filter to major bumps
         id: scan

--- a/.github/workflows/frontend-promote.yml
+++ b/.github/workflows/frontend-promote.yml
@@ -40,8 +40,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ env.SHA }}
+      # Kept in lockstep with deploy-frontend in verify.yml — this workflow's
+      # self-heal fallback rebuilds the same artifact, and the two builds are
+      # meant to be byte-identical. Bump both together or they are not.
       - uses: oven-sh/setup-bun@v2
-        with: { bun-version: 1.3.11 }
+        with: { bun-version: 1.4.0 }
 
       - name: Resolve uploaded version for this commit (fast path)
         id: v

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3064,9 +3064,17 @@ jobs:
           fi
           exit $failed
 
+      # Pinned, not `latest`: setup-bun cannot match a cached install against
+      # an unresolved `latest`, so it re-downloads bun-linux-x64.zip (~35 MB)
+      # on every run of every job that asks for it — even when the runner
+      # already has that exact revision. Normally 3-8s and invisible; during an
+      # egress dip on 2026-08-30 the same download took 13m53s and turned a 9m
+      # CI run into 34m. Pinning restores the tool-cache hit. 1.3.11 matches
+      # deploy-frontend and frontend-promote, so lint and build now agree on a
+      # bun version instead of drifting apart as `latest` moves.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       # Run `bun audit` against frontend/ on every CI trigger. Fail when any
       # critical or high advisory affects a PRODUCTION dependency path. The
@@ -3682,10 +3690,12 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Pinned for the same reason as static-checks above: `latest` defeats
+      # setup-bun's cache and re-downloads ~35 MB per run.
       - uses: oven-sh/setup-bun@v2
         if: steps.guard.outputs.skip != 'true'
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       # A lockfile resolved on a machine with a global `registry=` bakes that
       # LAN host into every tarball URL, which works for us and is unusable

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5287,8 +5287,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Pinned, unlike the lint jobs which resolve latest: this builds the
+      # artifact that ships, so the bun version moves when we decide it does,
+      # not when oven-sh publishes. 1.4.0 matches what `latest` resolves to
+      # today, so lint and this build agree again — verified locally on 1.4.0
+      # (`bun install --frozen-lockfile` clean, lockfile untouched,
+      # `build:saas` green) because this job only runs on main, so no PR can
+      # exercise the bump before it deploys.
       - uses: oven-sh/setup-bun@v2
-        with: { bun-version: 1.3.11 }
+        with: { bun-version: 1.4.0 }
 
       - name: Install
         working-directory: frontend

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3064,17 +3064,39 @@ jobs:
           fi
           exit $failed
 
-      # Pinned, not `latest`: setup-bun cannot match a cached install against
-      # an unresolved `latest`, so it re-downloads bun-linux-x64.zip (~35 MB)
-      # on every run of every job that asks for it — even when the runner
-      # already has that exact revision. Normally 3-8s and invisible; during an
-      # egress dip on 2026-08-30 the same download took 13m53s and turned a 9m
-      # CI run into 34m. Pinning restores the tool-cache hit. 1.3.11 matches
-      # deploy-frontend and frontend-promote, so lint and build now agree on a
-      # bun version instead of drifting apart as `latest` moves.
+      # Resolve `latest` to a concrete version OURSELVES, then hand setup-bun
+      # that number. Still tracks latest — it just stops paying for it twice.
+      #
+      # setup-bun keys its cache on the version string, so a literal `latest`
+      # is unkeyable: every run missed the cache and re-downloaded
+      # bun-linux-x64.zip (~35 MB) from github.com, even when the runner
+      # already had that exact revision. Normally 3-8s and invisible; when
+      # GitHub's release CDN served this network at ~42 KB/s on 2026-08-30 the
+      # same download took 13m53s, in two jobs at once, and turned a 9m CI run
+      # into 34m. A concrete version restores the cache hit, which comes off
+      # the LAN cache backend at ~9 MB/s instead of crossing the WAN at all.
+      #
+      # A genuinely new bun release still downloads once, then caches. That
+      # cost is irreducible — it is what tracking latest means.
+      - name: Resolve latest bun version
+        id: bun
+        run: |
+          set -euo pipefail
+          v=$(curl -sSfL --max-time 20 \
+                -H "Authorization: Bearer ${{ github.token }}" \
+                https://api.github.com/repos/oven-sh/bun/releases/latest \
+              | jq -r '.tag_name' | sed 's/^bun-v//')
+          # Fail loud rather than silently falling back to `latest` — a
+          # sloppy fallback would restore the every-run download and nobody
+          # would notice until CI got slow again.
+          [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::could not resolve latest bun version (got '$v')"; exit 1; }
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved bun latest -> $v"
+
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ steps.bun.outputs.version }}
 
       # Run `bun audit` against frontend/ on every CI trigger. Fail when any
       # critical or high advisory affects a PRODUCTION dependency path. The
@@ -3690,12 +3712,27 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Pinned for the same reason as static-checks above: `latest` defeats
-      # setup-bun's cache and re-downloads ~35 MB per run.
+      # Resolve latest ourselves for the same reason as static-checks above: a
+      # literal `latest` is unkeyable, so setup-bun re-downloads ~35 MB per run
+      # instead of restoring from the LAN cache.
+      - name: Resolve latest bun version
+        id: bun
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          v=$(curl -sSfL --max-time 20 \
+                -H "Authorization: Bearer ${{ github.token }}" \
+                https://api.github.com/repos/oven-sh/bun/releases/latest \
+              | jq -r '.tag_name' | sed 's/^bun-v//')
+          [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::could not resolve latest bun version (got '$v')"; exit 1; }
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved bun latest -> $v"
+
       - uses: oven-sh/setup-bun@v2
         if: steps.guard.outputs.skip != 'true'
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ steps.bun.outputs.version }}
 
       # A lockfile resolved on a machine with a global `registry=` bakes that
       # LAN host into every tarball URL, which works for us and is unusable


### PR DESCRIPTION
Two changes: lint jobs keep `latest` but stop re-downloading it, and the build path moves to 1.4.0 so it stops disagreeing with lint.

## 1. Keep `latest`, stop paying for it every run

`setup-bun` keys its cache on the version string, so a literal `latest` is unkeyable and always misses. The three jobs asking for it re-downloaded `bun-linux-x64.zip` (~35 MB) from github.com on every run — even when the runner already had that exact revision. From `static checks` on 2026-08-30:

```
12:04:29  bun --revision -> 1.4.0+34cbb9a40
12:04:29  Downloading a new version of Bun: .../bun-v1.4.0/bun-linux-x64.zip
12:18:23  unzip
12:18:23  bun --revision -> 1.4.0+34cbb9a40
```

A job passing a **concrete** version, same day, same action, same 35 MB:

```
Cache hit for: bun-D+vY/5K5IeIeZla4MvXaHXd6xhc=
Received 35431932 of 35431932 (100.0%), 9.0 MBs/sec
Using a cached version of Bun: 1.3.11+af24e281e
```

Off the LAN cache backend instead of across the WAN. So: resolve `latest` to a number in a prior step, hand that to `setup-bun`. Still tracks latest; the cache can now key on it. A genuinely new bun release downloads once and then caches — that cost is what tracking latest means.

The resolver fails loud if the API doesn't return clean semver rather than falling back to `latest`, which would quietly restore the every-run download.

### Why it mattered

GitHub's release CDN served this network at ~42 KB/s for roughly fifteen minutes on 2026-08-30. The download took **13m53s**, in two jobs at once, and a 9m CI run became 34m (`unit-tests` queued 11m behind it; `squawk`, also a release-binary pull, took 505s in the same window).

`sar` on the runner shows its link idle throughout — `%ifutil` 0.00, under 1 MB/s while that download crawled — and the two stalled jobs were on *different* pools (`fastraid-5`, `runner-4`). Upstream and transient, not local saturation and not a bad host. Nothing to prevent; only something to stop touching three times a run.

## 2. Build path 1.4.0

`deploy-frontend` and `frontend-promote` were pinned at 1.3.11 while lint resolved `latest` = 1.4.0, so lint and typecheck gated on a different bun than the artifact that ships. Both move to 1.4.0.

These two stay **pinned** rather than resolving latest: they build what ships, so the version should move when we decide it does. They're bumped together deliberately — frontend-promote's self-heal fallback rebuilds the same artifact and the two are meant to be byte-identical.

## Verification

`deploy-frontend` only runs on main push or `workflow_dispatch`, so no PR can exercise the bump before it deploys. Verified locally on bun 1.4.0 instead:

- `bun install --frozen-lockfile` — clean, 1466 installs across 1289 packages, **lockfile untouched**
- `bun run build:saas` — green, `✓ built in 15.87s`
- (First attempt failed on a missing `VITE_CLERK_PUBLISHABLE_KEY` *after* transforming all 5999 modules — an env guard, not a toolchain problem. Re-ran with a dummy key to confirm completion.)

For part 1:

- Resolver dry-run against the live API returns `1.4.0`, matching what `latest` gave CI; the semver guard accepts it
- All three workflows parse (`yaml.safe_load`)
- `id: bun` lands in three distinct jobs (`static-checks`, `frontend-lint`, cron) — step ids are job-scoped, no collision
- The real check is CI here: those jobs should log `Cache hit for: bun-...` instead of `Downloading a new version of Bun`

## Known consequence

Lint tracks latest and the build path is pinned, so they agree today and will drift again when 1.4.1 ships. That's the intended trade: lint gets new bun early, prod builds move on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp