### PR TITLE
feat(crdt): room-free write for an idle note (crdt_doc_update)

### DIFF
--- a/docs/context/crdt-room-lifetime-and-drain.md
+++ b/docs/context/crdt-room-lifetime-and-drain.md
@@ -186,6 +186,45 @@ its unbind checkpoint. A memory backstop must never cost a room its checkpoint.
 `max_resident` defaults to 64 and wants tuning against real index-doc sizes once #1150 exists;
 #1146's arithmetic says ~128 resident rooms would consume an entire task.
 
+## Residency is a property of the TRANSPORT, not of handshakes (#1493)
+
+The natural reading of a room-count problem is "too many handshakes." That is the wrong shape and
+it costs a day if you chase it.
+
+`crdt_msg` routes **every** frame through `ensure_room` (`crdt_channel.ex:234`) — a syncStep1, a
+STEP2, and a plain `sync_update` for a note nobody has open, all of them. So a room is not what you
+get for *asking to handshake*; it is what you get for *sending anything at all* about a note. On
+2026-08-28 a 1.4k-note sync put residency at **314 against a cap of 64**, and the top contributor
+was the plugin's durable op-queue drain (`sync.ts fireCrdtReHandshake`) — which cannot be gated,
+because it is the delivery path for idle notes' queued edits and skipping it loses them.
+
+Two things follow, and both are non-obvious enough to be worth writing down:
+
+**1. The lifetime knob is WHO OBSERVES, not whether a room starts.** `CrdtRegistry.ensure_observed`
+binds a room's lifetime to the calling process (`auto_exit` fires on last-unobserve). Call it from
+the channel and the room lives as long as the socket. Call it from a short-lived task and the room
+checkpoints and exits the moment the task does — or stays untouched if a live editor is also
+observing it. Same room, same apply, same fan-out; residency goes from O(notes pushed) to
+O(applies in flight). That is the whole of `crdt_doc_update`'s mechanism.
+
+Do **not** "fix" this by calling `ensure_started` without an observer. A room with no observer
+never trips `auto_exit` and falls back on the idle drain alone — worse than what you started with.
+For the same reason `crdt_doc_update` does not `Task.shutdown` its applier on timeout: killing it
+between `ensure_started` and `observe` lands in exactly that state. It disowns the task instead.
+
+**2. A room-free frame must still bill the handshake lane.** `crdt_doc_state` and `crdt_doc_update`
+both stand in for a handshake, so putting them on the edit lane would let a bulk vault sync starve
+the user's real typing — the 2026-07-07 cross-file-overwrite incident shape. Both use
+`state_frame_class/1` (a size gate: small rides `:handshake`, oversized pays `:edit`), which
+`crdt_create`'s genesis seed introduced.
+
+**What this does NOT do:** it does not make `@max_evictions_per_sweep` right. That cap is still a
+fixed batch with no feedback term, deliberately, because each eviction costs the owning channel a
+serial ~1s probe. Its comment scopes the trade to "stops mattering once a bulk upload no longer
+creates a room per note (#1409)" — a precondition that was assumed met from 2026-08-26 and was
+still false in the field on 2026-08-28. Re-read it only once #1493's two PRs are **in a release**,
+not when they merge.
+
 ## Observability
 
 `[:engram, :crdt, :room_drain]`, `%{count: 1}`, `%{phase: :requested | :reasked |

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -76,6 +76,14 @@ defmodule Engram.Application do
         # cluster-wide singletons via :global; this supervisor is the local
         # owner when a room is started on this node (see CrdtRegistry).
         {DynamicSupervisor, name: Engram.Notes.CrdtDocSupervisor, strategy: :one_for_one},
+        # Short-lived tasks that must NOT be owned by the process that asked for
+        # them. `crdt_doc_update` (#1493) is the reason it exists: a room is
+        # bound to whichever process observes it, so applying a room-free write
+        # from the channel would pin that room to the socket — exactly the
+        # residency this frame removes. Running it here gives the room an
+        # observer that dies immediately, and `async_nolink` keeps a crashing
+        # apply from taking the channel (and its other rooms) with it.
+        {Task.Supervisor, name: Engram.TaskSupervisor},
         # Pyroscope continuous CPU profiler. Returns nil when GRAFANA_PYROSCOPE_URL
         # is unset (dev, test, self-host), and Enum.reject below filters it out.
         pyroscope_child(),

--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -147,11 +147,15 @@ defmodule Engram.Notes.CrdtTransport do
   fastlanes it to live observers), and returns the new head marker.
 
   A malformed update yields `{:error, :invalid_update}` and mutates nothing.
+
+  `source` is attached to the room_start telemetry so a room allocated by this
+  path is attributable in `engram_prom_ex_crdt_room_start_total` rather than
+  landing in `:unknown` — the question #1493 is actually about.
   """
-  @spec apply_update(map(), map(), String.t(), binary()) ::
+  @spec apply_update(map(), map(), String.t(), binary(), atom()) ::
           {:ok, %{head: String.t()}}
           | {:error, :not_found | :invalid_update | :room_unavailable}
-  def apply_update(user, vault, note_id, update) do
+  def apply_update(user, vault, note_id, update, source \\ :unknown) do
     if Notes.note_in_vault?(user, vault.id, note_id) do
       # ensure_observed (not ensure_started): registers THIS process (the
       # per-request caller) as a SharedDoc observer so the room's lifetime is
@@ -161,7 +165,7 @@ defmodule Engram.Notes.CrdtTransport do
       # here. With an observer, when this process exits (end of request, or
       # here in tests, the spawned caller), the room checkpoints and exits
       # unless a live channel is also observing it.
-      with {:ok, room} <- CrdtRegistry.ensure_observed(user.id, vault.id, note_id),
+      with {:ok, room} <- CrdtRegistry.ensure_observed(user.id, vault.id, note_id, source),
            {:ok, head} <- apply_in_room(room, note_id, update) do
         {:ok, %{head: head}}
       else

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -53,6 +53,18 @@ defmodule EngramWeb.CrdtChannel do
   @msg_limit 240
   @msg_scale_ms 10_000
 
+  # How long `crdt_doc_update` waits on its applier task before answering an
+  # error and letting the client fall back to the room handshake.
+  #
+  # This runs ON the channel process, so the budget is also the worst case that
+  # one note's write can hold up every other frame on the socket. It has to
+  # cover a cold room start plus an apply plus a `SharedDoc.update_doc` call, on
+  # a node whose pool may be busy — the genesis path measured 7.5-101 ms for
+  # comparable work — so 3 s is a wide margin over the expected case rather than
+  # a tuned figure. It is a CEILING, not a target: exceeding it is already a
+  # capacity problem, and the fallback converges anyway.
+  @room_free_apply_ms 3_000
+
   # Liveness-probe timeout before unobserving a drained room (see release_room/1).
   # Generous enough that a room merely busy in a NIF still answers, short enough
   # that a genuinely wedged one cannot hold this channel for y_ex's 5 s default.
@@ -343,7 +355,7 @@ defmodule EngramWeb.CrdtChannel do
   # frame_class_b64 doesn't apply to them — they ride the :handshake lane
   # unconditionally (see check_rate/2). `crdt_create` is different since
   # #1409: it MAY carry a genesis-seed `b64`, sized-gated by
-  # `genesis_create_class/1` exactly like frame_class_b64/1 gates a large
+  # `state_frame_class/1` exactly like frame_class_b64/1 gates a large
   # STEP2 — small (or absent) rides :handshake, oversized pays :edit. All are
   # still bounded either way (not exempt): the 2400/10s ceiling applies same
   # as real STEP1s.
@@ -351,7 +363,7 @@ defmodule EngramWeb.CrdtChannel do
   def handle_in("crdt_create", %{"doc_id" => doc_id, "path" => path} = payload, socket) do
     b64 = Map.get(payload, "b64")
 
-    with :ok <- check_rate(socket, genesis_create_class(b64)),
+    with :ok <- check_rate(socket, state_frame_class(b64)),
          {:ok, note_id} <- cast_doc_id(doc_id),
          :ok <- validate_create_path(path) do
       user = socket.assigns.current_user
@@ -500,6 +512,106 @@ defmodule EngramWeb.CrdtChannel do
     e ->
       log_doc_state_failed(note_id_or_nil(doc_id), Engram.Telemetry.error_kind(e))
       {:reply, {:error, %{reason: "doc_state_failed"}}, socket}
+  end
+
+  # Room-FREE write for an idle note (#1493) — the SEND half of the pair
+  # `crdt_doc_state` opened on the read side.
+  #
+  # `crdt_msg` routes EVERY frame through `ensure_room`, including a plain
+  # `sync_update` for a note nobody has open. That is fine for live editing,
+  # where the room is the point, and wrong for the durable op-queue drain: the
+  # plugin's `fireCrdtReHandshake` hands one queued edit per note to a full
+  # re-handshake, so a 1.4k-note flush asked for 1.4k rooms and prod measured
+  # residency at 314 against a cap of 64. Gating that client call site is not
+  # available — it is the DELIVERY path for idle notes' queued edits, and
+  # skipping it is data loss — so the fix has to be a delivery route that does
+  # not leave a room behind.
+  #
+  # ## Why this is not just `crdt_msg` without `ensure_room`
+  #
+  # The apply still needs a room: a Yjs merge happens inside the doc, and the
+  # room's persistence callback is what appends to the tail log AND fastlanes to
+  # live observers. Skipping it would fork the lineage of any note someone has
+  # open. What changes is WHO OWNS the room. `CrdtRegistry.ensure_observed`
+  # binds a room's lifetime to the observing process, and today that is the
+  # channel — so the room lives as long as the socket. Running the apply on a
+  # `Task.Supervisor` task instead gives it an observer that exits immediately:
+  # the room checkpoints and goes away, or, if a live editor is also observing,
+  # stays exactly as it was. Peak residency drops from O(notes pushed) to
+  # O(applies in flight).
+  #
+  # ## What it costs
+  #
+  # A room that would have batched several updates before one checkpoint now
+  # checkpoints per apply. For the queue drain that is parity — one delivery per
+  # note either way — but it means this frame is the wrong tool for a stream of
+  # edits to one note. Live editing keeps its room and keeps using `crdt_msg`.
+  #
+  # `sync_update` ONLY. A syncStep1 would decode perfectly well here and
+  # answering it means materialising the doc to build a STEP2 — the room
+  # allocation this frame exists to avoid, reachable by sending the wrong
+  # message type. Handshakes belong on `crdt_msg`.
+  #
+  # `is_binary(b64)` is a GUARD, not a validation step: `decode_frame/1` reaches
+  # `Base.decode64/1`, which raises FunctionClauseError on a non-binary, and a
+  # raise in `handle_in` costs the whole channel — every room it owns, every
+  # monitor — for one malformed frame. A non-binary falls to the catch-all
+  # `handle_in/3` and gets a `bad_frame` reply instead.
+  @impl true
+  def handle_in("crdt_doc_update", %{"doc_id" => doc_id, "b64" => b64}, socket)
+      when is_binary(b64) do
+    with :ok <- check_rate(socket, state_frame_class(b64)),
+         {:ok, note_id} <- cast_doc_id(doc_id),
+         {:ok, frame} <- decode_frame(b64),
+         :ok <- guard_frame(frame),
+         {:ok, update} <- take_sync_update(frame),
+         {:ok, %{head: head}} <- apply_room_free(socket, note_id, update) do
+      {:reply, {:ok, %{doc_id: note_id, head: head}}, socket}
+    else
+      {:error, :rate_limited} ->
+        {:reply, {:error, %{reason: "rate_limited"}}, socket}
+
+      {:error, :bad_doc_id} ->
+        {:reply, {:error, %{reason: "bad_doc_id"}}, socket}
+
+      {:error, :frame_too_large} ->
+        log_dropped(socket, doc_id, :frame_too_large)
+        {:reply, {:error, %{reason: "frame_too_large"}}, socket}
+
+      {:error, :implausible_state_vector} ->
+        log_dropped(socket, doc_id, :implausible_state_vector)
+        {:reply, {:error, %{reason: "implausible_state_vector"}}, socket}
+
+      # Includes a syncStep1 sent to the wrong frame. Named distinctly so the
+      # client can fall back to `crdt_msg` rather than retry into the same wall.
+      {:error, :not_sync_update} ->
+        {:reply, {:error, %{reason: "not_sync_update"}}, socket}
+
+      # Same signal `crdt_msg` sends for an unknown id, so the client's existing
+      # id-map reconcile (backend #955) fires on it unchanged. `doc_id` echoes
+      # safely: `cast_doc_id` already proved it is a UUID, never a cleartext
+      # path.
+      {:error, :not_found} ->
+        {:reply, {:error, %{reason: "note_not_found", doc_id: doc_id}}, socket}
+
+      # Every remaining shape is "the write did not land" — a malformed update,
+      # a room that died mid-apply, an applier that crashed or outran its
+      # budget. One reason for all of them ON PURPOSE: the client's response to
+      # each is identical (fall back to the room handshake, which is always
+      # correct and merely more expensive), and the diagnostic detail rides the
+      # log line where it cannot be echoed to a caller.
+      {:error, reason} ->
+        log_doc_update_failed(note_id_or_nil(doc_id), reason)
+        {:reply, {:error, %{reason: "doc_update_failed"}}, socket}
+    end
+  rescue
+    # Defense in depth, same discipline as `crdt_doc_state`: `message_decode`
+    # and the y_ex NIF below it run on THIS process, so an unmatched raise costs
+    # the socket its rooms rather than costing one note its write. The reason
+    # term is never echoed (it can embed a wrapped DEK).
+    e ->
+      log_doc_update_failed(note_id_or_nil(doc_id), Engram.Telemetry.error_kind(e))
+      {:reply, {:error, %{reason: "doc_update_failed"}}, socket}
   end
 
   @impl true
@@ -654,6 +766,57 @@ defmodule EngramWeb.CrdtChannel do
 
     :telemetry.execute([:engram, :crdt, :doc_state_failed], %{count: 1}, %{reason: kind})
   end
+
+  # Run the apply on a task so the ROOM'S OBSERVER is that task, not this
+  # channel — the whole mechanism behind `crdt_doc_update`. `async_nolink` for
+  # isolation: an apply that raises must cost one note, never the socket's other
+  # rooms. The supervisor also propagates `$callers`, which is what lets the
+  # task reach the Repo (and, in tests, the sandbox connection this channel is
+  # allowed on).
+  defp apply_room_free(socket, note_id, update) do
+    user = socket.assigns.current_user
+    vault = socket.assigns.vault
+
+    task =
+      Task.Supervisor.async_nolink(Engram.TaskSupervisor, fn ->
+        CrdtTransport.apply_update(user, vault, note_id, update, :room_free_update)
+      end)
+
+    case Task.yield(task, @room_free_apply_ms) do
+      {:ok, result} ->
+        result
+
+      {:exit, reason} ->
+        {:error, {:applier_crashed, Engram.Telemetry.error_kind(reason)}}
+
+      nil ->
+        # Deliberately NOT `Task.shutdown`. Killing the applier between
+        # `ensure_started` and `observe` would leave a room with no observer at
+        # all, which is strictly worse than the residency this frame removes —
+        # it would then depend on the idle drain alone to reap. Let it finish
+        # and disown it; the write is idempotent, so the client's fallback
+        # handshake converges on the same state either way.
+        _ = Task.ignore(task)
+        {:error, :apply_timeout}
+    end
+  end
+
+  defp log_doc_update_failed(note_id, reason) do
+    Logger.warning(
+      "crdt room-free doc_update failed",
+      Metadata.with_category(:warning, :sync, doc_id: note_id, error_kind: safe_kind(reason))
+    )
+
+    :telemetry.execute([:engram, :crdt, :doc_update_failed], %{count: 1}, %{
+      reason: safe_kind(reason)
+    })
+  end
+
+  # The reason term is never echoed or logged raw — the crypto/KMS class can
+  # embed a wrapped DEK, same rule `log_create_failed` follows.
+  defp safe_kind({:applier_crashed, kind}), do: kind
+  defp safe_kind(reason) when is_atom(reason), do: reason
+  defp safe_kind(reason), do: Engram.Telemetry.error_kind(reason)
 
   defp note_id_or_nil(doc_id) when is_binary(doc_id) do
     case Ecto.UUID.cast(doc_id) do
@@ -1699,27 +1862,31 @@ defmodule EngramWeb.CrdtChannel do
   # lane is the conservative default.
   defp frame_class_b64(_), do: :edit
 
-  # `crdt_create`'s own version of the frame_class_b64/1 size gate (#1409).
-  # A genesis seed is NOT a cheap echo like a small STEP2: it does a full
-  # decode, a NIF apply, an encrypt, AND a row write (`maybe_seed_detached/4`)
-  # — strictly more expensive per frame than the handshake lane's other
-  # occupants. 32 KB of base64 is ~24 KB of note text (base64 expands ~4/3),
-  # which covers the overwhelming majority of real markdown notes, so a real
-  # vault import still rides the handshake lane at its intended 2400/10s
-  # shape. An oversized note still syncs — `maybe_seed_detached/4` doesn't
-  # change — it just pays the edit budget like any other state-bearing frame.
+  # The frame_class_b64/1 size gate for STATE-BEARING frames that replace a
+  # handshake — `crdt_create`'s genesis seed (#1409) and `crdt_doc_update`
+  # (#1493). Neither is a cheap echo like a small STEP2: both do a full decode,
+  # a NIF apply and a write — strictly more expensive per frame than the
+  # handshake lane's other occupants. But both stand in for a handshake the
+  # client would otherwise send, so billing them on the edit lane would let a
+  # bulk vault sync starve the user's real typing (the 2026-07-07
+  # cross-file-overwrite incident shape).
+  #
+  # 32 KB of base64 is ~24 KB of note text (base64 expands ~4/3), covering the
+  # overwhelming majority of real markdown notes, so a real vault import still
+  # rides the handshake lane at its intended 2400/10s shape. An oversized note
+  # still syncs — neither caller's behaviour changes — it just pays the edit
+  # budget like any other state-bearing frame.
   @hs_genesis_max_b64 32_768
 
-  defp genesis_create_class(nil), do: :handshake
+  defp state_frame_class(nil), do: :handshake
 
-  defp genesis_create_class(b64) when is_binary(b64) and byte_size(b64) <= @hs_genesis_max_b64,
+  defp state_frame_class(b64) when is_binary(b64) and byte_size(b64) <= @hs_genesis_max_b64,
     do: :handshake
 
   # Non-binary (malformed client payload) and oversized both pay the edit
-  # budget — `maybe_seed_detached/4` independently rejects a non-binary b64,
-  # so this is only about which rate lane an ill-formed payload bills, never
-  # about accepting it.
-  defp genesis_create_class(_b64), do: :edit
+  # budget — the callers independently reject a non-binary b64, so this is only
+  # about which rate lane an ill-formed payload bills, never about accepting it.
+  defp state_frame_class(_b64), do: :edit
 
   defp check_rate(socket, class) do
     {key_prefix, limit} =

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -1241,6 +1241,192 @@ defmodule EngramWeb.CrdtChannelTest do
     end
   end
 
+  # The WRITE half of the room-free pair (#1493). `crdt_doc_state` gave cold
+  # notes a way to READ without a room; everything a client wanted to SEND still
+  # had to go through `crdt_msg` -> `ensure_room`, which is why a durable-queue
+  # drain over a 1.4k-note vault put 314 rooms resident against a cap of 64.
+  describe "crdt_doc_update (room-free write for an idle note)" do
+    test "applies the client's update and leaves NO resident room", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{"path" => "Notes/idle.md", "content" => "base"})
+
+      refute CrdtRegistry.lookup(note.id), "precondition: no room before the write"
+
+      frame = client_sync_update(socket, note.id, "QUEUED-")
+
+      ref = push(socket, "crdt_doc_update", %{"doc_id" => note.id, "b64" => Base.encode64(frame)})
+      assert_reply ref, :ok, %{doc_id: doc_id, head: head}, 3000
+      assert doc_id == note.id
+      assert is_binary(head)
+
+      # The edit is really on the server, not merely acked.
+      assert_note_content_eventually(user, vault, note.id, "QUEUED-base")
+
+      # And it is visible to a PEER, which is the only thing delivery means.
+      # The room exits right after the apply, so the update has to survive that
+      # exit — it does because `terminate/2` checkpoints, the same path the
+      # room-based handshake delivery has always relied on. Asserting the row
+      # alone would pass even if the write never reached the feed peers replay.
+      ref2 = push(socket, "crdt_catchup_since", %{"cursor_seq" => 0})
+      assert_reply ref2, :ok, %{changes: changes}, 3000
+      replayed = Enum.find(changes, &(&1.id == note.id))
+      assert replayed && replayed.content == "QUEUED-base"
+
+      # THE assertion this frame exists for. The room is bound to the SPAWNED
+      # applier, not to this channel, so it exits once the apply returns —
+      # asynchronously, since `terminate/2` checkpoints on the way out.
+      assert eventually_no_room?(note.id),
+             "crdt_doc_update must not leave a room resident on the socket (#1493)"
+    end
+
+    test "an ALREADY-resident room takes the update, and survives the write", %{
+      socket: socket,
+      user: user,
+      vault: vault,
+      doc_id: doc_id
+    } do
+      # A note someone is actively editing already has a room. The room-free
+      # frame must route INTO it rather than around it: applying beside a live
+      # room would fork the lineage, and the room's own persistence callback is
+      # what fastlanes the update to the other observers.
+      client = handshake_room(socket, doc_id)
+      room = CrdtRegistry.lookup(doc_id)
+      assert room, "precondition: the handshake left a room resident"
+
+      frame = edit_frame(client, "LIVE-")
+
+      ref = push(socket, "crdt_doc_update", %{"doc_id" => doc_id, "b64" => Base.encode64(frame)})
+      assert_reply ref, :ok, %{doc_id: ^doc_id}, 3000
+
+      # The applier unobserves on exit, but this socket is still an observer, so
+      # the room must NOT have been torn down under the live editor.
+      assert CrdtRegistry.lookup(doc_id) == room,
+             "the room-free write evicted a room a live client was still using"
+
+      assert_note_content_eventually(user, vault, doc_id, "LIVE-base")
+    end
+
+    test "rejects an unknown note_id with the same signal crdt_msg sends", %{socket: socket} do
+      frame = bare_sync_update()
+
+      ref =
+        push(socket, "crdt_doc_update", %{
+          "doc_id" => Ecto.UUID.generate(),
+          "b64" => Base.encode64(frame)
+        })
+
+      assert_reply ref, :error, %{reason: "note_not_found"}, 3000
+    end
+
+    test "rejects a non-UUID doc_id without echoing it back", %{socket: socket} do
+      ref =
+        push(socket, "crdt_doc_update", %{
+          "doc_id" => "Notes/cleartext-path.md",
+          "b64" => Base.encode64(bare_sync_update())
+        })
+
+      assert_reply ref, :error, reply
+      assert reply.reason == "bad_doc_id"
+      refute Map.has_key?(reply, :doc_id)
+    end
+
+    test "refuses to write into ANOTHER user's vault", %{socket: socket} do
+      {:ok, other} = Fixtures.user_with_dek_fixture()
+      other_vault = Fixtures.insert_vault!(other, "Other")
+
+      {:ok, note} =
+        Notes.upsert_note(other, other_vault, %{
+          "path" => "Notes/theirs.md",
+          "content" => "theirs"
+        })
+
+      ref =
+        push(socket, "crdt_doc_update", %{
+          "doc_id" => note.id,
+          "b64" => Base.encode64(bare_sync_update())
+        })
+
+      assert_reply ref, :error, %{reason: "note_not_found"}, 3000
+
+      {:ok, untouched} = Notes.get_note_by_id(other, other_vault, note.id)
+      assert untouched.content == "theirs"
+    end
+
+    test "a frame that is not a sync_update is refused, not guessed at", %{
+      socket: socket,
+      doc_id: doc_id
+    } do
+      # A syncStep1 is a well-formed Yjs message and would decode fine. Answering
+      # it here would mean materialising the doc to build a STEP2 — precisely the
+      # room allocation this frame exists to avoid, reachable by sending the
+      # wrong message type. `crdt_msg` is where a handshake belongs.
+      client = CrdtBridge.new_doc()
+      {:ok, {:sync_step1, sv}} = Yex.Sync.get_sync_step1(client)
+      {:ok, step1} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
+
+      ref =
+        push(socket, "crdt_doc_update", %{"doc_id" => doc_id, "b64" => Base.encode64(step1)})
+
+      assert_reply ref, :error, %{reason: "not_sync_update"}
+      refute CrdtRegistry.lookup(doc_id), "a refused frame must not have started a room"
+    end
+
+    test "a non-binary b64 is refused and leaves the CHANNEL ALIVE", %{
+      socket: socket,
+      doc_id: doc_id
+    } do
+      # `decode_frame/1` bottoms out in `Base.decode64/1`, which raises
+      # FunctionClauseError on a non-binary. A raise in `handle_in` costs the
+      # whole channel — every room it owns — for one malformed frame, after
+      # which the client rejoins and re-handshakes EVERY note. So the assertion
+      # that matters is not the error shape, it is that the NEXT frame works.
+      ref = push(socket, "crdt_doc_update", %{"doc_id" => doc_id, "b64" => 42})
+      assert_reply ref, :error, %{reason: "bad_frame"}
+
+      ref2 =
+        push(socket, "crdt_doc_update", %{
+          "doc_id" => doc_id,
+          "b64" => Base.encode64(bare_sync_update())
+        })
+
+      assert_reply ref2, :ok, %{doc_id: ^doc_id}, 3000
+    end
+
+    test "bills the handshake budget — it is the frame that REPLACES a handshake", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
+      # Same contract `crdt_doc_state` carries, and it matters MORE here: this
+      # path is what a bulk queue drain uses, so putting it on the edit lane
+      # would let a 1.4k-note flush starve the user's real typing — the
+      # 2026-07-07 cross-file-overwrite incident shape.
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{"path" => "Notes/billed-write.md", "content" => "b"})
+
+      Application.put_env(:engram, :crdt_hs_rate_limit_override, 1)
+
+      on_exit(fn ->
+        Application.delete_env(:engram, :crdt_hs_rate_limit_override)
+        EngramWeb.RateLimiter.reset_buckets!()
+      end)
+
+      EngramWeb.RateLimiter.reset_buckets!()
+
+      b64 = Base.encode64(bare_sync_update())
+
+      ref1 = push(socket, "crdt_doc_update", %{"doc_id" => note.id, "b64" => b64})
+      assert_reply ref1, :ok, %{doc_id: _}, 3000
+
+      ref2 = push(socket, "crdt_doc_update", %{"doc_id" => note.id, "b64" => b64})
+      assert_reply ref2, :error, %{reason: "rate_limited"}
+    end
+  end
+
   # Single-path catch-up (Phase B): replay the seq-ordered op-log over the
   # socket. Each op carries FULL content (not an SV-diff), so it is causally
   # complete and can never pend — the e2e test_85 deaf-note fix.
@@ -2444,6 +2630,58 @@ defmodule EngramWeb.CrdtChannelTest do
       end,
       deadline
     )
+  end
+
+  # --- room-free write helpers (#1493) ---------------------------------------
+
+  # Seed a client doc from the ROOM-FREE read, edit it, and encode the
+  # `sync_update` a real client would send. Deliberately not via a handshake:
+  # these tests assert no room appears, and a handshake would create one.
+  defp client_sync_update(socket, doc_id, prefix) do
+    ref = push(socket, "crdt_doc_state", %{"doc_id" => doc_id})
+    assert_reply ref, :ok, %{b64: b64}
+    {:ok, doc} = CrdtBridge.doc_from_state(Base.decode64!(b64))
+    edit_frame(doc, prefix)
+  end
+
+  # Handshake a client doc over `crdt_msg`, which leaves a room resident and
+  # puts the client on the server's lineage. Returns the seeded client doc.
+  defp handshake_room(socket, doc_id) do
+    client = CrdtBridge.new_doc()
+    {:ok, {:sync_step1, sv}} = Yex.Sync.get_sync_step1(client)
+    {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
+    push(socket, "crdt_msg", %{"doc_id" => doc_id, "b64" => Base.encode64(frame)})
+    assert_push "crdt_msg", %{"doc_id" => ^doc_id, "b64" => b64}, 3000
+    {:ok, {:sync, {:sync_step2, update}}} = Yex.Sync.message_decode(Base.decode64!(b64))
+    :ok = Yex.apply_update(client, update)
+    client
+  end
+
+  defp edit_frame(doc, prefix) do
+    Yex.Text.insert(Yex.Doc.get_text(doc, "content"), 0, prefix)
+    {:ok, update} = Yex.encode_state_as_update(doc)
+    {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_update, update}})
+    frame
+  end
+
+  # A well-formed `sync_update` on its OWN lineage, for the tests that only care
+  # which route a frame takes (unknown id, wrong vault, rate lane) and never
+  # assert on the resulting content.
+  defp bare_sync_update, do: edit_frame(CrdtBridge.new_doc(), "x")
+
+  # The room exits ASYNCHRONOUSLY after the applier process does: the last
+  # unobserve trips auto_exit, and `terminate/2` checkpoints on the way out. So
+  # "no room" is a settling condition, not an instant one.
+  defp eventually_no_room?(note_id, attempts \\ 300)
+  defp eventually_no_room?(_note_id, 0), do: false
+
+  defp eventually_no_room?(note_id, attempts) do
+    if CrdtRegistry.lookup(note_id) == nil do
+      true
+    else
+      Process.sleep(10)
+      eventually_no_room?(note_id, attempts - 1)
+    end
   end
 
   defp wait_until(condition, deadline \\ nil) do


### PR DESCRIPTION
Closes the actual root cause of #1493. Pairs with plugin PR (`feat/crdt-room-free-queue-delivery`) — **merge this first**; the client falls back to the room handshake against a backend that lacks the frame, so this is safe to land alone.

## Why

`crdt_doc_state` (#1409) gave cold notes a way to READ without a room. Everything a client wanted to **send** still went through `crdt_msg` → `ensure_room`, including a plain `sync_update` for a note nobody has open.

That is right for live editing and wrong for the durable op-queue drain. The plugin's `fireCrdtReHandshake` hands one queued edit per note to a full re-handshake — and it is **deliberately ungated**, because it is the delivery path for idle notes' queued edits and skipping it is data loss, not a room saving. So a 1.4k-note flush asked for 1.4k rooms, and prod on 2026-08-28 measured residency at **314 against a cap of 64**.

Since gating the client is not available, the fix has to be a route that leaves no room behind.

## How

The apply still needs a room — a Yjs merge happens inside the doc, and the room's persistence callback is what appends to the tail log *and* fastlanes to live observers. Applying beside a live room would fork the lineage of any note someone has open.

What changes is **who owns the room**. `CrdtRegistry.ensure_observed` binds a room's lifetime to the observing process, and that process was the channel — so the room lived as long as the socket. Running the apply on a `Task.Supervisor` task gives it an observer that exits immediately: the room checkpoints and goes away, or, if a live editor is also observing, stays exactly as it was.

**Peak residency drops from O(notes pushed) to O(applies in flight).**

`CrdtTransport.apply_update/4` already did this work and had **no production caller** — its REST route was deleted in Phase E3 (#1088). It gains a `source` argument so a room allocated this way is attributable in `room_start` rather than landing in `:unknown`, which is the question #1493 is actually about.

## Contract notes

- **`sync_update` only.** A syncStep1 decodes fine here, and answering one means materialising the doc to build a STEP2 — the allocation this frame exists to avoid, reachable by sending the wrong message type. Handshakes stay on `crdt_msg`.
- **Handshake rate lane.** It stands in for a handshake, so billing the edit lane would let a bulk sync starve the user's real typing (the 2026-07-07 cross-file-overwrite incident shape). Uses the same size gate `crdt_create`'s genesis seed already had — renamed `genesis_create_class/1` → `state_frame_class/1` now that two callers share it.
- **`is_binary(b64)` guard.** `decode_frame/1` bottoms out in `Base.decode64/1`, which raises on a non-binary, and a raise in `handle_in` costs the whole channel — every room it owns — for one malformed frame. A non-binary falls to the catch-all and gets `bad_frame`. Plus a `rescue`, same discipline as `crdt_doc_state`.
- **No `Task.shutdown` on timeout.** Killing the applier between `ensure_started` and `observe` would leave a room with *no* observer, which is worse than the residency being removed. It is disowned and left to finish; the write is idempotent.
- **One error reason for every "the write did not land" shape.** The client's response to each is identical (fall back to the handshake); the diagnostic detail rides the log line where it cannot be echoed to a caller.

## Cost

A room that would have batched several updates before one checkpoint now checkpoints per apply. For the queue drain that is parity — one delivery per note either way — but it makes this the wrong tool for a stream of edits to one note. Live editing keeps its room and keeps using `crdt_msg`.

## Test

New `crdt_doc_update` describe block in `crdt_channel_test.exs`: no resident room left behind (the assertion the frame exists for), an already-resident room takes the update and survives it, the write reaches the seq feed a peer replays, unknown id / non-UUID id / cross-vault refusal, a syncStep1 refused rather than guessed at, a non-binary `b64` leaving the channel alive, and the handshake budget actually being billed.

`format --check-formatted`, `compile --warnings-as-errors`, `credo --strict`, `engram.lint.limit_keys`, `dialyzer` (0 new) clean. Channel + transport suites 200/200. Full unit suite green apart from two load-induced timeouts (`QdrantHybridTest`, `OpenApiEndpointTest`) that pass isolated in 2.7s and differ run to run.

Refs #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp