### PR TITLE
fix(e2e): poll for the note_id mapping in _confirm_room_free

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -1037,6 +1037,31 @@ class CdpClient:
             f"? ({ENGINE_PATH}.noteIdMap.get({json.dumps(path)}) ?? null) : null"
         )
 
+    async def wait_for_note_id_for_path(self, path: str, timeout: float = 30) -> str:
+        """Poll until the plugin has mapped `path` to a note_id, and return it.
+
+        Same race as `wait_for_room_free` one method down, one step earlier in
+        the same sequence: `trigger_full_sync()` returning means the sync CALL
+        finished, not that every mapping it discovered has been committed to
+        `noteIdMap`. A single immediate `get_note_id_for_path()` therefore
+        samples a map that may still be a beat behind, and reads `None` for a
+        note that maps fine a few hundred ms later (engram-app/Engram#1489).
+
+        Poll instead. A note the device genuinely never maps still fails, via
+        timeout — so this weakens nothing, it only stops reporting a slow
+        mapping as a missing one.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            note_id = await self.get_note_id_for_path(path)
+            if note_id:
+                return note_id
+            await asyncio.sleep(0.2)
+        raise TimeoutError(
+            f"device never mapped a note_id for {path} within {timeout}s "
+            f"on CDP port {self.port}"
+        )
+
     async def get_enrolled_note_ids(self) -> list[str]:
         """Snapshot CrdtEnrollment.enrolled — the note_ids this device has
         STEP1-enrolled (opened a CRDT room for) this session."""

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -176,11 +176,20 @@ async def _confirm_room_free(cdp, path):
     release rather than sampling the enrolled set the instant the sync returns —
     a single immediate snapshot races the async release (the source of this
     test's flakiness). A genuinely stuck room still fails via timeout.
+
+    BOTH reads below poll for the same reason. trigger_full_sync() returning
+    means the sync call finished, not that the mapping it discovered has landed
+    in noteIdMap, so the note_id read raced it exactly as the enrolled-set read
+    did — reporting `assert None` ("device never mapped a note_id") for a note
+    that maps fine moments later, and taking 6-7 downstream tests with it
+    (engram-app/Engram#1489).
     """
     await cdp.wait_for_stream_connected()
     await cdp.trigger_full_sync()
-    note_id = await cdp.get_note_id_for_path(path)
-    assert note_id, f"device never mapped a note_id for {path} — cannot prove fan-out"
+    try:
+        note_id = await cdp.wait_for_note_id_for_path(path, timeout=CRDT_TIMEOUT)
+    except TimeoutError as e:
+        pytest.fail(f"device never mapped a note_id for {path} — cannot prove fan-out — {e}")
     try:
         await cdp.wait_for_room_free(note_id, timeout=CRDT_TIMEOUT)
     except TimeoutError as e:


### PR DESCRIPTION
Fixes the `_confirm_room_free` half of the e2e-crdt redness. The cold-send timeout (#1503 / #1522) is a **separate, unfixed** bug — see the note at the bottom.

## The race

`_confirm_room_free` read the path→note_id mapping once, immediately after `trigger_full_sync()` returned:

```python
note_id = await cdp.get_note_id_for_path(path)
assert note_id, f"device never mapped a note_id for {path} — cannot prove fan-out"
```

`trigger_full_sync()` returning means the sync **call** finished, not that every mapping it discovered has been committed to `noteIdMap`. The read races the commit and reports `assert None` for a note that maps fine a few hundred ms later.

Because it's the *first* assertion in the helper, one loss cascades — a failing run takes out 6-7 tests across `test_crdt_sync`, `test_live_bound_both_ends`, `test_obsidian_to_web_live`, `test_seq_gap_heal` and `test_web_to_obsidian_live`.

## Why this one is obvious in hindsight

The helper's own docstring already describes this exact race, for the enrolled-set read **one line below**:

> a single immediate snapshot races the async release (the source of this test's flakiness)

That one was fixed by polling (`wait_for_room_free`). The note_id read, one step *earlier* in the same sequence and with the same dependency on `trigger_full_sync()`, was left sampling once. This adds the matching `wait_for_note_id_for_path` and uses it.

A note the device genuinely never maps still fails, via timeout. The precondition isn't weakened — it just stops reporting a slow mapping as a missing one.

Closes #1489

## Verification

- `ruff check` clean on both files (this is what the `e2e harness lint` job runs)
- `py_compile` clean
- Real proof is `e2e-crdt` across several runs: `test_concurrent_cold_edits_survive_over_fanout` should stop failing with `assert None`

## Not fixed here

`test_cold_send_over_fanout_opens_no_room` (#1503, p1) times out at 120s waiting for content, which is a different failure with a different cause — the note_id maps fine there. Investigation so far: `FanoutPacer` drains 20 frames/100ms and never drops, so a single cold frame sitting undelivered for 120s doesn't fit a pacing delay; and #1503's own last comment confirms the server holds the content while device A never applies it. Deliberately left out of this PR rather than bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp