### PR TITLE
fix(billing): enforce the search cap on the MCP transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,8 @@ Grouped index into `docs/context/`. Each entry is a trigger → doc; read the do
 - Widening a column type without rewriting the table (`varchar[]` → `text[]` DOES rewrite; how to measure with relfilenode; when `# squawk-ignore-file` is justified) → `docs/context/migration-column-type-rewrites.md`
 - All env vars by category → `docs/context/environment-variables.md`
 - Rate limiter & cap architecture — Postgres + BEAM only, zero Redis → `docs/context/rate-limiter-architecture.md`
+- Adding a plan-limit / abuse gate as a plug, or a Free cap is not firing for a user clearly over it (a `request_path` guard cannot see MCP — every tool is one route, named in the JSON-RPC body) → `docs/context/mcp-bypasses-path-shaped-plugs.md`
+- Proving a limit is actually WIRED (delete the gate line and re-run; a green suite means unproven) → `docs/context/mcp-bypasses-path-shaped-plugs.md`
 - Cross-workspace SaaS pricing model → `../engram-workspace/docs/context/pricing-strategy.md`
 - Adding a top-level route / Plug.Static mount / Phoenix scope / Cloudflare rule, and wondering if it can collide with a vault name (it cannot — vault URLs are `/v/:slug`; the old `@reserved_slugs` list is deleted) → `docs/context/vault-url-prefix-and-collision-surface.md`
 

--- a/docs/context/mcp-bypasses-path-shaped-plugs.md
+++ b/docs/context/mcp-bypasses-path-shaped-plugs.md
@@ -79,3 +79,54 @@ are:
 
 Cap-reached events are returned to the caller (402 / `-32_005`), not logged, so
 Loki will not show them either.
+
+## The backstops that did not catch it, and why
+
+Two static checks were supposed to cover this class. Both had the same blind
+spot in different forms; both are fixed alongside the bug.
+
+**`Engram.Billing.LimitEnforcementTest`** asserted only
+`String.contains?(blob, ":#{key}")` over `lib/`. The key merely had to APPEAR
+somewhere, in any context — a moduledoc mention, an `@unenforced` reason
+string, or a call site no request can reach all passed equally.
+`:external_ai_searches_per_day` appeared in the dead plug branch, so the guard
+was green the entire time the cap was unenforced. It now walks the AST and
+requires a real `Billing.{effective_limit, check_limit, check_feature,
+limit_enforced?}` call with the key as an atom literal.
+
+That raises the floor from "the string exists" to "a gate exists". It still
+cannot prove the gate is REACHABLE — only a test that drives the actual route
+or worker does that.
+
+**A stale `@unenforced` entry is worse than none.** `cross_vault_search` sat in
+that exemption list as "legacy UX flag; no per-request gate point yet" long
+after `Engram.Search.cross_vault_allowed/2` started gating it, and nothing
+failed when the comment went stale. A second test now asserts the exemption
+list contains no key that is in fact gated, and
+`Engram.Search.CrossVaultGateTest` pins both the gate and its one deliberate
+MCP bypass.
+
+**`mix engram.lint.limit_keys`** skipped piped call sites. `Code.string_to_quoted!/2`
+does not expand `|>`, so `user |> Billing.effective_limit(:notes_cap)` parses as a
+call with a single argument, fell through the `[_user, key | _rest]` clause, and hit
+a catch-all commented "arity mismatch — ignore". A typo'd key in that shape was
+silently unlinted: exactly the thing the lint exists to catch. Now handled.
+
+## How to actually prove a limit
+
+Mutation is the cheap check. Delete the gate line and run the suite:
+
+```
+# before adding a test, confirm the current suite does NOT catch this
+$ <remove the `:ok <- SomeGate.check(...)` line>
+$ mix test test/path/to/relevant_test.exs
+```
+
+If it stays green, the limit is unproven no matter how many unit tests the
+gate's module has. `ConversationMeter.tick/1` had 8 unit tests and could be
+deleted from `McpController.dispatch/3` with 91 tests still passing.
+
+Match the test to where enforcement lives — a route test for a plug or
+controller gate, a worker test for `EmbedNote` / `InactivityCleanup`, a context
+test for `Accounts.Export` or `Search`. A conn-driving test is the wrong lens
+for a worker-enforced key and will report a false gap.

--- a/docs/context/mcp-bypasses-path-shaped-plugs.md
+++ b/docs/context/mcp-bypasses-path-shaped-plugs.md
@@ -24,7 +24,7 @@ Result: `external_ai_searches_per_day` (15/day on Free) was unenforced on MCP â€
 the exact client class the plug's own moduledoc named. The only remaining bound
 was `ConversationMeter` (5 conversations x 50 queries = ~250 tool calls/day, and
 every tool counts, not just searches), so Free got roughly 16x its intended
-search allowance. Fixed by engram#1506.
+search allowance. Fixed by engram#1527.
 
 **Being on the shared pipeline is not the same as running.** The pipeline
 guarantees the plug is *invoked*; a path guard inside it decides whether it
@@ -55,6 +55,20 @@ plug is at most half the gate. Grep the MCP handlers for the underlying context
 call (e.g. `grep -rn "Search.search(" lib/`) and confirm every call site is
 covered â€” MCP handlers call `Engram.*` contexts directly and never re-enter the
 HTTP stack.
+
+## Residual hole: uncharged searches via the write path
+
+`auto_place_folder/4` is exempt on purpose (see below), and that leaves the cap
+partially evadable. Repeated `write_note` against an EXISTING path grows no note
+count, so `notes_cap` never binds, and each call runs one uncharged search. The
+ceiling is `ConversationMeter` (~250 tool calls/day), so a determined Free client
+can reach roughly 250 searches/day against an intended 15.
+
+Accepted, not overlooked. Charging it would fail note creation with a search-cap
+error, which is a worse product than a bounded bypass that still costs the
+attacker a write per search. If this ever needs closing, the lever is a separate
+cheap bucket for write-path auto-placement, not folding it into
+`external_ai_searches_per_day`.
 
 ## Deliberate exemptions (do not "fix" these)
 

--- a/docs/context/mcp-bypasses-path-shaped-plugs.md
+++ b/docs/context/mcp-bypasses-path-shaped-plugs.md
@@ -1,0 +1,81 @@
+# MCP bypasses path-shaped plugs
+
+**Trigger:** you are adding or reviewing a plan-limit / abuse gate that lives in a
+plug, or a Free-tier cap is not firing for a user who is clearly over it.
+
+## The trap
+
+`EngramWeb.Plugs.EnforceSearchCap` sat on the shared `:authed_api` pipeline —
+the pipeline whose own comment says it is used by BOTH the REST scope and the
+MCP scope "so a new security control can't be added to one and silently missed
+on the other". It was still missed on MCP, because the plug's first clause is:
+
+```elixir
+def call(%Plug.Conn{method: "POST", request_path: "/api/search"} = conn, _opts)
+```
+
+MCP is a single route. Every tool — `search_notes`, `create_note`, all 21 of
+them — arrives as `POST /api/mcp` with the operation named in the **JSON-RPC
+body**, not the path. A plug matching on `request_path` therefore sees `/api/mcp`
+and falls through to the `def call(conn, _opts), do: conn` catch-all for the
+entire MCP transport.
+
+Result: `external_ai_searches_per_day` (15/day on Free) was unenforced on MCP —
+the exact client class the plug's own moduledoc named. The only remaining bound
+was `ConversationMeter` (5 conversations x 50 queries = ~250 tool calls/day, and
+every tool counts, not just searches), so Free got roughly 16x its intended
+search allowance. Fixed by engram#1506.
+
+**Being on the shared pipeline is not the same as running.** The pipeline
+guarantees the plug is *invoked*; a path guard inside it decides whether it
+*does anything*.
+
+## Why the tests did not catch it
+
+`test/engram_web/plugs/enforce_search_cap_test.exs` calls `EnforceSearchCap.call/2`
+directly on a synthesized conn whose `request_path` is already `/api/search`. It
+proves the rule, never the routing. A unit test that hands the plug the exact
+conn shape it pattern-matches on can never discover that no real request has
+that shape.
+
+The regression tests added with the fix drive `POST /api/mcp` through the real
+router (`test/engram_web/controllers/mcp_controller_test.exs`, describe
+`"external_ai_searches_per_day over MCP"`).
+
+## The rule
+
+A limit that must hold across transports lives in a **plain module**, not in a
+plug. `Engram.Usage.SearchCap.spend/2` owns both the bucket choice
+(external vs in-app) and the spend; the plug and `EngramWeb.McpController` each
+call it and only differ in how they render a denial (402 via `LimitResponse` on
+REST, JSON-RPC `-32_005` on MCP).
+
+When you add a cap, ask: **can this operation be reached over MCP?** If yes, the
+plug is at most half the gate. Grep the MCP handlers for the underlying context
+call (e.g. `grep -rn "Search.search(" lib/`) and confirm every call site is
+covered — MCP handlers call `Engram.*` contexts directly and never re-enter the
+HTTP stack.
+
+## Deliberate exemptions (do not "fix" these)
+
+- **`auto_place_folder`** (`Engram.MCP.Handlers`, reached from `create_note` /
+  `write_note`) runs a search internally for folder auto-placement. It is NOT
+  charged to the search bucket: the search is incidental to a write, is not the
+  abuse vector, and charging it would fail note creation with a search-cap error.
+- **`cross_vault_search`** is a Pro feature on REST but is deliberately bypassed
+  on MCP via `allow_cross_vault: true` — multi-vault search is the MCP default
+  on every tier (product decision 2026-07-10). See `Engram.Search.cross_vault_allowed/2`.
+
+## Observability
+
+There is still **no per-user usage counter** in Loki or Prometheus, and
+`Billing.plan_state/1` returns caps only, never current counts — so "how close
+is this user to their cap" is unanswerable from observability. The only signals
+are:
+
+- `engram_prom_ex_usage_daily_cap_total{kind,decision}` — allow/deny/fail_open
+  counts per bucket, from `Engram.Usage.DailyCap` (no `user_id` tag, by design).
+- `Engram.UsageMeters.notes_count/1` — DB-side, reachable only via ECS Exec + IEx.
+
+Cap-reached events are returned to the caller (402 / `-32_005`), not logged, so
+Loki will not show them either.

--- a/e2e/helpers/api.py
+++ b/e2e/helpers/api.py
@@ -327,6 +327,20 @@ class ApiClient:
         )
         return resp.json(), resp.status_code
 
+    def search_response(self, query: str, **body_extra) -> requests.Response:
+        """POST /search, returning the raw response instead of raising.
+
+        `search` raises on non-2xx, which makes it useless for asserting a
+        refusal (402 plan-limit, 429). Those assertions used to hand-roll their
+        own `session.post`, which silently opts out of SEARCH_TIMEOUT — the
+        exact hole `e2e/unit/test_search_timeout.py` guards. Same one budget,
+        caller inspects the status.
+        """
+        body: dict = {"query": query, **body_extra}
+        return self.session.post(
+            f"{self.base_url}/search", json=body, timeout=SEARCH_TIMEOUT
+        )
+
     def get_manifest(self) -> dict:
         """GET /sync/manifest. Returns manifest dict."""
         resp = self.session.get(f"{self.base_url}/sync/manifest", timeout=10)

--- a/e2e/tests/api_only/test_75_free_mcp_search_cap.py
+++ b/e2e/tests/api_only/test_75_free_mcp_search_cap.py
@@ -1,0 +1,170 @@
+"""E2E test 75: the Free search cap binds the MCP transport, not just /api/search.
+
+`EnforceSearchCap` is a plug guarded on `request_path: "/api/search"`. MCP tool
+calls arrive as a JSON-RPC body at `POST /api/mcp` and reach
+`Engram.Search.search/4` directly, so for the whole life of that plug the Free
+tier's `external_ai_searches_per_day` was unenforced on the exact client class
+its own moduledoc named. See docs/context/mcp-bypasses-path-shaped-plugs.md.
+
+The unit tests for that plug synthesize a conn whose `request_path` is already
+`/api/search`, which proves the rule and never the routing. This test proves the
+routing against a real server:
+
+  - a Free user's `search_notes` MCP call succeeds while budget remains,
+  - the next one comes back as JSON-RPC error -32_005 naming the limit key,
+  - `POST /api/search` for the SAME user is refused too — one bucket, two
+    transports, so a client cannot launder searches by switching protocol,
+  - a non-search MCP tool still works, i.e. we capped searches and not the
+    whole server.
+
+Auth is the OAuth device flow (internal JWT), not an API key: Free defaults
+`api_rps_cap` to 0 and `api_write_enabled` to false, so an API-key-authed MCP
+call is rejected by RequireApiRpsBudget long before reaching the search cap.
+Device-flow tokens are the real Free MCP path anyway.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+
+import pytest
+import requests
+
+from helpers.clerk import ClerkClient
+from helpers.oauth import provision_oauth_tokens
+
+logger = logging.getLogger(__name__)
+
+API_URL = os.environ.get("ENGRAM_API_URL", "http://localhost:8100/api")
+CLERK_SECRET = os.environ.get("E2E_CLERK_SECRET_KEY", "")
+CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres-1")
+
+pytestmark = pytest.mark.skipif(
+    not CLERK_SECRET,
+    reason="E2E_CLERK_SECRET_KEY not set — Clerk auth required for Free MCP search cap test",
+)
+
+# Pinned to 1 so the boundary is tight and the test spends one token, not 15.
+# DailyCap refills at capacity/86_400 per second, so a capacity of 1 regenerates
+# in ~24h — nothing leaks back inside a test run.
+SEARCH_BUDGET = 1
+
+
+def _set_search_cap(clerk_user_id: str, value: int) -> None:
+    """Pin external_ai_searches_per_day for one user via an operator override.
+
+    Keyed on `users.external_id` (the Clerk user id) rather than email:
+    provision_oauth_tokens mints the email internally and does not return it.
+    A DB trigger pg_notifies on user_limit_overrides writes, so OverrideCache
+    picks this up without a restart.
+    """
+    sql = (
+        "INSERT INTO user_limit_overrides (user_id, key, value, reason, set_by) "
+        f"VALUES ((SELECT id FROM users WHERE external_id = '{clerk_user_id}'), "
+        f"'external_ai_searches_per_day', '{{\"v\": {value}}}'::jsonb, 'e2e-test', 'e2e') "
+        "ON CONFLICT (user_id, key) DO UPDATE "
+        "SET value = EXCLUDED.value, set_at = NOW()"
+    )
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", CI_POSTGRES_CONTAINER,
+            "psql", "-U", "engram", "-d", "engram", "-c", sql,
+        ],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"_set_search_cap failed: {result.stderr.strip()}")
+    assert "INSERT 0 1" in result.stdout, (
+        f"override did not apply (user not found?): {result.stdout.strip()}"
+    )
+
+
+def _mcp_call(token: str, name: str, arguments: dict) -> dict:
+    resp = requests.post(
+        f"{API_URL}/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    assert resp.status_code == 200, (
+        f"MCP transport should answer 200 even for JSON-RPC errors; "
+        f"got {resp.status_code}: {resp.text[:300]}"
+    )
+    return resp.json()
+
+
+def test_free_mcp_search_cap_binds_and_is_shared_with_rest():
+    clerk = ClerkClient(CLERK_SECRET)
+    clerk_user_id, tokens = asyncio.run(
+        provision_oauth_tokens(clerk, API_URL, label="mcpcap")
+    )
+    token = tokens["access_token"]
+    vault_id = tokens["vault_id"]
+
+    # Stays Free on purpose — provision_oauth_tokens does not call
+    # grant_test_plan, so §G defaults hold and the cap under test is real.
+    _set_search_cap(clerk_user_id, SEARCH_BUDGET)
+
+    # Seed one note so a successful search has something to match and an empty
+    # result cannot be mistaken for a refusal.
+    seed = requests.post(
+        f"{API_URL}/notes",
+        json={
+            "path": "Health/Supplements.md",
+            "content": "# Supplements\n\nOmega 3 and vitamin D.",
+            "mtime": 1000.0,
+        },
+        headers={"Authorization": f"Bearer {token}", "X-Vault-ID": vault_id},
+        timeout=15,
+    )
+    assert seed.status_code in (200, 201), (
+        f"seed note failed: {seed.status_code} {seed.text[:300]}"
+    )
+
+    # 1. Budget remains → the tool answers normally.
+    first = _mcp_call(token, "search_notes", {"query": "supplements"})
+    assert "result" in first, f"first MCP search should succeed; got {first}"
+    assert "error" not in first, f"first MCP search should not error; got {first}"
+
+    # 2. Budget spent → JSON-RPC error naming the limit key. Before the fix this
+    #    returned a normal result forever: the plug never saw /api/mcp.
+    second = _mcp_call(token, "search_notes", {"query": "supplements"})
+    assert "error" in second, (
+        f"second MCP search must be refused — the Free search cap does not bind "
+        f"the MCP transport; got {second}"
+    )
+    assert second["error"]["code"] == -32_005, (
+        f"expected JSON-RPC -32005 rate_limited; got {second['error']}"
+    )
+    assert "external_ai_searches_per_day" in second["error"]["message"], (
+        f"the refusal must name the limit key so clients can route the upgrade "
+        f"prompt; got {second['error']['message']}"
+    )
+
+    # 3. Same bucket over REST. Switching transport must not buy more searches.
+    rest = requests.post(
+        f"{API_URL}/search",
+        json={"query": "supplements"},
+        headers={"Authorization": f"Bearer {token}", "X-Vault-ID": vault_id},
+        timeout=15,
+    )
+    assert rest.status_code == 402, (
+        f"POST /api/search must share the MCP bucket; got {rest.status_code}: "
+        f"{rest.text[:300]}"
+    )
+    body = rest.json()
+    assert body["reason"] == "external_ai_searches_per_day_exceeded", body
+    assert body["limit_key"] == "external_ai_searches_per_day", body
+
+    # 4. We capped searches, not the server. A non-search tool still answers.
+    folders = _mcp_call(token, "list_folders", {"vault_id": vault_id})
+    assert "result" in folders, (
+        f"list_folders must not be charged to the search bucket; got {folders}"
+    )

--- a/e2e/tests/api_only/test_75_free_mcp_search_cap.py
+++ b/e2e/tests/api_only/test_75_free_mcp_search_cap.py
@@ -30,8 +30,8 @@ import os
 import subprocess
 
 import pytest
-import requests
 
+from helpers.api import ApiClient
 from helpers.clerk import ClerkClient
 from helpers.oauth import provision_oauth_tokens
 
@@ -81,25 +81,6 @@ def _set_search_cap(clerk_user_id: str, value: int) -> None:
     )
 
 
-def _mcp_call(token: str, name: str, arguments: dict) -> dict:
-    resp = requests.post(
-        f"{API_URL}/mcp",
-        json={
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {"name": name, "arguments": arguments},
-        },
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=15,
-    )
-    assert resp.status_code == 200, (
-        f"MCP transport should answer 200 even for JSON-RPC errors; "
-        f"got {resp.status_code}: {resp.text[:300]}"
-    )
-    return resp.json()
-
-
 def test_free_mcp_search_cap_binds_and_is_shared_with_rest():
     clerk = ClerkClient(CLERK_SECRET)
     clerk_user_id, tokens = asyncio.run(
@@ -107,6 +88,8 @@ def test_free_mcp_search_cap_binds_and_is_shared_with_rest():
     )
     token = tokens["access_token"]
     vault_id = tokens["vault_id"]
+    api = ApiClient(API_URL, token)
+    api.session.headers["X-Vault-ID"] = vault_id
 
     # Stays Free on purpose — provision_oauth_tokens does not call
     # grant_test_plan, so §G defaults hold and the cap under test is real.
@@ -114,28 +97,17 @@ def test_free_mcp_search_cap_binds_and_is_shared_with_rest():
 
     # Seed one note so a successful search has something to match and an empty
     # result cannot be mistaken for a refusal.
-    seed = requests.post(
-        f"{API_URL}/notes",
-        json={
-            "path": "Health/Supplements.md",
-            "content": "# Supplements\n\nOmega 3 and vitamin D.",
-            "mtime": 1000.0,
-        },
-        headers={"Authorization": f"Bearer {token}", "X-Vault-ID": vault_id},
-        timeout=15,
-    )
-    assert seed.status_code in (200, 201), (
-        f"seed note failed: {seed.status_code} {seed.text[:300]}"
-    )
+    api.create_note("Health/Supplements.md", "# Supplements\n\nOmega 3 and vitamin D.")
 
     # 1. Budget remains → the tool answers normally.
-    first = _mcp_call(token, "search_notes", {"query": "supplements"})
+    first, status = api.mcp_call("search_notes", {"query": "supplements"})
+    assert status == 200, f"MCP transport should answer 200; got {status}"
     assert "result" in first, f"first MCP search should succeed; got {first}"
     assert "error" not in first, f"first MCP search should not error; got {first}"
 
     # 2. Budget spent → JSON-RPC error naming the limit key. Before the fix this
     #    returned a normal result forever: the plug never saw /api/mcp.
-    second = _mcp_call(token, "search_notes", {"query": "supplements"})
+    second, _ = api.mcp_call("search_notes", {"query": "supplements"})
     assert "error" in second, (
         f"second MCP search must be refused — the Free search cap does not bind "
         f"the MCP transport; got {second}"
@@ -149,12 +121,7 @@ def test_free_mcp_search_cap_binds_and_is_shared_with_rest():
     )
 
     # 3. Same bucket over REST. Switching transport must not buy more searches.
-    rest = requests.post(
-        f"{API_URL}/search",
-        json={"query": "supplements"},
-        headers={"Authorization": f"Bearer {token}", "X-Vault-ID": vault_id},
-        timeout=15,
-    )
+    rest = api.search_response("supplements")
     assert rest.status_code == 402, (
         f"POST /api/search must share the MCP bucket; got {rest.status_code}: "
         f"{rest.text[:300]}"
@@ -164,7 +131,7 @@ def test_free_mcp_search_cap_binds_and_is_shared_with_rest():
     assert body["limit_key"] == "external_ai_searches_per_day", body
 
     # 4. We capped searches, not the server. A non-search tool still answers.
-    folders = _mcp_call(token, "list_folders", {"vault_id": vault_id})
+    folders, _ = api.mcp_call("list_folders", {"vault_id": vault_id})
     assert "result" in folders, (
         f"list_folders must not be charged to the search bucket; got {folders}"
     )

--- a/e2e/unit/test_search_timeout.py
+++ b/e2e/unit/test_search_timeout.py
@@ -36,7 +36,7 @@ from helpers.api import ApiClient
 from helpers.latency import SEARCH_TIMEOUT
 
 # Both pay the same query-embed cost: MCP `tools/call` and REST `POST /search`.
-SEARCH_BEARING = [ApiClient.mcp_call, ApiClient.search]
+SEARCH_BEARING = [ApiClient.mcp_call, ApiClient.search, ApiClient.search_response]
 
 E2E_DIR = Path(__file__).resolve().parent.parent
 TESTS_DIR = E2E_DIR / "tests"

--- a/lib/engram/mcp/tools.ex
+++ b/lib/engram/mcp/tools.ex
@@ -84,6 +84,24 @@ defmodule Engram.MCP.Tools do
     end)
   end
 
+  # Tools whose PURPOSE is retrieval: they run `Engram.Search.search/4` and so
+  # spend the same daily bucket as `POST /api/search`. Lives here rather than in
+  # the controller because the registry is what a new tool gets added to, and a
+  # retrieval tool missing from this list is silently uncapped — the same
+  # "the gate exists but does not cover this path" class as the plug bypass it
+  # was written for. `Engram.MCP.SearchToolCoverageTest` pins it against the
+  # actual `Handlers.handle/4` clauses.
+  #
+  # `create_note` / `write_note` also search internally (folder auto-placement,
+  # `Handlers.auto_place_folder/4`) and are deliberately absent — that search is
+  # incidental to a write, and charging it would fail note creation with a
+  # search-cap error. See docs/context/mcp-bypasses-path-shaped-plugs.md for the
+  # residual hole that leaves.
+  @search_tools ~w(search_notes suggest_folder)
+
+  @spec search_tools() :: [String.t(), ...]
+  def search_tools, do: @search_tools
+
   @spec get(String.t()) :: {:ok, tool_def()} | :error
   def get(name) do
     case Enum.find(list(), &(&1.name == name)) do

--- a/lib/engram/usage/search_cap.ex
+++ b/lib/engram/usage/search_cap.ex
@@ -1,0 +1,86 @@
+defmodule Engram.Usage.SearchCap do
+  @moduledoc """
+  THE answer to "may this user run another search today?".
+
+  Pricing v2 §D — rolling-24h search caps on the Free tier, split by where the
+  request came from so a noisy MCP / PAT bot can't burn the user's in-app
+  budget and vice-versa:
+
+    * `external_ai_searches_per_day` — PAT, OAuth, device-flow, MCP
+    * `inapp_searches_per_day`       — Web SPA (Clerk JWT, no markers)
+
+  This module owns BOTH the bucket choice and the spend. It exists because the
+  rule used to live inside `EngramWeb.Plugs.EnforceSearchCap`, guarded on
+  `request_path: "/api/search"` — which silently exempted the entire MCP
+  transport, the exact client class the external bucket was written for. MCP
+  searches arrive as a JSON-RPC `tools/call` at `POST /api/mcp` and reach
+  `Engram.Search.search/4` directly, so no path-shaped gate can ever see them.
+
+  Every caller — the plug and `EngramWeb.McpController` — routes through
+  `spend/2`. Keep it that way: a second copy of the bucket-kind branch is how
+  the two transports drift apart again.
+
+  Returns `:ok` or `{:denied, limit_key, limit}`. The RESPONSE is the caller's
+  business (402 via `LimitResponse` on REST, JSON-RPC `-32_005` on MCP) — this
+  module only decides.
+  """
+
+  alias Engram.Billing
+  alias Engram.Usage.DailyCap
+
+  @type result :: :ok | {:denied, atom(), non_neg_integer()}
+
+  @doc """
+  Spends one search token for `user`, choosing the bucket from `assigns`.
+
+  Pass the conn's assigns (REST) or the MCP conn's assigns — the marker keys
+  are set by `EngramWeb.Plugs.Auth` on both.
+  """
+  @spec spend(map(), Engram.Accounts.User.t()) :: result()
+  def spend(assigns, user) do
+    case cap_kind(assigns) do
+      :external -> external(user)
+      :inapp -> inapp(user)
+    end
+  end
+
+  # PAT (API key) OR internal JWT (device-flow / OAuth / MCP) → external.
+  # Anything else (Clerk JWT, web SPA) → in-app.
+  defp cap_kind(%{current_api_key: _}), do: :external
+  defp cap_kind(%{current_auth_method: :internal_jwt}), do: :external
+  defp cap_kind(_), do: :inapp
+
+  # The two branches pin the cap key as a literal so the
+  # `engram.lint.limit_keys` static check is satisfied.
+  defp external(user) do
+    user
+    |> Billing.effective_limit(:external_ai_searches_per_day)
+    |> check(user, :external_ai_searches_per_day, "ext_search")
+  end
+
+  defp inapp(user) do
+    user
+    |> Billing.effective_limit(:inapp_searches_per_day)
+    |> check(user, :inapp_searches_per_day, "inapp_search")
+  end
+
+  # A `0` cap denies without touching the bucket — capacity 0 would make
+  # DailyCap's refill rate 0 and its retry hint meaningless.
+  defp check(0, _user, key, _bucket_kind), do: {:denied, key, 0}
+
+  defp check(limit, user, key, bucket_kind) when is_integer(limit) and limit > 0 do
+    # Token-bucket: capacity = daily allowance, refill = allowance/86_400 per
+    # sec → continuous regeneration, no reset cliff, no cron. Durable in
+    # Postgres.
+    case DailyCap.spend(user.id, bucket_kind, limit, limit / 86_400) do
+      {:allow, _left} -> :ok
+      {:deny, _retry} -> {:denied, key, limit}
+    end
+  end
+
+  # `:unlimited` (enforcement off), `nil` (Starter / Pro default) and any
+  # unexpected shape all mean "no ceiling". Fails OPEN deliberately: this is
+  # abuse defense, not an authorization boundary, and a malformed override row
+  # must not lock a paying user out of search.
+  defp check(_other, _user, _key, _bucket_kind), do: :ok
+end

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -8,6 +8,7 @@ defmodule EngramWeb.McpController do
   alias Engram.Abuse.OriginStats
   alias Engram.ConversationMeter
   alias Engram.MCP.Tools
+  alias Engram.Usage.SearchCap
 
   @server_info %{"name" => "engram", "version" => "0.1.0"}
   @capabilities %{"tools" => %{"listChanged" => false}}
@@ -101,6 +102,7 @@ defmodule EngramWeb.McpController do
          # §E — record origin fingerprint for daily-rollup aggregation.
          _ = OriginStats.record(user.id, get_req_header_first(conn, "user-agent")),
          :ok <- ConversationMeter.tick(user.id),
+         :ok <- spend_search_cap(conn, tool, user),
          :ok <- validate_tool_args(tool, args) do
       dispatch_tool(tool, user, normalize_args(tool, args), conn)
     else
@@ -126,6 +128,27 @@ defmodule EngramWeb.McpController do
   defp dispatch(_conn, _method, _params) do
     {:error, -32_601, "Method not found"}
   end
+
+  # Tools whose PURPOSE is retrieval, and which therefore spend the same daily
+  # search bucket as `POST /api/search`. `EngramWeb.Plugs.EnforceSearchCap`
+  # cannot reach them: it is guarded on `request_path: "/api/search"` and these
+  # arrive as a JSON-RPC body at `/api/mcp`, so the Free tier's
+  # `external_ai_searches_per_day` was unenforced on the whole MCP transport.
+  #
+  # `create_note` / `write_note` also run a search internally (auto-placement,
+  # `Handlers.auto_place_folder/4`) and are deliberately NOT listed. That search
+  # is incidental to a write, is not the abuse vector, and charging it here
+  # would fail note creation with a search-cap error.
+  @search_tools ~w(search_notes suggest_folder)
+
+  defp spend_search_cap(conn, %{name: name}, user) when name in @search_tools do
+    case SearchCap.spend(conn.assigns, user) do
+      :ok -> :ok
+      {:denied, key, _limit} -> {:rate_limited, key}
+    end
+  end
+
+  defp spend_search_cap(_conn, _tool, _user), do: :ok
 
   # A non-binary `name` (client sent an object/array/number) can't match any
   # tool, but MUST NOT crash the "Unknown tool" message itself — `name` may

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -102,8 +102,8 @@ defmodule EngramWeb.McpController do
          # §E — record origin fingerprint for daily-rollup aggregation.
          _ = OriginStats.record(user.id, get_req_header_first(conn, "user-agent")),
          :ok <- ConversationMeter.tick(user.id),
-         :ok <- spend_search_cap(conn, tool, user),
-         :ok <- validate_tool_args(tool, args) do
+         :ok <- validate_tool_args(tool, args),
+         :ok <- spend_search_cap(conn, tool, user) do
       dispatch_tool(tool, user, normalize_args(tool, args), conn)
     else
       :error ->
@@ -129,26 +129,28 @@ defmodule EngramWeb.McpController do
     {:error, -32_601, "Method not found"}
   end
 
-  # Tools whose PURPOSE is retrieval, and which therefore spend the same daily
-  # search bucket as `POST /api/search`. `EngramWeb.Plugs.EnforceSearchCap`
-  # cannot reach them: it is guarded on `request_path: "/api/search"` and these
-  # arrive as a JSON-RPC body at `/api/mcp`, so the Free tier's
-  # `external_ai_searches_per_day` was unenforced on the whole MCP transport.
+  # Spends a daily search token for retrieval tools. `Engram.MCP.Tools.search_tools/0`
+  # owns the list; `Engram.MCP.SearchToolCoverageTest` asserts it covers every
+  # `Handlers.handle/4` clause that runs a search.
   #
-  # `create_note` / `write_note` also run a search internally (auto-placement,
-  # `Handlers.auto_place_folder/4`) and are deliberately NOT listed. That search
-  # is incidental to a write, is not the abuse vector, and charging it here
-  # would fail note creation with a search-cap error.
-  @search_tools ~w(search_notes suggest_folder)
-
-  defp spend_search_cap(conn, %{name: name}, user) when name in @search_tools do
-    case SearchCap.spend(conn.assigns, user) do
-      :ok -> :ok
-      {:denied, key, _limit} -> {:rate_limited, key}
+  # Deliberately BELOW `validate_tool_args/2`: a malformed `search_notes` call
+  # already answers -32602 without running a search, and charging it would let
+  # a misconfigured client drain a Free user's 15/day allowance and then report
+  # `rate_limited` — an upgrade prompt for searches that never happened. This is
+  # the opposite ordering from `OriginStats`/`ConversationMeter` above, which
+  # must count malformed calls precisely because abuse fingerprinting cares
+  # about clients that only ever send garbage. A billing allowance is a
+  # different contract from an abuse counter.
+  defp spend_search_cap(conn, %{name: name}, user) do
+    if name in Tools.search_tools() do
+      case SearchCap.spend(conn.assigns, user) do
+        :ok -> :ok
+        {:denied, key, _limit} -> {:rate_limited, key}
+      end
+    else
+      :ok
     end
   end
-
-  defp spend_search_cap(_conn, _tool, _user), do: :ok
 
   # A non-binary `name` (client sent an object/array/number) can't match any
   # tool, but MUST NOT crash the "Unknown tool" message itself — `name` may

--- a/lib/engram_web/plugs/enforce_search_cap.ex
+++ b/lib/engram_web/plugs/enforce_search_cap.ex
@@ -1,96 +1,36 @@
 defmodule EngramWeb.Plugs.EnforceSearchCap do
   @moduledoc """
-  Free-tier abuse defense — rolling-24h cap on POST /api/search. Split
-  into two distinct buckets so an automated MCP / PAT client can't burn
-  the user's in-app budget and vice-versa:
+  Free-tier abuse defense on `POST /api/search` — the REST half of the
+  rolling-24h search caps. `Engram.Usage.SearchCap` owns the rule (which
+  bucket, what capacity, whether it's spent); this plug only maps a denial
+  onto a 402 via `EngramWeb.LimitResponse` so the UpgradeDialog surface
+  routes the reason like any other plan limit.
 
-    * `external_ai_searches_per_day` — PAT, OAuth, device-flow, MCP
-    * `inapp_searches_per_day`       — Web SPA (Clerk JWT, no markers)
+  Fires only for `POST /api/search` — note reads, manifest pulls and
+  attachment fetches are not counted, so this plug can sit on a broad
+  pipeline cheaply.
 
-  Both caps live in `Engram.Billing.LimitKeys`. A `nil` (Starter / Pro
-  default) means no enforcement. On deny: 402 via
-  `EngramWeb.LimitResponse` so the UpgradeDialog surface routes the
-  reason like any other plan limit.
-
-  Fires only for `POST /api/search` — note reads, manifest pulls,
-  attachment fetches are not counted. Other endpoints pass through
-  untouched, so this plug can sit on a broad pipeline cheaply.
+  **This plug is not the whole gate.** MCP searches never reach it: they
+  arrive as a JSON-RPC `tools/call` at `POST /api/mcp` and call
+  `Engram.Search.search/4` directly, so `EngramWeb.McpController` spends the
+  same bucket through `SearchCap` at its own dispatch point. Adding a new
+  search entry point means calling `SearchCap.spend/2` there too — a
+  path-shaped gate here can only ever cover this one route.
   """
 
-  alias Engram.Billing
+  alias Engram.Usage.SearchCap
   alias EngramWeb.LimitResponse
 
   def init(opts), do: opts
 
   def call(%Plug.Conn{method: "POST", request_path: "/api/search"} = conn, _opts) do
-    user = conn.assigns.current_user
-
-    case cap_kind(conn.assigns) do
-      :external -> enforce_external(conn, user)
-      :inapp -> enforce_inapp(conn, user)
+    case SearchCap.spend(conn.assigns, conn.assigns.current_user) do
+      :ok -> conn
+      {:denied, key, limit} -> LimitResponse.halt(conn, reason_for(key), key, limit, limit)
     end
   end
 
   def call(conn, _opts), do: conn
-
-  # PAT (API key) OR internal JWT (device-flow / OAuth / MCP) → external.
-  # Anything else (Clerk JWT, web SPA) → in-app. Pure routing — the
-  # branches below pin the cap key as a literal so the
-  # `engram.lint.limit_keys` static check is satisfied.
-  defp cap_kind(%{current_api_key: _}), do: :external
-  defp cap_kind(%{current_auth_method: :internal_jwt}), do: :external
-  defp cap_kind(_), do: :inapp
-
-  defp enforce_external(conn, user) do
-    case Billing.effective_limit(user, :external_ai_searches_per_day) do
-      :unlimited ->
-        conn
-
-      nil ->
-        conn
-
-      0 ->
-        deny(conn, :external_ai_searches_per_day, 0)
-
-      limit when is_integer(limit) and limit > 0 ->
-        check(conn, user, :external_ai_searches_per_day, "ext_search", limit)
-
-      _ ->
-        conn
-    end
-  end
-
-  defp enforce_inapp(conn, user) do
-    case Billing.effective_limit(user, :inapp_searches_per_day) do
-      :unlimited ->
-        conn
-
-      nil ->
-        conn
-
-      0 ->
-        deny(conn, :inapp_searches_per_day, 0)
-
-      limit when is_integer(limit) and limit > 0 ->
-        check(conn, user, :inapp_searches_per_day, "inapp_search", limit)
-
-      _ ->
-        conn
-    end
-  end
-
-  # Token-bucket: capacity = daily allowance, refill = allowance/86_400 per sec
-  # → continuous regeneration, no reset cliff, no cron. Durable in Postgres.
-  defp check(conn, user, key, bucket_kind, limit) do
-    case Engram.Usage.DailyCap.spend(user.id, bucket_kind, limit, limit / 86_400) do
-      {:allow, _left} -> conn
-      {:deny, _retry} -> deny(conn, key, limit)
-    end
-  end
-
-  defp deny(conn, key, limit) do
-    LimitResponse.halt(conn, reason_for(key), key, limit, limit)
-  end
 
   defp reason_for(:external_ai_searches_per_day), do: "external_ai_searches_per_day_exceeded"
   defp reason_for(:inapp_searches_per_day), do: "inapp_searches_per_day_exceeded"

--- a/lib/mix/tasks/engram.lint.limit_keys.ex
+++ b/lib/mix/tasks/engram.lint.limit_keys.ex
@@ -84,7 +84,15 @@ defmodule Mix.Tasks.Engram.Lint.LimitKeys do
     end
   end
 
-  # Arity mismatch (e.g. a Billing.* call with only one arg) — ignore.
+  # Piped call: `user |> Billing.effective_limit(:notes_cap)`.
+  # `Code.string_to_quoted!/2` does not expand `|>`, so the key lands in
+  # position 1 and the clause above never matches. This used to fall through
+  # to the ignore-everything clause below, which meant a TYPO in a piped gate
+  # call was silently unlinted — the one shape the lint exists to catch.
+  defp check_args(file, meta, fun, [key], lines),
+    do: check_args(file, meta, fun, [nil, key], lines)
+
+  # Genuine arity mismatch (no arguments at all) — ignore.
   defp check_args(_file, _meta, _fun, _args, _lines), do: []
 
   defp allow_dynamic?(lines, line),

--- a/lib/mix/tasks/engram.lint.limit_keys.ex
+++ b/lib/mix/tasks/engram.lint.limit_keys.ex
@@ -71,29 +71,49 @@ defmodule Mix.Tasks.Engram.Lint.LimitKeys do
     acc
   end
 
-  defp check_args(file, meta, fun, [_user, key | _rest], lines) do
+  # `Code.string_to_quoted!/2` does not expand `|>`, so the key's position
+  # depends on the spelling: `Billing.check_limit(user, :notes_cap, n)` puts it
+  # second, `user |> Billing.check_limit(:notes_cap, n)` puts it first. Rather
+  # than re-implement pipe expansion, treat a call as clean when EITHER of the
+  # first two arguments is a catalog key — no gate takes a catalog key in
+  # either position for any other purpose, so this cannot pass a real typo.
+  #
+  # This used to be a `[_user, key | _rest]` head plus a catch-all commented
+  # "arity mismatch — ignore", which silently skipped every piped call site:
+  # a typo'd key in that shape was unlinted, the one thing this task exists to
+  # catch.
+  defp check_args(file, meta, fun, args, lines) when is_list(args) and args != [] do
     line = meta[:line]
+    candidates = Enum.take(args, 2)
 
     cond do
-      ignore?(lines, line) -> []
-      is_atom(key) and LimitKeys.defined?(key) -> []
+      ignore?(lines, line) ->
+        []
+
+      Enum.any?(candidates, &(is_atom(&1) and LimitKeys.defined?(&1))) ->
+        []
+
+      true ->
+        classify(file, line, fun, key_arg(args), lines)
+    end
+  end
+
+  defp check_args(_file, _meta, _fun, _args, _lines), do: []
+
+  # No candidate was a valid key, so one of them is the offender. Prefer the
+  # unpiped position; a piped 3-arity call with a bad key reports against the
+  # wrong argument, but it still FAILS, which is the safe direction.
+  defp key_arg([_user, key | _rest]), do: key
+  defp key_arg([key]), do: key
+
+  defp classify(file, line, fun, key, lines) do
+    cond do
       is_atom(key) -> [{file, line, fun, :unknown_atom, key}]
       is_binary(key) -> [{file, line, fun, :string_key, key}]
       allow_dynamic?(lines, line) -> []
       true -> [{file, line, fun, :dynamic_key, Macro.to_string(key)}]
     end
   end
-
-  # Piped call: `user |> Billing.effective_limit(:notes_cap)`.
-  # `Code.string_to_quoted!/2` does not expand `|>`, so the key lands in
-  # position 1 and the clause above never matches. This used to fall through
-  # to the ignore-everything clause below, which meant a TYPO in a piped gate
-  # call was silently unlinted — the one shape the lint exists to catch.
-  defp check_args(file, meta, fun, [key], lines),
-    do: check_args(file, meta, fun, [nil, key], lines)
-
-  # Genuine arity mismatch (no arguments at all) — ignore.
-  defp check_args(_file, _meta, _fun, _args, _lines), do: []
 
   defp allow_dynamic?(lines, line),
     do: prev_line_matches?(lines, line, ~r/#\s*lint:limit_keys\s+allow_dynamic/)

--- a/test/engram/billing/limit_enforcement_test.exs
+++ b/test/engram/billing/limit_enforcement_test.exs
@@ -2,55 +2,138 @@ defmodule Engram.Billing.LimitEnforcementTest do
   @moduledoc """
   Guards against advertising a limit we only enforce in the client.
 
-  Every `LimitKeys` key whose Free default is restrictive must be referenced
-  somewhere in `lib/`. Keys that are deliberately display-only go in
-  `@unenforced` with a reason.
+  Every `LimitKeys` key whose Free default is restrictive must have a real
+  `Engram.Billing` call site in `lib/`. Keys that are deliberately
+  display-only go in `@unenforced` with a reason.
 
   This replaces `mix engram.lint.no_client_only_rate_limits`, whose whole
   coverage check was this same scan — the task's own test reimplemented it
   verbatim, so the task was 180 lines of duplicate plus a CI step. Its other
   half scanned for a `# client-only-rate-limit` comment marker that no source
   file has ever carried.
+
+  ## Why this walks the AST instead of grepping
+
+  The original version asserted `String.contains?(blob, ":\#{key}")` — the key
+  merely had to APPEAR anywhere in `lib/`, in any context. That is how the
+  MCP search-cap bypass survived: `:external_ai_searches_per_day` appeared in
+  `EngramWeb.Plugs.EnforceSearchCap`, which was guarded on
+  `request_path: "/api/search"` and therefore never ran for the MCP transport.
+  A mention in a moduledoc, a `@unenforced` reason string, or a call site that
+  no request can reach all satisfied the old check equally.
+
+  Requiring a real `Billing.{effective_limit, check_limit, check_feature,
+  limit_enforced?}` call with the key as an atom literal raises the floor from
+  "the string exists" to "a gate exists". It still cannot prove the gate is
+  REACHABLE — only a test that drives the actual route or worker does that
+  (see `EngramWeb.McpControllerTest`, `Engram.Workers.InactivityCleanupTest`,
+  `Engram.Accounts.ExportTest`). Treat this as the cheap backstop, not the
+  proof.
   """
   use ExUnit.Case, async: true
 
   alias Engram.Billing.LimitKeys
 
+  # Functions whose second argument is the limit key. Mirrors
+  # `Mix.Tasks.Engram.Lint.LimitKeys`'s target list plus `limit_enforced?/2`,
+  # which is a legitimate half of a gate (it reorders the expensive count).
+  @gate_funs ~w(effective_limit check_limit check_feature limit_enforced?)a
+
   # Deliberately not enforced server-side.
+  #
+  # `cross_vault_search` used to live here as "legacy UX flag; no per-request
+  # gate point yet". That went stale: `Engram.Search.cross_vault_allowed/2`
+  # gates it on every REST search. An @unenforced entry that outlives its
+  # reason is worse than no entry — it tells the next reader not to look.
   @unenforced %{
-    cross_vault_search: "legacy UX flag; no per-request gate point yet",
     vault_scoped_keys: "legacy; superseded by the api_key_vaults table"
   }
 
-  test "every Free-restrictive limit key is referenced in lib/" do
-    # Exclusions: a key merely NAMED somewhere is not an enforcement site.
-    # `lib/mix/tasks/` covers lint tasks that list catalog keys in their docs,
-    # and the catalog itself is excluded because its own moduledoc carries
-    # `:notes_cap` in three usage examples — leaving it in meant that key
-    # passed on its own docstring no matter what enforced it.
-    blob =
-      "lib/**/*.ex"
-      |> Path.wildcard()
-      |> Enum.reject(fn f ->
-        String.contains?(f, "lib/mix/tasks/") or String.contains?(f, "billing/limit_keys.ex")
-      end)
-      |> Enum.map_join("\n", &File.read!/1)
+  test "every Free-restrictive limit key has a real Billing gate call in lib/" do
+    gated = gated_keys()
 
     missing =
       Enum.reject(LimitKeys.all(), fn key ->
         LimitKeys.default_for(key, :free) in [nil, true] or
           Map.has_key?(@unenforced, key) or
-          String.contains?(blob, ":#{key}")
+          MapSet.member?(gated, key)
       end)
 
     assert missing == [],
            """
-           These Free-restrictive limit keys have no reference in lib/:
+           These Free-restrictive limit keys have no Billing gate call in lib/:
 
              #{Enum.map_join(missing, "\n  ", &":#{&1}")}
 
-           Add a Billing.{check_limit, check_feature, effective_limit} call
-           site, or add the key to @unenforced with a reason.
+           Add a Billing.{check_limit, check_feature, effective_limit,
+           limit_enforced?} call site taking the key as an atom literal, or add
+           the key to @unenforced with a reason.
            """
+  end
+
+  test "@unenforced does not list a key that is in fact gated" do
+    gated = gated_keys()
+
+    stale =
+      @unenforced
+      |> Map.keys()
+      |> Enum.filter(&MapSet.member?(gated, &1))
+
+    assert stale == [],
+           """
+           These keys are listed in @unenforced but DO have a Billing gate call:
+
+             #{Enum.map_join(stale, "\n  ", &":#{&1}")}
+
+           Remove them. A stale exemption hides the very gap this file exists
+           to surface, and tells the next reader the key is unenforced when it
+           is not.
+           """
+  end
+
+  # Collects every limit key passed as an atom literal to a Billing gate
+  # function anywhere in `lib/`. Excludes the catalog itself, whose moduledoc
+  # carries `:notes_cap` in usage examples, and `lib/mix/tasks/`, whose lint
+  # tasks quote catalog keys in their docs.
+  defp gated_keys do
+    "lib/**/*.ex"
+    |> Path.wildcard()
+    |> Enum.reject(fn f ->
+      String.contains?(f, "lib/mix/tasks/") or String.contains?(f, "billing/limit_keys.ex")
+    end)
+    |> Enum.flat_map(&keys_in_file/1)
+    |> MapSet.new()
+  end
+
+  defp keys_in_file(path) do
+    path
+    |> File.read!()
+    |> Code.string_to_quoted!(file: path)
+    |> Macro.prewalk([], fn node, acc -> {node, collect_key(node) ++ acc} end)
+    |> elem(1)
+  end
+
+  # `Engram.Billing.fun(_, :key, ...)` and bare `Billing.fun(_, :key, ...)` /
+  # `fun(_, :key, ...)` — the codebase aliases `Engram.Billing` at most call
+  # sites and calls some gates unqualified from inside `Engram.Billing` itself.
+  #
+  # Position 1 is checked as well as position 2 because `Code.string_to_quoted!`
+  # does not expand `|>`: `user |> Billing.effective_limit(:notes_cap)` parses
+  # as a call whose only argument is the key. Matching on "an argument in the
+  # first two positions is a known catalog key" covers both spellings without
+  # re-implementing pipe expansion, and cannot false-positive — no gate takes a
+  # catalog key in either position for any other purpose.
+  defp collect_key({{:., _, [_mod, fun]}, _, args}) when fun in @gate_funs,
+    do: catalog_keys(args)
+
+  defp collect_key({fun, _, args}) when fun in @gate_funs and is_list(args),
+    do: catalog_keys(args)
+
+  defp collect_key(_), do: []
+
+  defp catalog_keys(args) do
+    args
+    |> Enum.take(2)
+    |> Enum.filter(&(is_atom(&1) and LimitKeys.defined?(&1)))
   end
 end

--- a/test/engram/mcp/search_tool_coverage_test.exs
+++ b/test/engram/mcp/search_tool_coverage_test.exs
@@ -1,0 +1,95 @@
+defmodule Engram.MCP.SearchToolCoverageTest do
+  @moduledoc """
+  Every MCP tool that runs a search must spend the daily search bucket.
+
+  `Tools.search_tools/0` is a hand-maintained name list, while the
+  `Search.search/4` calls live in `Engram.MCP.Handlers`. Nothing fails at
+  compile time if a new retrieval tool is added to `Handlers` and not to that
+  list — which is structurally the same "the gate exists but does not cover
+  this path" bug as the `EnforceSearchCap` plug bypass, moved up one layer.
+
+  So derive the truth from `Handlers` and compare.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.MCP.Tools
+
+  # Tools that reach `Search.search/4` but are deliberately not charged.
+  # Empty today: `create_note` / `write_note` search only through the private
+  # `auto_place_folder/4`, which this scan does not attribute to a tool (see
+  # the moduledoc note on limits below).
+  @exempt []
+
+  test "every Handlers clause that searches is in Tools.search_tools/0" do
+    charged = MapSet.new(Tools.search_tools())
+    exempt = MapSet.new(@exempt)
+
+    uncovered =
+      searching_tools()
+      |> Enum.reject(&(MapSet.member?(charged, &1) or MapSet.member?(exempt, &1)))
+
+    assert uncovered == [],
+           """
+           These MCP tools call Engram.Search.search/4 but are not charged to
+           the daily search bucket:
+
+             #{Enum.map_join(uncovered, "\n  ", & &1)}
+
+           Add them to `@search_tools` in Engram.MCP.Tools, or to @exempt here
+           with a reason. An uncharged retrieval tool is a free-tier bypass.
+           """
+  end
+
+  test "Tools.search_tools/0 lists no tool that does not search" do
+    searching = MapSet.new(searching_tools())
+
+    stale = Enum.reject(Tools.search_tools(), &MapSet.member?(searching, &1))
+
+    assert stale == [],
+           """
+           These tools are charged to the search bucket but no longer call
+           Engram.Search.search/4:
+
+             #{Enum.map_join(stale, "\n  ", & &1)}
+
+           Remove them — charging a tool that does not search burns a Free
+           user's allowance for nothing.
+           """
+  end
+
+  # Tool names whose `def handle("name", ...)` clause body contains a direct
+  # `Search.search(...)` call.
+  #
+  # LIMIT: direct calls only. A clause that searches via a private helper (as
+  # `create_note` does through `auto_place_folder/4`) is invisible here. That is
+  # acceptable because the helper case is a documented, deliberate exemption;
+  # the case this guards is the realistic one — someone adds a new retrieval
+  # tool and forgets the list.
+  defp searching_tools do
+    "lib/engram/mcp/handlers.ex"
+    |> File.read!()
+    |> Code.string_to_quoted!()
+    |> Macro.prewalk([], fn node, acc -> {node, clause_name(node) ++ acc} end)
+    |> elem(1)
+    |> Enum.uniq()
+  end
+
+  defp clause_name({:def, _, [{:handle, _, [name | _]} | _] = body}) when is_binary(name) do
+    if searches?(body), do: [name], else: []
+  end
+
+  defp clause_name(_), do: []
+
+  defp searches?(ast) do
+    {_, found} =
+      Macro.prewalk(ast, false, fn
+        {{:., _, [{:__aliases__, _, mods}, :search]}, _, _} = n, _ when is_list(mods) ->
+          {n, List.last(mods) == :Search}
+
+        n, acc ->
+          {n, acc}
+      end)
+
+    found
+  end
+end

--- a/test/engram/search/cross_vault_gate_test.exs
+++ b/test/engram/search/cross_vault_gate_test.exs
@@ -1,0 +1,59 @@
+defmodule Engram.Search.CrossVaultGateTest do
+  @moduledoc """
+  Pins the `cross_vault_search` gate and its ONE deliberate bypass.
+
+  This key spent time in `LimitEnforcementTest`'s `@unenforced` list as
+  "legacy UX flag; no per-request gate point yet". That went stale —
+  `Engram.Search.cross_vault_allowed/2` gates every REST search — and nothing
+  failed when it did, because no test drove the gate. Two things are pinned
+  here so the exemption cannot come back by drift:
+
+    1. A Free user asking for cross-vault search over REST is refused.
+    2. MCP passing `allow_cross_vault: true` is NOT refused — multi-vault
+       search is the MCP default on every tier (product decision 2026-07-10,
+       see `Engram.MCP.Handlers.handle("search_notes", ...)`).
+
+  (2) is the load-bearing half. It is an intentional hole in a billing gate,
+  and an intentional hole with no test looks exactly like an accidental one to
+  whoever reads it next.
+  """
+  use Engram.DataCase, async: true
+
+  import Engram.Factory
+
+  alias Engram.Search
+
+  describe "cross_vault_search gate" do
+    test "a Free user is refused cross-vault search on the REST path" do
+      user = insert(:user)
+
+      assert {:error, :feature_not_available} =
+               Search.search(user, nil, "anything", cross_vault: true)
+    end
+
+    test "an entitled user is not refused" do
+      user = insert(:user)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "cross_vault_search",
+        value: %{"v" => true}
+      )
+
+      # Only the gate is under test — an entitled user gets past it. Whatever
+      # the search itself returns (including an empty list for a user with no
+      # notes) is not `:feature_not_available`.
+      refute Search.search(user, nil, "anything", cross_vault: true) ==
+               {:error, :feature_not_available}
+    end
+
+    test "allow_cross_vault bypasses the gate for a Free user (MCP default)" do
+      user = insert(:user)
+
+      refute Search.search(user, nil, "anything",
+               cross_vault: true,
+               allow_cross_vault: true
+             ) == {:error, :feature_not_available}
+    end
+  end
+end

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -1250,6 +1250,36 @@ defmodule EngramWeb.McpControllerTest do
       assert resp["error"]["message"] =~ "external_ai_searches_per_day"
     end
 
+    test "the conversation meter gates the route, not just the module", %{conn: conn, user: user} do
+      # Regression guard for a wiring bug, not for the meter's arithmetic
+      # (`Engram.ConversationMeterTest` owns that). Deleting
+      # `ConversationMeter.tick/1` from `dispatch/3` used to leave the entire
+      # suite green: the meter was unit-tested in isolation and nothing
+      # asserted it was reachable from `POST /api/mcp`, which is the only
+      # transport it exists to cap.
+      insert(:user_limit_override,
+        user: user,
+        key: "ai_conversations_per_day",
+        value: %{"v" => 1}
+      )
+
+      # Cap of 1: the first call opens conversation #1, the second rotates
+      # (the 30-min window is fresh, so rotation comes from the per-conversation
+      # cap) — drive enough calls to force a second conversation and trip it.
+      insert(:user_limit_override,
+        user: user,
+        key: "ai_queries_per_conversation",
+        value: %{"v" => 1}
+      )
+
+      assert tool_text(call_tool(conn, "list_folders"))
+
+      resp = json_response(call_tool(conn, "list_folders"), 200)
+
+      assert resp["error"]["code"] == -32_005
+      assert resp["error"]["message"] =~ "conversations_per_day"
+    end
+
     test "a non-search tool is not counted against the search bucket", %{conn: conn} do
       # Over-capping is the opposite failure: list_folders must stay free even
       # after the search bucket is empty.

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -1209,4 +1209,53 @@ defmodule EngramWeb.McpControllerTest do
       assert log =~ "search_notes"
     end
   end
+
+  # =========================================================================
+  # Free-tier search cap (external bucket) over the MCP transport
+  # =========================================================================
+
+  describe "external_ai_searches_per_day over MCP" do
+    # `EnforceSearchCap` is a plug guarded on `request_path: "/api/search"`, so
+    # it can never fire for a JSON-RPC `tools/call` arriving at `/api/mcp` —
+    # which is the exact client class its own moduledoc says the external
+    # bucket covers. These tests drive the real route, not a synthesized conn,
+    # so a path-shaped regression cannot pass them again.
+
+    setup %{user: user} do
+      insert(:user_limit_override,
+        user: user,
+        key: "external_ai_searches_per_day",
+        value: %{"v" => 1}
+      )
+
+      :ok
+    end
+
+    test "search_notes is refused once the daily cap is spent", %{conn: conn} do
+      assert tool_text(call_tool(conn, "search_notes", %{"query" => "supplements"}))
+
+      resp = json_response(call_tool(conn, "search_notes", %{"query" => "supplements"}), 200)
+
+      assert resp["error"]["code"] == -32_005
+      assert resp["error"]["message"] =~ "external_ai_searches_per_day"
+    end
+
+    test "suggest_folder spends the same bucket", %{conn: conn} do
+      assert tool_text(call_tool(conn, "search_notes", %{"query" => "supplements"}))
+
+      resp =
+        json_response(call_tool(conn, "suggest_folder", %{"description" => "vitamin d"}), 200)
+
+      assert resp["error"]["code"] == -32_005
+      assert resp["error"]["message"] =~ "external_ai_searches_per_day"
+    end
+
+    test "a non-search tool is not counted against the search bucket", %{conn: conn} do
+      # Over-capping is the opposite failure: list_folders must stay free even
+      # after the search bucket is empty.
+      assert tool_text(call_tool(conn, "search_notes", %{"query" => "supplements"}))
+
+      assert json_response(call_tool(conn, "list_folders"), 200)["result"]
+    end
+  end
 end


### PR DESCRIPTION
## The bug

`EnforceSearchCap` matches on `request_path: "/api/search"`. MCP tools arrive as a JSON-RPC body at `POST /api/mcp` and call `Search.search/4` directly, so the plug fell through to its catch-all for the **entire MCP transport** — leaving Free's `external_ai_searches_per_day` (15/day) unenforced on the exact client class its own moduledoc named.

Being on the shared `:authed_api` pipeline is not the same as running. The pipeline guarantees the plug is invoked; a path guard inside it decides whether it does anything.

Blast radius: the only remaining bound was `ConversationMeter` (5 conversations x 50 queries = ~250 tool calls/day, every tool counted, not just searches). A Free account got roughly **16x** its intended search allowance. Found while checking prod for a Free account that had blown past its limits.

## The fix

The rule moves out of the plug into `Engram.Usage.SearchCap`, which owns both the bucket choice and the spend. The plug and `McpController` each call it and differ only in rendering the denial (402 via `LimitResponse` on REST, JSON-RPC `-32_005` on MCP), so the two transports cannot drift again.

`create_note` / `write_note` run a search internally for folder auto-placement (`Handlers.auto_place_folder/4`) and are deliberately **not** charged — that search is incidental to a write, and charging it would fail note creation with a search-cap error.

## Why nothing caught it, and what now does

Three backstops should have covered this class. All three had the same blind spot.

**The plug's own test** synthesized a conn whose `request_path` was already `/api/search`. It proved the rule and never the routing — a test that hands the plug the exact shape it pattern-matches on can't discover that no real request has that shape.

**`LimitEnforcementTest`** asserted `String.contains?(blob, ":#{key}")` over `lib/`. The key merely had to *appear* — a moduledoc mention, an `@unenforced` reason string, or a call site no request can reach all passed equally. `:external_ai_searches_per_day` appeared in the dead plug branch, so the guard was green the whole time. Now AST-walks for a real `Billing.{effective_limit, check_limit, check_feature, limit_enforced?}` call with the key as an atom literal.

**`mix engram.lint.limit_keys`** skipped piped call sites. `string_to_quoted` doesn't expand `|>`, so `user |> Billing.effective_limit(:key)` parses with one argument and hit a catch-all commented "arity mismatch — ignore". A typo'd key in that shape was silently unlinted. Probe-verified fixed: it now reports `:notes_capp`.

## The bigger thing this surfaced

`ConversationMeter` was not proven wired **at all**. Deleting `:ok <- ConversationMeter.tick(user.id)` from `dispatch/3` left the suite green — **91 tests, 0 failures**. Its 8 unit tests never issue a request. That is the same shape as this bug, on the gate that was the last thing standing between Free and unlimited MCP search.

Added a route-level guard; verified it fails under that exact mutation (79 tests, 1 failure).

Also: `cross_vault_search` sat in `@unenforced` as "legacy UX flag; no per-request gate point yet" long after `Search.cross_vault_allowed/2` started gating it, and nothing failed when that went stale. A second test now asserts no `@unenforced` key is in fact gated, and `CrossVaultGateTest` pins the gate plus its one deliberate MCP bypass — an intentional hole in a billing gate reads exactly like an accidental one without a test.

## Tests

- `EngramWeb.McpControllerTest` — search cap fires over MCP, `suggest_folder` shares the bucket, a non-search tool is not charged, and the conversation meter gates the route.
- `Engram.Search.CrossVaultGateTest` — Free refused, entitled allowed, MCP bypass preserved.
- `Engram.Billing.LimitEnforcementTest` — AST gate-call check + stale-exemption check.
- **e2e 75** (`api_only/test_75_free_mcp_search_cap.py`) — real Free OAuth device-flow identity against a live server: `search_notes` succeeds, next call returns `-32_005` naming the limit key, `POST /api/search` for the same user is refused from the same bucket, non-search tool still answers. Uses device-flow tokens rather than an API key because Free's `api_rps_cap: 0` rejects API-key MCP traffic before it reaches the search cap.

**Local verification:** credo `--strict` 0, `engram.lint.limit_keys` 0, dialyzer passed, `4937 tests, 0 failures`.

**Not verified locally:** e2e 75 — `E2E_CLERK_SECRET_KEY` is an Actions secret and the CI stack isn't up on my box, so it would skip rather than prove anything. It runs on this PR, but `e2e-*` jobs are report-only (#1076), so only the unit-level guards actually gate.

Context doc: `docs/context/mcp-bypasses-path-shaped-plugs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHisz8p92vPQagnfKjn7fM