### PR TITLE
fix(e2e): stop suppression stubbing handleStreamEvent (#1503)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1623,17 +1623,7 @@ jobs:
     # !cancelled(): same repository_dispatch rationale as e2e-clerk —
     # prebuild-mix skips there and must not auto-skip this suite.
     # bot-pr guard: see the fingerprint job's `bot-pr` output.
-    #
-    # NEVER skip on main (#1503). The fingerprint is content-correct — it skipped
-    # release/docs pushes where nothing relevant changed, which is right — but it
-    # trusts a recorded pass forever, and a pass can be meaningless: the four
-    # fan-out isolation tests in this suite spent an unknown number of runs
-    # stubbing NOTHING (every method name in the helper had been renamed away),
-    # so they would have gone green with the feature completely dead. Every green
-    # they recorded is still in the marker store being trusted. A regression then
-    # rode onto main and sat there while `e2e-crdt: skipped` read as success.
-    # PRs keep the shortcut; merges to main pay ~2 min to actually look.
-    if: ${{ !cancelled() && needs.fingerprint.outputs.bot-pr != 'true' && (needs.fingerprint.outputs.skip-e2e-crdt != 'true' || github.ref == 'refs/heads/main') && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
+    if: ${{ !cancelled() && needs.fingerprint.outputs.bot-pr != 'true' && needs.fingerprint.outputs.skip-e2e-crdt != 'true' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
     runs-on: [self-hosted, linux, x64, isolated, heavy]
 
     env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1623,7 +1623,17 @@ jobs:
     # !cancelled(): same repository_dispatch rationale as e2e-clerk —
     # prebuild-mix skips there and must not auto-skip this suite.
     # bot-pr guard: see the fingerprint job's `bot-pr` output.
-    if: ${{ !cancelled() && needs.fingerprint.outputs.bot-pr != 'true' && needs.fingerprint.outputs.skip-e2e-crdt != 'true' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
+    #
+    # NEVER skip on main (#1503). The fingerprint is content-correct — it skipped
+    # release/docs pushes where nothing relevant changed, which is right — but it
+    # trusts a recorded pass forever, and a pass can be meaningless: the four
+    # fan-out isolation tests in this suite spent an unknown number of runs
+    # stubbing NOTHING (every method name in the helper had been renamed away),
+    # so they would have gone green with the feature completely dead. Every green
+    # they recorded is still in the marker store being trusted. A regression then
+    # rode onto main and sat there while `e2e-crdt: skipped` read as success.
+    # PRs keep the shortcut; merges to main pay ~2 min to actually look.
+    if: ${{ !cancelled() && needs.fingerprint.outputs.bot-pr != 'true' && (needs.fingerprint.outputs.skip-e2e-crdt != 'true' || github.ref == 'refs/heads/main') && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
     runs-on: [self-hosted, linux, x64, isolated, heavy]
 
     env:

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -816,18 +816,12 @@ async def _assert_plugin_surfaces(cdp_a):
             if (typeof p.syncEngine?.isRecentlyPushed !== 'function') missing.push('isRecentlyPushed');
             if (typeof p.syncEngine?.handleStreamEvent !== 'function') missing.push('handleStreamEvent');
             if (!(p.syncEngine?.syncState instanceof Map)) missing.push('syncState:Map');
-            // The fan-out isolation tests are only meaningful if the cold-apply
-            // backstop can be stubbed. It has been renamed twice (coldReceive ->
-            // catchupViaSocket -> catchupViaSeqReplay) and `pull` was retired
-            // alongside them — all three names in suppress_fanout_backstops()
-            // had gone dead without anything noticing, because the helper skips
-            // a missing method. The four "TRUE fan-out proof" tests were running
-            // with every backstop live. Assert the surface here so the next
-            // rename fails the session at start, not silently mid-suite.
-            const coldApply = ['catchupViaSeqReplay', 'coldReceive', 'catchupViaSocket'];
-            if (!coldApply.some(m => typeof p.syncEngine?.[m] === 'function')) {
-                missing.push('cold-apply backstop (one of ' + coldApply.join('/') + ')');
-            }
+            // NOT checked here: the cold-apply backstop that
+            // suppress_fanout_backstops() stubs. It belongs to 4 crdt tests, and
+            // this fixture is session-scoped autouse across every suite — a
+            // rename would fail the ~110-test clerk session for a reason with no
+            // bearing on it. The helper raises on its own instead (#1503), which
+            // is the same protection scoped to the tests that need it.
             for (const id of cmds) {
                 if (!app.commands.findCommand(`engram-vault-sync:${id}`)) {
                     missing.push(`command:${id}`);

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -816,6 +816,19 @@ async def _assert_plugin_surfaces(cdp_a):
             if (typeof p.syncEngine?.isRecentlyPushed !== 'function') missing.push('isRecentlyPushed');
             if (typeof p.syncEngine?.handleStreamEvent !== 'function') missing.push('handleStreamEvent');
             if (!(p.syncEngine?.syncState instanceof Map)) missing.push('syncState:Map');
+            // The fan-out isolation tests are only meaningful if these two can
+            // be stubbed. The backstop has been renamed twice (coldReceive ->
+            // catchupViaSocket -> catchupViaSeqReplay) and BOTH earlier names
+            // went dead without anything noticing: suppress_fanout_backstops()
+            // skips a missing method, so the four "TRUE fan-out proof" tests ran
+            // with a live backstop and would have passed with a dead fan-out.
+            // Assert the surface here so the next rename fails the session at
+            // start, not silently mid-suite.
+            if (typeof p.syncEngine?.pull !== 'function') missing.push('pull');
+            const coldApply = ['catchupViaSeqReplay', 'coldReceive', 'catchupViaSocket'];
+            if (!coldApply.some(m => typeof p.syncEngine?.[m] === 'function')) {
+                missing.push('cold-apply backstop (one of ' + coldApply.join('/') + ')');
+            }
             for (const id of cmds) {
                 if (!app.commands.findCommand(`engram-vault-sync:${id}`)) {
                     missing.push(`command:${id}`);

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -816,15 +816,14 @@ async def _assert_plugin_surfaces(cdp_a):
             if (typeof p.syncEngine?.isRecentlyPushed !== 'function') missing.push('isRecentlyPushed');
             if (typeof p.syncEngine?.handleStreamEvent !== 'function') missing.push('handleStreamEvent');
             if (!(p.syncEngine?.syncState instanceof Map)) missing.push('syncState:Map');
-            // The fan-out isolation tests are only meaningful if these two can
-            // be stubbed. The backstop has been renamed twice (coldReceive ->
-            // catchupViaSocket -> catchupViaSeqReplay) and BOTH earlier names
-            // went dead without anything noticing: suppress_fanout_backstops()
-            // skips a missing method, so the four "TRUE fan-out proof" tests ran
-            // with a live backstop and would have passed with a dead fan-out.
-            // Assert the surface here so the next rename fails the session at
-            // start, not silently mid-suite.
-            if (typeof p.syncEngine?.pull !== 'function') missing.push('pull');
+            // The fan-out isolation tests are only meaningful if the cold-apply
+            // backstop can be stubbed. It has been renamed twice (coldReceive ->
+            // catchupViaSocket -> catchupViaSeqReplay) and `pull` was retired
+            // alongside them — all three names in suppress_fanout_backstops()
+            // had gone dead without anything noticing, because the helper skips
+            // a missing method. The four "TRUE fan-out proof" tests were running
+            // with every backstop live. Assert the surface here so the next
+            // rename fails the session at start, not silently mid-suite.
             const coldApply = ['catchupViaSeqReplay', 'coldReceive', 'catchupViaSocket'];
             if (!coldApply.some(m => typeof p.syncEngine?.[m] === 'function')) {
                 missing.push('cold-apply backstop (one of ' + coldApply.join('/') + ')');

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -1015,8 +1015,19 @@ class CdpClient:
         js = f"""
         (function() {{
             const se = {ENGINE_PATH};
-            if (se.__fanoutIsolated) return 'already-isolated';
-            se.__fanoutIsolated = true;
+            // Idempotent re-entry reports what is ACTUALLY stubbed right now,
+            // not a bare 'already-isolated' — the caller's zero-stub assertion
+            // has to run on this path too. A restore_fanout_backstops() that
+            // throws (CDP reconnect, renderer reload) leaves __fanoutIsolated
+            // set with nothing stubbed, and every later suppress in this
+            // session would otherwise short-circuit past the guard and hand
+            // the fan-out tests the exact false-green this guard exists for.
+            if (se.__fanoutIsolated) {{
+                return Object.keys(se)
+                    .filter(k => k.startsWith('__orig_'))
+                    .map(k => k.slice('__orig_'.length))
+                    .join(',');
+            }}
             // The cold-apply backstop has been renamed twice: coldReceive ->
             // catchupViaSocket -> catchupViaSeqReplay. backend-main e2e pairs
             // against EITHER plugin branch, so stub whichever exists and never
@@ -1031,13 +1042,14 @@ class CdpClient:
                     stubbed.push(m);
                 }}
             }}
+            // Set AFTER the loop: the flag means "isolation is in place", and
+            // setting it first made a zero-stub run claim isolation it never had.
+            se.__fanoutIsolated = true;
             return stubbed.join(',');
         }})()
         """
         result = await self.evaluate(js)
         logger.info("Fan-out backstops suppressed on CDP port %d: %s", self.port, result)
-        if result == "already-isolated":
-            return result
         stubbed = set(str(result).split(",")) - {""}
         # A rename silently empties this loop (the typeof guard skips what is
         # gone) and the tests then prove nothing, so require the cold-apply

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -924,38 +924,12 @@ class CdpClient:
             await_promise=True,
         )
 
-    async def pause_incoming_sync(self) -> None:
-        """Silence incoming WebSocket events by replacing handleStreamEvent.
-
-        Lets a test guarantee that ``pull()`` is the ONLY path that can apply
-        remote content — without this, a full_sync push broadcasts an upsert
-        event that races against pull().
-        """
-        js = f"""
-        (function() {{
-            const se = {ENGINE_PATH};
-            if (se._origHandleStreamEvent) return 'already-paused';
-            se._origHandleStreamEvent = se.handleStreamEvent.bind(se);
-            se.handleStreamEvent = async () => {{}};
-            return 'paused';
-        }})()
-        """
-        result = await self.evaluate(js)
-        logger.info("Incoming sync paused on CDP port %d: %s", self.port, result)
-
-    async def resume_incoming_sync(self) -> None:
-        """Restore the WebSocket event handler saved by pause_incoming_sync()."""
-        js = f"""
-        (function() {{
-            const se = {ENGINE_PATH};
-            if (!se._origHandleStreamEvent) return 'not-paused';
-            se.handleStreamEvent = se._origHandleStreamEvent;
-            delete se._origHandleStreamEvent;
-            return 'resumed';
-        }})()
-        """
-        result = await self.evaluate(js)
-        logger.info("Incoming sync resumed on CDP port %d: %s", self.port, result)
+    # pause_incoming_sync/resume_incoming_sync lived here. Deleted with #1503:
+    # zero callers repo-wide, and they stubbed handleStreamEvent — the same trap
+    # that broke test_cold_send_over_fanout_opens_no_room. A device with that
+    # handler dead stops committing noteIdMap and can no longer PUSH, so the
+    # helper was only ever safe on a pure receiver. Don't reintroduce it without
+    # that caveat in the docstring.
 
     # ------------------------------------------------------------------
     # Vault-channel fan-out isolation (crdt/test_crdt_sync.py)
@@ -968,25 +942,39 @@ class CdpClient:
 
         Under the vault-channel model an IDLE note (not open in the editor)
         converges via the server's ``note_yjs_update`` broadcast → the plugin's
-        ``applyPushedNoteUpdate`` (sync.ts). TWO other paths also converge a cold
-        note off the ~5s checkpoint ``note_changed`` and would mask a broken
-        fan-out — every existing crdt test still passes at checkpoint latency
-        even if the fan-out is dead:
+        ``applyPushedNoteUpdate`` (sync.ts). The checkpoint-driven backfill also
+        converges a cold note off the ~5s ``note_changed`` and would mask a
+        broken fan-out — every existing crdt test still passes at checkpoint
+        latency even if the fan-out is dead:
 
           * ``pull()`` — its cursor-feed backfill (``flushFromCrdt`` on a
             content_hash divergence) AND ``coldReceive()``, which ``pull()`` is
             the sole caller of (invoked at its tail, sync.ts:2707).
-          * ``handleStreamEvent`` — the ``note_changed``/upsert handler, which
-            can STEP1-enroll the note's CRDT room (sync.ts:3246); an open room's
-            ``crdt_msg`` stream would then deliver the body independently.
 
-        This stubs ``pull()``, the cold-apply backstop (``coldReceive()``
+        This stubs ``pull()`` and the cold-apply backstop (``coldReceive()``
         pre-rewire / ``catchupViaSocket()`` post-authoritative-rewire — stubs
-        whichever the paired plugin build exposes) and ``handleStreamEvent`` to
-        no-ops (saving originals). The fan-out is a SEPARATE channel dispatch:
-        ``channel.ts`` routes ``note_yjs_update`` straight to ``onNoteYjsUpdate``
-        → ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
+        whichever the paired plugin build exposes) to no-ops (saving originals).
+        The fan-out is a SEPARATE channel dispatch: ``channel.ts`` routes
+        ``note_yjs_update`` straight to ``onNoteYjsUpdate`` →
+        ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
         stays fully live. Idempotent.
+
+        ``handleStreamEvent`` is deliberately NOT stubbed (#1503). It was on the
+        list to stop the ``note_changed`` handler STEP1-enrolling the note's CRDT
+        room, whose ``crdt_msg`` stream would then deliver the body independently
+        — but that enroll (``sync.ts`` ~7222, formerly the stale 3246 this
+        docstring cited) is already gated on ``isCanvasPath || isLiveBound``, so
+        it cannot fire for the idle markdown note these tests use. A stray room
+        would fail the enrolled-set assertion rather than pass silently.
+
+        Stubbing it was NOT free: ``applyStreamEvent`` is what commits
+        ``noteIdMap.set(event.path, noteId)``. With it dead the map goes stale,
+        ``pushFile`` reads a null id, and ``shouldDeferMint`` refuses the push —
+        so the suppressed device silently loses the ability to SEND. That is the
+        #1503 failure: ``test_cold_send_over_fanout_opens_no_room`` suppressed
+        the sender and then waited 120s for an edit that never left the device.
+        Suppression is only safe on a pure receiver; leaving this handler live
+        makes it safe on both.
 
         Instances are SESSION-scoped and shared across tests, so every caller
         MUST pair this with ``restore_fanout_backstops`` in a ``finally``.
@@ -1000,10 +988,11 @@ class CdpClient:
             // catchupViaSocket in the authoritative-sync rewire. backend-main
             // e2e pairs against EITHER plugin branch, so stub whichever method
             // exists and never .bind() an absent one (guards future renames).
-            for (const m of ['pull', 'coldReceive', 'catchupViaSocket', 'handleStreamEvent']) {{
+            // handleStreamEvent stays LIVE — see the docstring (#1503).
+            for (const m of ['pull', 'coldReceive', 'catchupViaSocket']) {{
                 if (typeof se[m] === 'function') {{
                     se['__orig_' + m] = se[m].bind(se);
-                    se[m] = m === 'handleStreamEvent' ? async () => {{}} : async () => 0;
+                    se[m] = async () => 0;
                 }}
             }}
             return 'isolated';
@@ -1019,7 +1008,7 @@ class CdpClient:
         (function() {{
             const se = {ENGINE_PATH};
             if (!se.__fanoutIsolated) return 'not-isolated';
-            for (const m of ['pull', 'coldReceive', 'catchupViaSocket', 'handleStreamEvent']) {{
+            for (const m of ['pull', 'coldReceive', 'catchupViaSocket']) {{
                 const orig = se['__orig_' + m];
                 if (orig) {{ se[m] = orig; delete se['__orig_' + m]; }}
             }}

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -959,6 +959,17 @@ class CdpClient:
         ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
         stays fully live. Idempotent.
 
+        PRECONDITION — the receiving device MUST already hold the file on disk
+        (what ``_establish_on_both`` guarantees). ``handleStreamEvent`` is left
+        live (below), and two of its legs write note bodies off the ~5s
+        checkpoint: ``applyStreamEvent``'s first-delivery
+        ``applyOp(eventToOp(...))`` and ``catchupViaSeqReplay``. Both gate
+        themselves out when the file is already present
+        (``priorState === undefined`` / ``!getAbstractFileByPath``). Suppress
+        before the receiver has the file and those legs converge the note for
+        you — the assert goes green with the fan-out completely dead, which is
+        the one outcome this helper exists to make impossible.
+
         ``handleStreamEvent`` is deliberately NOT stubbed (#1503). It was on the
         list to stop the ``note_changed`` handler STEP1-enrolling the note's CRDT
         room, whose ``crdt_msg`` stream would then deliver the body independently
@@ -967,14 +978,19 @@ class CdpClient:
         it cannot fire for the idle markdown note these tests use. A stray room
         would fail the enrolled-set assertion rather than pass silently.
 
-        Stubbing it was NOT free: ``applyStreamEvent`` is what commits
-        ``noteIdMap.set(event.path, noteId)``. With it dead the map goes stale,
-        ``pushFile`` reads a null id, and ``shouldDeferMint`` refuses the push —
-        so the suppressed device silently loses the ability to SEND. That is the
-        #1503 failure: ``test_cold_send_over_fanout_opens_no_room`` suppressed
-        the sender and then waited 120s for an edit that never left the device.
-        Suppression is only safe on a pure receiver; leaving this handler live
-        makes it safe on both.
+        Stubbing it was NOT free: ``applyStreamEvent`` commits
+        ``noteIdMap.set(event.path, noteId)`` (sync.ts:7213). With it dead a
+        device that loses its path→id entry never repairs it, ``pushFile`` reads
+        a null id, and ``shouldDeferMint`` refuses the push — so the suppressed
+        device silently loses the ability to SEND. That is the #1503 failure:
+        ``test_cold_send_over_fanout_opens_no_room`` suppressed the sender and
+        then waited 120s for an edit that never left the device.
+
+        What DROPPED the entry is not established. ``applyStreamEvent`` also
+        deletes (7088) and relocates (``moveIfIdRelocated``, 6953), so it cannot
+        be the remover while stubbed — restoring it restores the repair, not the
+        absence of the cause. Treat a repeat 120s timeout as that unfound
+        remover, not as a fan-out regression.
 
         Instances are SESSION-scoped and shared across tests, so every caller
         MUST pair this with ``restore_fanout_backstops`` in a ``finally``.

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -947,32 +947,35 @@ class CdpClient:
         broken fan-out — every existing crdt test still passes at checkpoint
         latency even if the fan-out is dead:
 
-          * ``pull()`` — its cursor-feed backfill (``flushFromCrdt`` on a
-            content_hash divergence).
-          * ``catchupViaSeqReplay()`` — the seq-replay cold-apply backstop.
-            Reached from ``scheduleSeqHeal`` (sync.ts:2589), from the topic-join
-            replay, and from ``applyStreamEvent``'s tail. Its row-apply writes
-            bodies to files that ALREADY exist (the cold-note leg at
-            sync.ts:8609 → ``convergeColdNoteRoomFree`` → ``flushFromCrdt``), so
-            no file-exists precondition contains it — it must be stubbed.
+          * ``catchupViaSeqReplay()`` — the seq-replay cold-apply backstop, and
+            as of plugin main the ONLY one. Reached from ``scheduleSeqHeal``
+            (sync.ts:2589), from the topic-join replay, and from
+            ``applyStreamEvent``'s tail. Its row-apply (``applyChange``) writes
+            bodies to files that ALREADY exist — the cold-note leg at
+            sync.ts:8609 → ``convergeColdNoteRoomFree`` → ``flushFromCrdt`` — so
+            no file-exists precondition contains it, and it also owns the
+            discovery enroll at sync.ts:8244. It must be stubbed.
 
-        This stubs both to no-ops (saving originals). ``coldReceive`` and
-        ``catchupViaSocket`` are its RETIRED predecessors, kept in the list only
-        so a backend branch paired against an older plugin build still isolates;
-        neither exists on plugin main (sync.ts:7705 "the retired
-        ``catchupViaSocket`` loop"). The fan-out is a SEPARATE channel dispatch:
-        ``channel.ts`` routes ``note_yjs_update`` straight to ``onNoteYjsUpdate``
-        → ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
+        ``pull``, ``coldReceive`` and ``catchupViaSocket`` are RETIRED
+        predecessors, kept in the list only so a backend branch paired against an
+        older plugin build still isolates. NONE of the three exist on plugin main
+        (sync.ts:7705 "the retired ``catchupViaSocket`` loop"); ``pull()``'s
+        cursor-feed backfill folded into the seq-replay above. ``pullAll()`` is
+        NOT its successor for this purpose — that is the user-triggered
+        replay-from-0 behind the pull-all command, never fired spontaneously.
+
+        The fan-out is a SEPARATE channel dispatch: ``channel.ts`` routes
+        ``note_yjs_update`` straight to ``onNoteYjsUpdate`` →
+        ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
         stays fully live. Idempotent.
 
-        Raises if it stubs nothing recognisable. The ``typeof`` guard makes a
-        rename SILENT — the loop skips every missing method and still reports
-        success. That is exactly what happened: ``coldReceive`` and
-        ``catchupViaSocket`` were both retired, so for an unknown number of runs
-        this helper stubbed ``pull()`` alone and the four "TRUE fan-out proof"
-        tests carried a live seq-replay backstop. A dead fan-out would have
-        passed them at checkpoint latency. The assertion below is what stops the
-        next rename doing the same thing.
+        Raises if no cold-apply backstop was stubbed. The ``typeof`` guard makes
+        a rename SILENT — the loop skips every missing method and still reports
+        success. All three original names had been retired, so this helper was
+        stubbing NOTHING: for an unknown number of runs the four "TRUE fan-out
+        proof" tests ran with every backstop live and would have passed with a
+        completely dead fan-out. The assertion below is what stops the next
+        rename doing the same thing.
 
         PRECONDITION — the receiving device MUST already hold the file on disk
         (what ``_establish_on_both`` guarantees). ``handleStreamEvent`` is left
@@ -1037,20 +1040,20 @@ class CdpClient:
             return result
         stubbed = set(str(result).split(",")) - {""}
         # A rename silently empties this loop (the typeof guard skips what is
-        # gone), and the tests then prove nothing. Fail loudly instead: pull is
-        # the cursor-feed backfill, and at least one cold-apply backstop must be
-        # dead or a broken fan-out still converges at checkpoint latency.
+        # gone) and the tests then prove nothing, so require the cold-apply
+        # backstop by name. It is the WHOLE isolation now: `pull()` was retired
+        # along with coldReceive/catchupViaSocket, and its cursor-feed backfill
+        # folded into catchupViaSeqReplay -> applyChange -> flushFromCrdt.
+        # `pullAll()` is not a substitute — it is the user-triggered replay-from-0
+        # behind the pull-all command, never fired spontaneously, so it cannot
+        # converge a note behind an assertion.
         cold_apply = {"catchupViaSeqReplay", "coldReceive", "catchupViaSocket"}
-        missing = []
-        if "pull" not in stubbed:
-            missing.append("pull")
         if not (stubbed & cold_apply):
-            missing.append(f"one of {sorted(cold_apply)}")
-        if missing:
             raise AssertionError(
                 f"suppress_fanout_backstops stubbed {sorted(stubbed) or 'NOTHING'} on CDP port "
-                f"{self.port} — missing {missing}. The plugin renamed a method out from under "
-                f"this helper; the fan-out tests would pass with a dead fan-out. Update the list."
+                f"{self.port} — none of {sorted(cold_apply)} exist on this plugin build. The "
+                f"cold-apply backstop was renamed out from under this helper; the fan-out tests "
+                f"would pass with a dead fan-out. Add the new name to the list."
             )
         return str(result)
 

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -948,25 +948,39 @@ class CdpClient:
         latency even if the fan-out is dead:
 
           * ``pull()`` — its cursor-feed backfill (``flushFromCrdt`` on a
-            content_hash divergence) AND ``coldReceive()``, which ``pull()`` is
-            the sole caller of (invoked at its tail, sync.ts:2707).
+            content_hash divergence).
+          * ``catchupViaSeqReplay()`` — the seq-replay cold-apply backstop.
+            Reached from ``scheduleSeqHeal`` (sync.ts:2589), from the topic-join
+            replay, and from ``applyStreamEvent``'s tail. Its row-apply writes
+            bodies to files that ALREADY exist (the cold-note leg at
+            sync.ts:8609 → ``convergeColdNoteRoomFree`` → ``flushFromCrdt``), so
+            no file-exists precondition contains it — it must be stubbed.
 
-        This stubs ``pull()`` and the cold-apply backstop (``coldReceive()``
-        pre-rewire / ``catchupViaSocket()`` post-authoritative-rewire — stubs
-        whichever the paired plugin build exposes) to no-ops (saving originals).
-        The fan-out is a SEPARATE channel dispatch: ``channel.ts`` routes
-        ``note_yjs_update`` straight to ``onNoteYjsUpdate`` →
-        ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
+        This stubs both to no-ops (saving originals). ``coldReceive`` and
+        ``catchupViaSocket`` are its RETIRED predecessors, kept in the list only
+        so a backend branch paired against an older plugin build still isolates;
+        neither exists on plugin main (sync.ts:7705 "the retired
+        ``catchupViaSocket`` loop"). The fan-out is a SEPARATE channel dispatch:
+        ``channel.ts`` routes ``note_yjs_update`` straight to ``onNoteYjsUpdate``
+        → ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
         stays fully live. Idempotent.
+
+        Raises if it stubs nothing recognisable. The ``typeof`` guard makes a
+        rename SILENT — the loop skips every missing method and still reports
+        success. That is exactly what happened: ``coldReceive`` and
+        ``catchupViaSocket`` were both retired, so for an unknown number of runs
+        this helper stubbed ``pull()`` alone and the four "TRUE fan-out proof"
+        tests carried a live seq-replay backstop. A dead fan-out would have
+        passed them at checkpoint latency. The assertion below is what stops the
+        next rename doing the same thing.
 
         PRECONDITION — the receiving device MUST already hold the file on disk
         (what ``_establish_on_both`` guarantees). ``handleStreamEvent`` is left
-        live (below), and two of its legs write note bodies off the ~5s
-        checkpoint: ``applyStreamEvent``'s first-delivery
-        ``applyOp(eventToOp(...))`` and ``catchupViaSeqReplay``. Both gate
-        themselves out when the file is already present
-        (``priorState === undefined`` / ``!getAbstractFileByPath``). Suppress
-        before the receiver has the file and those legs converge the note for
+        live (below), and its first-delivery leg
+        (``applyOp(eventToOp(...))``) writes a note body; it gates itself out
+        when the file is already present (``priorState === undefined`` /
+        ``!getAbstractFileByPath`` at the sync.ts:7302 call site). Suppress
+        before the receiver has the file and that leg converges the note for
         you — the assert goes green with the fan-out completely dead, which is
         the one outcome this helper exists to make impossible.
 
@@ -1000,23 +1014,45 @@ class CdpClient:
             const se = {ENGINE_PATH};
             if (se.__fanoutIsolated) return 'already-isolated';
             se.__fanoutIsolated = true;
-            // The cold-note apply backstop was renamed coldReceive ->
-            // catchupViaSocket in the authoritative-sync rewire. backend-main
-            // e2e pairs against EITHER plugin branch, so stub whichever method
-            // exists and never .bind() an absent one (guards future renames).
+            // The cold-apply backstop has been renamed twice: coldReceive ->
+            // catchupViaSocket -> catchupViaSeqReplay. backend-main e2e pairs
+            // against EITHER plugin branch, so stub whichever exists and never
+            // .bind() an absent one. Report WHICH were stubbed — the caller
+            // asserts on it, because a silent zero-stub run is a false green.
             // handleStreamEvent stays LIVE — see the docstring (#1503).
-            for (const m of ['pull', 'coldReceive', 'catchupViaSocket']) {{
+            const stubbed = [];
+            for (const m of ['pull', 'catchupViaSeqReplay', 'coldReceive', 'catchupViaSocket']) {{
                 if (typeof se[m] === 'function') {{
                     se['__orig_' + m] = se[m].bind(se);
                     se[m] = async () => 0;
+                    stubbed.push(m);
                 }}
             }}
-            return 'isolated';
+            return stubbed.join(',');
         }})()
         """
         result = await self.evaluate(js)
         logger.info("Fan-out backstops suppressed on CDP port %d: %s", self.port, result)
-        return result if isinstance(result, str) else "isolated"
+        if result == "already-isolated":
+            return result
+        stubbed = set(str(result).split(",")) - {""}
+        # A rename silently empties this loop (the typeof guard skips what is
+        # gone), and the tests then prove nothing. Fail loudly instead: pull is
+        # the cursor-feed backfill, and at least one cold-apply backstop must be
+        # dead or a broken fan-out still converges at checkpoint latency.
+        cold_apply = {"catchupViaSeqReplay", "coldReceive", "catchupViaSocket"}
+        missing = []
+        if "pull" not in stubbed:
+            missing.append("pull")
+        if not (stubbed & cold_apply):
+            missing.append(f"one of {sorted(cold_apply)}")
+        if missing:
+            raise AssertionError(
+                f"suppress_fanout_backstops stubbed {sorted(stubbed) or 'NOTHING'} on CDP port "
+                f"{self.port} — missing {missing}. The plugin renamed a method out from under "
+                f"this helper; the fan-out tests would pass with a dead fan-out. Update the list."
+            )
+        return str(result)
 
     async def restore_fanout_backstops(self) -> None:
         """Restore the methods stubbed by suppress_fanout_backstops()."""
@@ -1024,7 +1060,7 @@ class CdpClient:
         (function() {{
             const se = {ENGINE_PATH};
             if (!se.__fanoutIsolated) return 'not-isolated';
-            for (const m of ['pull', 'coldReceive', 'catchupViaSocket']) {{
+            for (const m of ['pull', 'catchupViaSeqReplay', 'coldReceive', 'catchupViaSocket']) {{
                 const orig = se['__orig_' + m];
                 if (orig) {{ se[m] = orig; delete se['__orig_' + m]; }}
             }}

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -155,11 +155,17 @@ async def test_edit_after_discovery_round_trips(vault_a, vault_b, cdp_a, cdp_b, 
 # would STILL pass at ~5s checkpoint latency, masking a dead fan-out.
 #
 # The tests below suppress those backstops on the RECEIVING device via
-# cdp.suppress_fanout_backstops() (stubs pull, coldReceive AND handleStreamEvent
-# — the note_changed room-enroll path — while leaving applyPushedNoteUpdate
-# untouched, since the fan-out is a separate channel dispatch). With the
-# backstops dead, a disk-convergence assert can ONLY be satisfied by the
-# fan-out, so a broken fan-out actually FAILS. See helpers/cdp.py.
+# cdp.suppress_fanout_backstops() (stubs pull and coldReceive, while leaving
+# applyPushedNoteUpdate untouched, since the fan-out is a separate channel
+# dispatch). With the backstops dead, a disk-convergence assert can ONLY be
+# satisfied by the fan-out, so a broken fan-out actually FAILS.
+#
+# handleStreamEvent used to be stubbed too, for the note_changed room-enroll
+# path. It no longer is (#1503): that enroll is already gated on
+# isCanvasPath || isLiveBound so it cannot fire for an idle markdown note, and
+# stubbing it broke the SENDING device — applyStreamEvent is what commits
+# noteIdMap, so a suppressed sender read a null id and shouldDeferMint refused
+# its push. See helpers/cdp.py.
 
 
 async def _confirm_room_free(cdp, path):
@@ -267,11 +273,16 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     An idle SEND ships its edit channel-up / as a durable /updates entry and is
     never required to enroll (sync.ts isCrdtManagedOffline: "Enrollment (STEP1)
     is only the down-sync pull, never required to SEND"). We suppress backstops
-    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B so its
-    own checkpoint `note_changed` echo can't drive a RECEIVE-side enroll — the
-    enrolled-set assertion then isolates the SEND path. The negative signal is a
-    direct read of B's CrdtEnrollment.enrolled set (deterministic, no log-flush
-    timing dependency).
+    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B so a
+    checkpoint-driven pull can't converge the note behind the assertion. The
+    negative signal is a direct read of B's CrdtEnrollment.enrolled set
+    (deterministic, no log-flush timing dependency).
+
+    #1503: suppression used to stub handleStreamEvent as well, which killed B's
+    noteIdMap upkeep — B's push was refused by shouldDeferMint and the edit never
+    left the device, so this timed out at 120s looking like a receive-side bug.
+    The handler now stays live on both devices; the room-enroll it was stubbed to
+    prevent is already gated on isCanvasPath || isLiveBound.
     """
     path = "E2E/Crdt/FanoutColdSend.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin\n", "origin")

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -218,8 +218,8 @@ async def test_idle_note_converges_via_fanout_only(vault_a, vault_b, cdp_a, cdp_
     channel fan-out ALONE.
 
     B never opens or edits the note. Before A's edit we suppress the
-    checkpoint-driven backstops on B (pull() cursor-backfill + coldReceive). The
-    ONLY path that can then converge B's disk is the server's `note_yjs_update`
+    checkpoint-driven backstop on B (catchupViaSeqReplay's row-apply). The ONLY
+    path that can then converge B's disk is the server's `note_yjs_update`
     broadcast → applyPushedNoteUpdate. So a broken fan-out FAILS here instead of
     silently passing at checkpoint latency.
 
@@ -306,13 +306,13 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     Whatever dropped the entry is still there and still unstubbed. If this test
     times out at 120s again, that is the thread to pull, not the fan-out.
 
-    Tension worth knowing: pull() is the other noteIdMap repair (the manifest
-    reconcile at sync.ts:1066), and this test keeps it stubbed on B for the
-    enroll reason above. So B deliberately runs with one repair path dead.
+    Tension worth knowing: catchupViaSeqReplay reaches applyChange, which is a
+    noteIdMap writer, and B runs with it stubbed for the enroll reason above. So
+    B deliberately runs with one map-repair path dead while the assertion holds.
     """
-    # ponytail: B keeps pull() stubbed on purpose. If #1526 lands and the map
-    # loss turns out to need that repair, this test needs the enrolled-set
-    # assertion rebuilt on something other than "no room may exist on B".
+    # ponytail: B keeps catchupViaSeqReplay stubbed on purpose. If #1526 lands
+    # and the map loss turns out to need that repair, this test needs the
+    # enrolled-set assertion rebuilt on something other than "no room on B".
     path = "E2E/Crdt/FanoutColdSend.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin\n", "origin")
     note_id_b = await _confirm_room_free(cdp_b, path)

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -211,11 +211,15 @@ async def test_idle_note_converges_via_fanout_only(vault_a, vault_b, cdp_a, cdp_
     """[P0] A pre-existing IDLE note on B converges to A's edit via the vault-
     channel fan-out ALONE.
 
-    B never opens or edits the note. Before A's edit we suppress every
-    checkpoint-driven backstop on B (pull() cursor-backfill + coldReceive, and
-    the note_changed room-enroll path). The ONLY path that can then converge B's
-    disk is the server's `note_yjs_update` broadcast → applyPushedNoteUpdate. So
-    a broken fan-out FAILS here instead of silently passing at checkpoint latency.
+    B never opens or edits the note. Before A's edit we suppress the
+    checkpoint-driven backstops on B (pull() cursor-backfill + coldReceive). The
+    ONLY path that can then converge B's disk is the server's `note_yjs_update`
+    broadcast → applyPushedNoteUpdate. So a broken fan-out FAILS here instead of
+    silently passing at checkpoint latency.
+
+    B already holds the file (`_establish_on_both`), which is what keeps
+    handleStreamEvent's own content-writing legs out of the picture — see the
+    precondition in suppress_fanout_backstops().
     """
     path = "E2E/Crdt/FanoutPassive.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "shared base\n", "shared base")
@@ -273,16 +277,27 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     An idle SEND ships its edit channel-up / as a durable /updates entry and is
     never required to enroll (sync.ts isCrdtManagedOffline: "Enrollment (STEP1)
     is only the down-sync pull, never required to SEND"). We suppress backstops
-    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B so a
-    checkpoint-driven pull can't converge the note behind the assertion. The
-    negative signal is a direct read of B's CrdtEnrollment.enrolled set
-    (deterministic, no log-flush timing dependency).
+    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B so
+    pull()'s own discovery/heal enroll (sync.ts:8244, and the un-gated cold-note
+    re-handshake `_confirm_room_free` documents) can't open a room on B and break
+    the negative assertion. That assertion is a direct read of B's
+    CrdtEnrollment.enrolled set (deterministic, no log-flush timing dependency).
 
-    #1503: suppression used to stub handleStreamEvent as well, which killed B's
-    noteIdMap upkeep — B's push was refused by shouldDeferMint and the edit never
-    left the device, so this timed out at 120s looking like a receive-side bug.
-    The handler now stays live on both devices; the room-enroll it was stubbed to
-    prevent is already gated on isCanvasPath || isLiveBound.
+    #1503: suppression used to stub handleStreamEvent as well. With it dead B's
+    `pushFile` read a null id from noteIdMap, shouldDeferMint refused the push,
+    and the edit never left the device — a 120s timeout that read as a
+    receive-side fan-out bug. Restoring the handler fixes it, and the room-enroll
+    it was stubbed to prevent is already gated on isCanvasPath || isLiveBound.
+
+    NOT established: what emptied B's map in the first place. applyStreamEvent
+    both sets (sync.ts:7213) and deletes/relocates (7088, moveIfIdRelocated at
+    6953), so stubbing it removed a REPAIR — it cannot itself be the remover.
+    Whatever dropped the entry is still there and still unstubbed. If this test
+    times out at 120s again, that is the thread to pull, not the fan-out.
+
+    Tension worth knowing: pull() is the other noteIdMap repair (the manifest
+    reconcile at sync.ts:1066), and this test keeps it stubbed on B for the
+    enroll reason above. So B deliberately runs with one repair path dead.
     """
     path = "E2E/Crdt/FanoutColdSend.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin\n", "origin")

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -148,17 +148,23 @@ async def test_edit_after_discovery_round_trips(vault_a, vault_b, cdp_a, cdp_b, 
 # ---------------------------------------------------------------------------
 #
 # The tests above prove eventual convergence but NOT that it rides the vault-
-# channel fan-out (`note_yjs_update` → applyPushedNoteUpdate). Two checkpoint-
-# driven backstops on the receiving device also converge a cold note: pull()'s
-# cursor-feed backfill (flushFromCrdt) and coldReceive() (invoked at pull()'s
-# tail). So if applyPushedNoteUpdate were completely broken, every test above
-# would STILL pass at ~5s checkpoint latency, masking a dead fan-out.
+# channel fan-out (`note_yjs_update` → applyPushedNoteUpdate). A checkpoint-
+# driven backstop on the receiving device also converges a cold note:
+# catchupViaSeqReplay's row-apply (applyChange → flushFromCrdt). So if
+# applyPushedNoteUpdate were completely broken, every test above would STILL
+# pass at ~5s checkpoint latency, masking a dead fan-out.
 #
-# The tests below suppress those backstops on the RECEIVING device via
-# cdp.suppress_fanout_backstops() (stubs pull and coldReceive, while leaving
-# applyPushedNoteUpdate untouched, since the fan-out is a separate channel
-# dispatch). With the backstops dead, a disk-convergence assert can ONLY be
-# satisfied by the fan-out, so a broken fan-out actually FAILS.
+# The tests below suppress that backstop on the RECEIVING device via
+# cdp.suppress_fanout_backstops(), leaving applyPushedNoteUpdate untouched since
+# the fan-out is a separate channel dispatch. With it dead, a disk-convergence
+# assert can ONLY be satisfied by the fan-out, so a broken fan-out actually
+# FAILS.
+#
+# It did not, for an unknown number of runs. All three names the helper stubbed
+# (pull, coldReceive, catchupViaSocket) had been retired from the plugin, and
+# the helper skips a method that no longer exists — so it stubbed NOTHING and
+# these tests ran with every backstop live. The helper now raises if it cannot
+# stub a cold-apply backstop, and conftest asserts the surface at session start.
 #
 # handleStreamEvent used to be stubbed too, for the note_changed room-enroll
 # path. It no longer is (#1503): that enroll is already gated on
@@ -279,7 +285,7 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     is only the down-sync pull, never required to SEND"). We suppress backstops
     on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B to
     keep anything from opening a room there and breaking the negative assertion.
-    TWO paths would: pull()'s discovery/heal enroll (sync.ts:8244, and the
+    TWO paths would: catchupViaSeqReplay's discovery enroll (applyChange, sync.ts:8244, and the
     un-gated cold-note re-handshake `_confirm_room_free` documents), and
     catchupViaSeqReplay → convergeColdNoteRoomFree, which falls back to
     socketConverge → fireCrdtReHandshake (sync.ts:6288) when the room-free

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -300,19 +300,20 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     receive-side fan-out bug. Restoring the handler fixes it, and the room-enroll
     it was stubbed to prevent is already gated on isCanvasPath || isLiveBound.
 
-    NOT established: what emptied B's map in the first place. applyStreamEvent
-    both sets (sync.ts:7213) and deletes/relocates (7088, moveIfIdRelocated at
-    6953), so stubbing it removed a REPAIR — it cannot itself be the remover.
-    Whatever dropped the entry is still there and still unstubbed. If this test
-    times out at 120s again, that is the thread to pull, not the fan-out.
+    Nothing deletes B's map entry (#1526): a full sync REBUILDS noteIdMap and
+    leaves the path transiently unmapped, and this test triggers one on B via
+    _confirm_room_free immediately before writing on B. The write lands in that
+    window, shouldDeferMint refuses the push, and the edit falls to the flush
+    queue's ~107s recovery. Measured twice at 109s and 108s, against a 120s
+    deadline — a coin-flip, not a fan-out failure. The re-poll below closes it.
 
     Tension worth knowing: catchupViaSeqReplay reaches applyChange, which is a
     noteIdMap writer, and B runs with it stubbed for the enroll reason above. So
     B deliberately runs with one map-repair path dead while the assertion holds.
     """
-    # ponytail: B keeps catchupViaSeqReplay stubbed on purpose. If #1526 lands
-    # and the map loss turns out to need that repair, this test needs the
-    # enrolled-set assertion rebuilt on something other than "no room on B".
+    # ponytail: B keeps catchupViaSeqReplay stubbed on purpose. The re-poll
+    # before the write is what makes that safe — B's map is proven present at
+    # the only moment it has to be, so no repair path needs to be live.
     path = "E2E/Crdt/FanoutColdSend.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin\n", "origin")
     note_id_b = await _confirm_room_free(cdp_b, path)
@@ -320,6 +321,22 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     try:
         await cdp_a.suppress_fanout_backstops()
         await cdp_b.suppress_fanout_backstops()
+
+        # B's map must hold the path AT WRITE TIME, not merely when
+        # _confirm_room_free checked it (#1526). `shouldDeferMint` refuses a
+        # push on `unmapped + engine-flushed` (sync.ts:5292), and a full sync
+        # rebuilding noteIdMap leaves the path transiently unmapped — this test
+        # runs one on B via _confirm_room_free and then writes on B, so the edit
+        # can land inside B's own rebuild window. The push is then deferred to
+        # the flush queue, whose recovery the plugin measures at ~107s in CI
+        # (sync.ts:4419 comment) — under the 120s deadline below only by a hair,
+        # which is what made this test flake as a 120s content timeout that
+        # looked like a dead fan-out.
+        #
+        # Re-poll immediately before the write. This removes the race rather
+        # than running it, and a genuinely lost mapping now fails here with the
+        # cause named instead of two minutes later with a symptom.
+        await cdp_b.wait_for_note_id_for_path(path, timeout=CRDT_TIMEOUT)
 
         # B edits the CLOSED note (never opened in the editor).
         write_note(vault_b, path, "origin\nCOLD_SEND_FROM_B\n")

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -277,11 +277,16 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     An idle SEND ships its edit channel-up / as a durable /updates entry and is
     never required to enroll (sync.ts isCrdtManagedOffline: "Enrollment (STEP1)
     is only the down-sync pull, never required to SEND"). We suppress backstops
-    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B so
-    pull()'s own discovery/heal enroll (sync.ts:8244, and the un-gated cold-note
-    re-handshake `_confirm_room_free` documents) can't open a room on B and break
-    the negative assertion. That assertion is a direct read of B's
-    CrdtEnrollment.enrolled set (deterministic, no log-flush timing dependency).
+    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B to
+    keep anything from opening a room there and breaking the negative assertion.
+    TWO paths would: pull()'s discovery/heal enroll (sync.ts:8244, and the
+    un-gated cold-note re-handshake `_confirm_room_free` documents), and
+    catchupViaSeqReplay → convergeColdNoteRoomFree, which falls back to
+    socketConverge → fireCrdtReHandshake (sync.ts:6288) when the room-free
+    converge fails — deliberately NOT gated on isLiveBound, so stubbing pull()
+    alone does not close it. Both are in the suppression list. That assertion is
+    a direct read of B's CrdtEnrollment.enrolled set (deterministic, no
+    log-flush timing dependency).
 
     #1503: suppression used to stub handleStreamEvent as well. With it dead B's
     `pushFile` read a null id from noteIdMap, shouldDeferMint refused the push,
@@ -299,6 +304,9 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
     reconcile at sync.ts:1066), and this test keeps it stubbed on B for the
     enroll reason above. So B deliberately runs with one repair path dead.
     """
+    # ponytail: B keeps pull() stubbed on purpose. If #1526 lands and the map
+    # loss turns out to need that repair, this test needs the enrolled-set
+    # assertion rebuilt on something other than "no room may exist on B".
     path = "E2E/Crdt/FanoutColdSend.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin\n", "origin")
     note_id_b = await _confirm_room_free(cdp_b, path)


### PR DESCRIPTION
Fixes #1503. The failure is on the SEND side, and the suppression helper causes it.

## What is proven

`suppress_fanout_backstops()` stubbed four methods. Three are genuine convergence backstops that must die for a fan-out proof to mean anything. `handleStreamEvent` is not one of them, and stubbing it broke the sending device.

From the `ci-crdt-debug` artifact of run [33220824768](https://github.com/engram-app/Engram/actions/runs/33220824768), every line for `n9` = `E2E/Crdt/FanoutColdSend.md`:

```
23:46:08.995  [vault] modify path=E2E/Crdt/FanoutColdSend.md bytes=24
23:46:08.995  [push]  Push start: n9 | type=note | active=1
23:46:08.995  [push]  Mint refused (engine-flushed file, id relocated away): n9

   ... 109 seconds. no note_yjs_update emitted for this note id ...

23:47:58.495  [push]  CRDT push ok: n9        <- only after restore_fanout_backstops()
```

`pushFile` read a null id from `noteIdMap`, `shouldDeferMint` (issue #972) refused to mint a second one, and nothing was transmitted. The test waited 120s for an edit that never left device B. The server held only the 7-byte base for the entire assertion window — the `GET 200` / 306 bytes cited in #1503 as "the server has the content" is the post-failure probe, read after the `finally` restored the backstops.

Restoring `handleStreamEvent` makes it pass. `e2e-crdt` is 25/25 on [run 33362890160](https://github.com/engram-app/Engram/actions/runs/33362890160), including the three sibling fan-out tests that were already green.

## What is NOT proven — corrected after review

An earlier version of this PR said stubbing `handleStreamEvent` is what emptied B's map. That is wrong. `applyStreamEvent` both sets (`sync.ts:7213`) **and** deletes (`7088`) / relocates (`moveIfIdRelocated`, `6953`), so while stubbed it cannot have been the remover either.

What the stub actually removed is the **repair**: `noteIdMap.set` is how a device that lost its path→id entry gets it back. Something else drops the entry, it is still unstubbed, and it is still there. Filed separately as #1526.

This PR is still the right fix — it restores the repair and turns a hard failure into a pass — but a repeat 120s timeout on this test is that unfound remover, not a fan-out regression. That caveat is now in the helper docstring rather than only in this description.

## Why removing the stub is safe

The enroll it was there to prevent is at `sync.ts` ~7222 and is already gated:

```ts
if (this.isCanvasPath(normalizePath(event.path)) || this.isLiveBound(normalizePath(event.path))) {
    this.crdtEnrollment?.enroll(noteId);
}
```

Every test using this helper uses an idle markdown note — neither canvas nor live-bound — so it cannot fire. If it somehow did, the test's final assertion reads `CrdtEnrollment.enrolled` directly, so a stray room fails loudly rather than passing silently.

The docstring justified the stub by citing `sync.ts:3246`. That line is `stageAndConverge` now; the reference went stale and outlived its reason.

## Precondition this exposes

Leaving `handleStreamEvent` live re-opens two content-writing legs that reach disk only through it: `applyStreamEvent`'s first-delivery `applyOp(eventToOp(...))` and `catchupViaSeqReplay`. Both gate themselves out when the file already exists, which every current caller guarantees via `_establish_on_both`.

That precondition was nowhere in the docstring and now is: **suppress only on a device that already holds the file.** A caller that suppresses before the receiver has the file gets a green assert with the fan-out completely dead — the one outcome the helper exists to prevent.

## Also in here

`pause_incoming_sync` / `resume_incoming_sync` deleted — zero callers repo-wide, and they stubbed `handleStreamEvent` the same way. Replaced with a comment recording the hazard.

Docstrings on the helper, the module comment block, and both affected tests corrected. The helper previously claimed the send path was "untouched by suppression", which is what made this look like a receive-side bug for three days.

## Verification

- `e2e-crdt` 25/25 green, `force_full=true` ([run 33362890160](https://github.com/engram-app/Engram/actions/runs/33362890160)). All 17 CI jobs green.
- `ruff check` + `py_compile` clean.
- Note this needs `workflow_dispatch` with `force_full=true` — a normal dispatch fingerprint-skips `e2e-crdt`, which is how the regression rode onto main unnoticed.

## Not fixed here

- #1526 — whatever drops the path→id entry.
- The fingerprint-skip that let `e2e-crdt` report `skipped` on main for days. Deserves its own issue.

#1514 and #1522 are duplicates of #1503 and can be closed with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp
