### PR TITLE
feat(crdt): scrape resident room count against its cap

### DIFF
--- a/lib/engram/notes/crdt_room_lru.ex
+++ b/lib/engram/notes/crdt_room_lru.ex
@@ -135,6 +135,18 @@ defmodule Engram.Notes.CrdtRoomLru do
     end
   end
 
+  @doc """
+  The resident-room ceiling this node is enforcing right now.
+
+  Public because `resident_count/0` is meaningless on its own: the number that
+  matters is the OVERSHOOT, and a dashboard or alert that hardcodes 64 starts
+  lying the day `config :engram, #{inspect(__MODULE__)}, max_resident:` moves.
+  Exported next to the count so both travel together — see
+  `Engram.PromEx.Crdt.execute_room_metrics/0`.
+  """
+  @spec max_resident() :: pos_integer()
+  def max_resident, do: Keyword.get(cfg(), :max_resident) || @default_max_resident
+
   # This module's GenServer owns the table, so between its death and its
   # restart the table does not exist. A bare :ets call would raise
   # ArgumentError in the CALLER — and the caller is CrdtCheckpointTimer, which
@@ -303,6 +315,5 @@ defmodule Engram.Notes.CrdtRoomLru do
   defp schedule_sweep, do: Process.send_after(self(), :sweep, sweep_interval_ms())
 
   defp cfg, do: Application.get_env(:engram, __MODULE__, [])
-  defp max_resident, do: Keyword.get(cfg(), :max_resident) || @default_max_resident
   defp sweep_interval_ms, do: Keyword.get(cfg(), :sweep_interval_ms) || @default_sweep_interval_ms
 end

--- a/lib/engram/prom_ex/crdt.ex
+++ b/lib/engram/prom_ex/crdt.ex
@@ -86,6 +86,39 @@ defmodule Engram.PromEx.Crdt do
   Together with the BEAM memory gauges this is how #1152's "resident room count
   bounded under a soak" gets answered in production rather than in a test.
 
+  ## Residency is polled, not evented (#1493)
+
+  Every metric above is a COUNTER. Counters answer "how many arrived" and can
+  never answer "how many are here NOW" — the only question a memory backstop is
+  tuned against. The 2026-08-28 prod sync peaked at **314 resident rooms against
+  a cap of 64** and the sole record of it is a `Logger.warning` line emitted by
+  the LRU sweep, so nothing could alert and nothing could be graphed.
+
+  `..._crdt_rooms_resident` / `..._crdt_rooms_cap` close that. Read them as a
+  RATIO: the cap ships alongside the count precisely so a dashboard never
+  hardcodes 64 and starts lying when the config moves.
+
+  Two limits to know before trusting the number:
+
+    * It counts **rooms, not bytes**. Each room holds its Yjs doc inside the
+      `y_ex` NIF, which is off-heap and invisible to `:erlang.memory/0`, so no
+      BEAM gauge — `beam_memory_allocated` included — counts the dominant cost
+      of a room. This gauge is the closest available proxy, and the reason the
+      cap is count-based in the first place. It is also why note rooms and index
+      rooms (~50x heavier, per `CrdtRoomLru`'s moduledoc) weigh the same here.
+    * It can **overcount**, never undercount. `resident_count/0` reads the raw
+      ETS size. An exiting room normally removes its own entry promptly — its
+      `CrdtCheckpointTimer` traps the room's `{:EXIT, …}` and calls
+      `CrdtRoomLru.forget/1` — so this is close to live. What it misses is the
+      case where that timer itself died abnormally, which the sweep's
+      `prune_dead` reclaims within one interval (30s). Left as-is deliberately:
+      for a memory alarm stale-high is the safe direction, and pruning on a 15s
+      scrape would make a metrics read mutate the table the LRU is mid-decision
+      on.
+
+  Per-node by construction — memory is per-node and each node bounds its own
+  residency — so aggregate with `max by (instance)`, never `sum`.
+
   Cardinality contract: the phase atoms listed above and nothing else. NEVER add
   note_id, vault_id, or user_id — there is one series per phase, and a room
   drains repeatedly.
@@ -93,7 +126,10 @@ defmodule Engram.PromEx.Crdt do
 
   use PromEx.Plugin
 
+  alias Engram.Notes.CrdtRoomLru
+
   @claim_event [:engram, :crdt, :index_claim]
+  @rooms_event [:engram, :crdt, :rooms]
   @recheck_event [:engram, :crdt, :index_recheck]
   @in_transaction_event [:engram, :crdt, :index_in_transaction]
   @tail_event [:engram, :crdt, :index_tail]
@@ -249,6 +285,57 @@ defmodule Engram.PromEx.Crdt do
           tags: [:phase]
         )
       ]
+    )
+  end
+
+  @impl true
+  def polling_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :crdt)
+    poll_rate = Keyword.get(opts, :crdt_poll_rate, 15_000)
+
+    Polling.build(
+      :engram_crdt_polling_metrics,
+      poll_rate,
+      {__MODULE__, :execute_room_metrics, []},
+      [
+        last_value(
+          metric_prefix ++ [:rooms, :resident],
+          event_name: @rooms_event,
+          measurement: :resident,
+          description:
+            "CRDT rooms resident on THIS node. Compare against rooms_cap — sustained overshoot " <>
+              "means the LRU is not keeping up. Aggregate with max by (instance), never sum. " <>
+              "Overcounts, never undercounts: a room whose checkpoint timer died abnormally " <>
+              "lingers until the next sweep prunes it."
+        ),
+        last_value(
+          metric_prefix ++ [:rooms, :cap],
+          event_name: @rooms_event,
+          measurement: :cap,
+          description:
+            "The max_resident ceiling this node is enforcing. Shipped with the count so " <>
+              "dashboards and alerts read a ratio instead of hardcoding the default."
+        )
+      ]
+    )
+  end
+
+  @doc """
+  Polled emitter for room residency. Reports the count and the ceiling it is
+  judged against in ONE event, so the two can never be scraped from different
+  moments and compared as if they were simultaneous.
+
+  Cheap by design: an `:ets.info(_, :size)` and a config read. It deliberately
+  does NOT prune dead entries first — see the moduledoc on why a scrape must not
+  mutate the LRU's table.
+  """
+  @spec execute_room_metrics() :: :ok
+  def execute_room_metrics do
+    :telemetry.execute(
+      @rooms_event,
+      %{resident: CrdtRoomLru.resident_count(), cap: CrdtRoomLru.max_resident()},
+      %{}
     )
   end
 end

--- a/test/engram/prom_ex/crdt_test.exs
+++ b/test/engram/prom_ex/crdt_test.exs
@@ -1,0 +1,66 @@
+defmodule Engram.PromEx.CrdtTest do
+  @moduledoc """
+  The CRDT plugin's polling group (#1493).
+
+  Every other CRDT room signal is a COUNTER — rooms started, rooms drained. A
+  counter answers "how many arrived" and can never answer "how many are here
+  now", which is the question a memory backstop is tuned against. The 2026-08-28
+  prod sync peaked at 314 resident rooms against a cap of 64 and the only record
+  of it is a `Logger.warning` line; nothing was scrapeable, so nothing could
+  alert. These tests pin the gauge that closes that.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.Notes.CrdtRoomLru
+  alias Engram.PromEx.Crdt, as: Plugin
+  alias PromEx.MetricTypes.Polling
+
+  defp polling, do: Plugin.polling_metrics(otp_app: :engram) |> List.wrap()
+
+  test "is registered in the PromEx plugin list (else metrics never reach /metrics)" do
+    assert Plugin in Engram.PromEx.plugins()
+  end
+
+  test "returns a Polling group with resident + cap last_value gauges" do
+    groups = polling()
+    assert groups != []
+    assert Enum.all?(groups, &match?(%Polling{}, &1))
+
+    metrics = Enum.flat_map(groups, & &1.metrics)
+    names = Enum.map(metrics, & &1.name)
+
+    assert [:engram, :prom_ex, :crdt, :rooms, :resident] in names
+    assert [:engram, :prom_ex, :crdt, :rooms, :cap] in names
+    assert Enum.all?(metrics, &match?(%Telemetry.Metrics.LastValue{}, &1))
+  end
+
+  test "no per-tenant / unbounded tags on the polled gauges" do
+    banned = [:user_id, :vault_id, :note_id, :doc_id, :path, :tenant_id]
+
+    for group <- polling(), m <- group.metrics, tag <- m.tags do
+      refute tag in banned, "metric #{inspect(m.name)} has banned tag #{inspect(tag)}"
+    end
+  end
+
+  test "execute_room_metrics/0 emits resident alongside the cap it is judged against" do
+    ref = make_ref()
+    test_pid = self()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:engram, :crdt, :rooms],
+      fn _name, meas, _meta, _ -> send(test_pid, {:rooms, ref, meas}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+    Plugin.execute_room_metrics()
+
+    # The cap ships WITH the count on purpose: overshoot is the signal, and a
+    # dashboard that hardcodes 64 silently lies the day the config changes.
+    assert_receive {:rooms, ^ref, %{resident: resident, cap: cap}}, 1000
+    assert is_integer(resident) and resident >= 0
+    assert cap == CrdtRoomLru.max_resident()
+  end
+end


### PR DESCRIPTION
## Why

Every CRDT room signal we publish is a **counter** — rooms started, rooms drained by phase. A counter answers *how many arrived*. It can never answer *how many are here now*, which is the only question `CrdtRoomLru`'s cap is tuned against.

The 2026-08-28 prod sync peaked at **314 resident rooms against a cap of 64** and the sole record of it is a `Logger.warning` from the LRU sweep. Not scrapeable, not graphable, not alertable.

Worse, no BEAM gauge covers the gap either. Each room holds its Yjs doc inside the `y_ex` NIF, which is off-heap and invisible to `:erlang.memory/0` — during that same window the app reported `beam_memory_allocated 168 MB` against an 820 MB container cap, and neither figure included the 314 rooms. We would see an OOM kill, never the approach to one.

## What

A `Polling` group on `Engram.PromEx.Crdt`:

- `engram_prom_ex_crdt_rooms_resident` — rooms resident on this node
- `engram_prom_ex_crdt_rooms_cap` — the `max_resident` ceiling being enforced

Both come from **one** telemetry event, so the two can never be scraped from different moments and then compared as if they were simultaneous. `CrdtRoomLru.max_resident/0` becomes public for the same reason: a dashboard that hardcodes 64 starts lying the day the config moves. Read them as a ratio.

## Notes

- **Rooms, not bytes.** This is a proxy, and the reason the cap is count-based in the first place. Note rooms and index rooms (~50x heavier) weigh the same here.
- **Overcounts, never undercounts.** An exiting room removes its own entry promptly (its `CrdtCheckpointTimer` traps the room's `EXIT` and calls `forget/1`), so this is close to live. What it misses is a timer that died abnormally, which the sweep's `prune_dead` reclaims within 30s. Left as-is deliberately: stale-high is the safe direction for a memory alarm, and pruning on a 15s scrape would make a metrics read mutate the table the LRU is mid-decision on.
- **Per-node by construction.** Aggregate with `max by (instance)`, never `sum`.

Deliberately does **not** touch `@max_evictions_per_sweep`. #1493 is right that eviction has no feedback term, but making the LRU more aggressive treats the symptom; the root cause is a client that allocates a room per pushed note, and that fix is separate.

## Test

`test/engram/prom_ex/crdt_test.exs` — pins the Polling group shape, plugin registration, the cardinality contract, and that the emitter ships `cap` equal to what the LRU is actually enforcing.

`format --check-formatted`, `compile --warnings-as-errors`, `credo --strict`, `engram.lint.limit_keys`, `dialyzer` all clean.

Refs #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp