### PR TITLE
fix(billing): pin Paddle checkout theme, fix dark-mode contrast

### DIFF
--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -341,21 +341,24 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		expect(queryAllByText("Starter").length).toBeGreaterThan(0);
 	});
 
-	it("settings (overlay): does not rebuild the Paddle instance while a checkout is open, so an in-flight overlay isn't stranded on a stale theme", async () => {
-		// Regression for the theme-freeze fix: the overlay path (settings, no
-		// onActivated prop) has no `checkingOut` flag, so it must rely on Paddle's
-		// own checkout.loaded/checkout.closed events to freeze appliedTheme.
+	it("settings (overlay): does not pass a theme to Paddle, and does not rebuild on an app theme flip", async () => {
+		// Paddle's branded-inline-checkout dashboard config is a single static
+		// color set with no light/dark variant — feeding it a live theme just
+		// produces mismatched contrast against whatever palette is configured
+		// there, so `theme` is intentionally omitted. An app theme flip must
+		// neither add a theme value nor rebuild the Paddle instance.
 		mockBillingApi();
-		let captured: ((event: { name: string; data?: unknown }) => void) | undefined;
-		initializePaddleMock.mockImplementation(async (opts: { eventCallback?: typeof captured }) => {
-			captured = opts.eventCallback;
-			return { Checkout: { open: vi.fn(), close: vi.fn() } };
-		});
+		initializePaddleMock.mockImplementation(async () => ({
+			Checkout: { open: vi.fn(), close: vi.fn() },
+		}));
 
 		function Harness() {
 			const { setTheme } = useTheme();
 			return (
 				<>
+					<button type="button" onClick={() => setTheme("light")}>
+						go-light
+					</button>
 					<button type="button" onClick={() => setTheme("dark")}>
 						go-dark
 					</button>
@@ -380,29 +383,16 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		);
 
 		await waitFor(() => expect(initializePaddleMock).toHaveBeenCalledTimes(1));
+		expect(initializePaddleMock.mock.calls[0]![0].checkout.settings.theme).toBeUndefined();
 
 		await act(async () => {
-			captured!({ name: "checkout.loaded" });
-			await Promise.resolve();
-		});
-
-		await act(async () => {
+			screen.getByRole("button", { name: "go-light" }).click();
 			screen.getByRole("button", { name: "go-dark" }).click();
 			await Promise.resolve();
 		});
 
-		// Frozen: theme flip while the overlay is open must NOT tear down/rebuild.
+		// No rebuild — the checkout settings never depended on app theme at all.
 		expect(initializePaddleMock).toHaveBeenCalledTimes(1);
-
-		await act(async () => {
-			captured!({ name: "checkout.closed" });
-			await Promise.resolve();
-		});
-
-		// Resyncs once closed, and the rebuild picks up the new theme.
-		await waitFor(() => expect(initializePaddleMock).toHaveBeenCalledTimes(2));
-		const { settings } = initializePaddleMock.mock.calls[1]![0].checkout;
-		expect(settings.theme).toBe("dark");
 	});
 
 	it("onboarding (inline): cooldown arms on CHECKOUT_PAYMENT_INITIATED so a dropped COMPLETED still surfaces the recovery banner", async () => {

--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -439,6 +439,70 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		);
 	});
 
+	it("onboarding (inline): the recovery banner (slow) does NOT get the forced-light frame treatment, even though the wrapper is still told checkout is active", async () => {
+		// onCheckoutActiveChange (broad: checkingOut || slow || finalizing) drives
+		// header-hiding and stays true here. onCheckoutFrameActiveChange (narrow:
+		// only while the Paddle frame itself renders) drives the wrapper's
+		// forced-light card and must flip back to false once slow replaces the
+		// frame with our own theme-aware SlowActivationBanner — otherwise that
+		// banner's text renders light-on-white in dark mode.
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		mockBillingApi();
+		let captured: ((event: { name: string; data?: unknown }) => void) | undefined;
+		initializePaddleMock.mockImplementation(async (opts: { eventCallback?: typeof captured }) => {
+			captured = opts.eventCallback;
+			return { Checkout: { open: vi.fn(), close: vi.fn() } };
+		});
+
+		const onCheckoutActiveChange = vi.fn();
+		const onCheckoutFrameActiveChange = vi.fn();
+		const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const { container, queryAllByText } = render(
+			<QueryClientProvider client={qc}>
+				<AuthContext.Provider value={authAdapter}>
+					<ThemeProvider>
+						<MemoryRouter>
+							<BillingPage
+								onActivated={() => {}}
+								onCheckoutActiveChange={onCheckoutActiveChange}
+								onCheckoutFrameActiveChange={onCheckoutFrameActiveChange}
+							/>
+						</MemoryRouter>
+					</ThemeProvider>
+				</AuthContext.Provider>
+			</QueryClientProvider>,
+		);
+
+		await waitFor(() => expect(queryAllByText("Starter").length).toBeGreaterThan(0));
+		const startBtn = Array.from(container.querySelectorAll("button")).find(
+			(b) => b.textContent === "Start free trial",
+		)!;
+		await act(async () => {
+			startBtn.click();
+			await Promise.resolve();
+		});
+
+		expect(onCheckoutActiveChange).toHaveBeenLastCalledWith(true);
+		expect(onCheckoutFrameActiveChange).toHaveBeenLastCalledWith(true);
+
+		await act(async () => {
+			captured!({ name: "checkout.payment.initiated", data: { transaction_id: "txn_1" } });
+			await Promise.resolve();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(15_500);
+			await Promise.resolve();
+		});
+
+		await waitFor(() =>
+			expect(
+				screen.queryByText(/Payment received\. We're finishing your activation/iu),
+			).toBeInTheDocument(),
+		);
+		expect(onCheckoutActiveChange).toHaveBeenLastCalledWith(true);
+		expect(onCheckoutFrameActiveChange).toHaveBeenLastCalledWith(false);
+	});
+
 	it("onboarding (inline): closes Paddle and fires onActivated when subscription_activated push arrives", async () => {
 		mockBillingApi();
 		const closeMock = vi.fn();

--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -341,12 +341,12 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		expect(queryAllByText("Starter").length).toBeGreaterThan(0);
 	});
 
-	it("settings (overlay): does not pass a theme to Paddle, and does not rebuild on an app theme flip", async () => {
+	it("settings (overlay): Paddle theme is fixed to light and does not follow the app's live theme", async () => {
 		// Paddle's branded-inline-checkout dashboard config is a single static
-		// color set with no light/dark variant — feeding it a live theme just
-		// produces mismatched contrast against whatever palette is configured
-		// there, so `theme` is intentionally omitted. An app theme flip must
-		// neither add a theme value nor rebuild the Paddle instance.
+		// color set with no light/dark variant, tuned for light — feeding it a
+		// live theme just produces mismatched contrast, so `theme: "light"` is
+		// a fixed constant. An app theme flip must neither change it nor
+		// rebuild the Paddle instance.
 		mockBillingApi();
 		initializePaddleMock.mockImplementation(async () => ({
 			Checkout: { open: vi.fn(), close: vi.fn() },
@@ -383,7 +383,7 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		);
 
 		await waitFor(() => expect(initializePaddleMock).toHaveBeenCalledTimes(1));
-		expect(initializePaddleMock.mock.calls[0]![0].checkout.settings.theme).toBeUndefined();
+		expect(initializePaddleMock.mock.calls[0]![0].checkout.settings.theme).toBe("light");
 
 		await act(async () => {
 			screen.getByRole("button", { name: "go-light" }).click();

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -71,6 +71,12 @@ interface BillingPageProps {
 	// Onboarding-only: fired when the inline Paddle checkout view opens/closes so
 	// the wrapper can hide its own chrome (header, free link) during payment.
 	onCheckoutActiveChange?: (active: boolean) => void;
+	// Onboarding-only: fired specifically while the Paddle frame itself (or its
+	// dev stand-in) is showing — narrower than onCheckoutActiveChange, which
+	// also covers the slow/finalizing states. Those render our own
+	// theme-aware SlowActivationBanner/spinner, so the wrapper must NOT force
+	// its card light for them the way it does for the Paddle-branded frame.
+	onCheckoutFrameActiveChange?: (active: boolean) => void;
 }
 
 function SlowActivationBanner({
@@ -154,6 +160,7 @@ export default function BillingPage({
 	onActivated,
 	freeOption,
 	onCheckoutActiveChange,
+	onCheckoutFrameActiveChange,
 }: BillingPageProps) {
 	// Onboarding mounts BillingPage with onActivated; settings does not. The
 	// prop's presence is what flips Paddle from overlay → inline. Inline gives
@@ -478,6 +485,18 @@ export default function BillingPage({
 		onCheckoutActiveChangeRef.current?.(checkoutActive);
 	}, [checkoutActive]);
 
+	// Narrower than checkoutActive: true only for the branch that actually
+	// renders the Paddle frame (or its dev stand-in) — matches the ternary
+	// condition below exactly. slow/finalizing render our own components and
+	// must not be included, or the wrapper's forced-light card (see
+	// onboard-billing-page.tsx) makes their theme-aware text illegible.
+	const showingPaddleFrame = isInline && checkingOut && !slow && !finalizing;
+	const onCheckoutFrameActiveChangeRef = useRef(onCheckoutFrameActiveChange);
+	onCheckoutFrameActiveChangeRef.current = onCheckoutFrameActiveChange;
+	useEffect(() => {
+		onCheckoutFrameActiveChangeRef.current?.(showingPaddleFrame);
+	}, [showingPaddleFrame]);
+
 	if (isLoading || !billing) {
 		return <BillingPageSkeleton hideHeading={hideHeading} />;
 	}
@@ -607,9 +626,13 @@ export default function BillingPage({
 								← Choose a different plan
 							</button>
 							{DEV_FAKE_CHECKOUT ? (
-								<div className="rounded-lg border border-primary/50 border-dashed bg-muted/30 p-6 text-center">
-									<p className="font-medium text-foreground text-sm">Test checkout (dev only)</p>
-									<p className="mx-auto mt-1 max-w-sm text-muted-foreground text-xs">
+								// Fixed light colors throughout, not theme tokens: this stub
+								// only ever renders inside the forced-light checkout card (see
+								// onboard-billing-page.tsx), so text-foreground/text-muted-foreground
+								// would resolve to their dark-mode (light-on-light) values here.
+								<div className="rounded-lg border border-primary/50 border-dashed bg-gray-50 p-6 text-center">
+									<p className="font-medium text-gray-900 text-sm">Test checkout (dev only)</p>
+									<p className="mx-auto mt-1 max-w-sm text-gray-500 text-xs">
 										Paddle's checkout can't embed on localhost, so this stand-in lets you walk the
 										flow. Not shown in production.
 									</p>
@@ -633,6 +656,7 @@ export default function BillingPage({
 											className={cn(
 												"rounded-lg px-4 py-2 font-medium text-sm transition",
 												ctaOutline,
+												"border-gray-300 text-gray-900 hover:bg-gray-100",
 											)}
 										>
 											Simulate failure

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -599,7 +599,10 @@ export default function BillingPage({
 									setCheckingOut(false);
 									setCompletedAt(null);
 								}}
-								className="text-muted-foreground text-sm underline-offset-4 hover:text-foreground hover:underline"
+								// Fixed light-gray, not theme tokens: this button sits on the
+								// checkout card, which is forced light (see
+								// onboard-billing-page.tsx) regardless of app theme.
+								className="text-gray-700 text-sm underline-offset-4 hover:text-gray-900 hover:underline"
 							>
 								← Choose a different plan
 							</button>

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -361,11 +361,13 @@ export default function BillingPage({
 						break;
 				}
 			},
-			// No `theme` here: Paddle's branded-inline-checkout dashboard config
-			// (Paddle > Checkout > Branded inline checkout) is a single static
-			// color set with no light/dark variant — once configured it fully
-			// overrides Paddle's theme-adaptive styling, so `theme` has no effect.
-			// Colors are 100% dashboard-driven.
+			// Paddle's branded-inline-checkout dashboard config (Paddle > Checkout
+			// > Branded inline checkout) is a single static color set with no
+			// light/dark variant, tuned for light. `theme: "light"` matches it so
+			// the unbranded chrome (page background behind fields, default text)
+			// doesn't clash with the branded fields. Fixed, not tied to the app's
+			// live theme — a dynamic value here tore down/rebuilt the Paddle
+			// instance on every app theme toggle, stranding an open checkout.
 			checkout: {
 				settings: isInline
 					? {
@@ -378,10 +380,14 @@ export default function BillingPage({
 							// box. frameInitialHeight covers the initial paint before Paddle
 							// reports the real height. (min-width matches Paddle's own sample.)
 							frameStyle: "width:100%; min-width:312px; background:transparent; border:none;",
+							theme: "light",
+							variant: "one-page",
 							locale: "en",
 						}
 					: {
 							displayMode: "overlay",
+							theme: "light",
+							variant: "one-page",
 							locale: "en",
 						},
 			},

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -18,7 +18,6 @@ import {
 	useBillingSubscriptionDetail,
 	useMe,
 } from "../api/queries";
-import { useTheme } from "../theme/theme-provider";
 import BillingHistoryTable from "./billing-history-table";
 import CancelPanel from "./cancel-panel";
 import CurrentPlanCard from "./current-plan-card";
@@ -169,7 +168,6 @@ export default function BillingPage({
 	const hasSubscription = Boolean(billing?.subscription);
 	const { data: detail } = useBillingSubscriptionDetail(hasSubscription);
 	const { data: history } = useBillingHistory(hasSubscription);
-	const { resolved } = useTheme();
 	const qc = useQueryClient();
 	const [paddle, setPaddle] = useState<Paddle>();
 	// Ref mirror of `paddle` so the eventCallback (captured pre-instance) can
@@ -244,7 +242,6 @@ export default function BillingPage({
 		}
 		paddleRef.current?.Checkout.close();
 		setCheckingOut(false);
-		setCheckoutOpen(false);
 		setCompletedAt(null);
 		setSlow(false);
 		await invalidateBillingState(qc);
@@ -296,26 +293,6 @@ export default function BillingPage({
 		}
 	}, []);
 
-	// Mirrors Paddle's own checkout.loaded/checkout.closed events — covers ALL
-	// checkout entry points (inline, overlay plan purchase, overlay payment-method
-	// update), not just the inline/onboarding `checkingOut` flag.
-	const [checkoutOpen, setCheckoutOpen] = useState(false);
-
-	// Frozen while a checkout is mounted: the Paddle-init effect below tears
-	// down and rebuilds the SDK instance whenever this changes, which would
-	// kill an open checkout mid-fill and leave it stranded on its old theme
-	// while the page around it (background, .dark class) has already flipped —
-	// invisible text. `checkingOut` covers the inline gap between click and
-	// Paddle's own `checkout.loaded` (the div is mounted but Paddle hasn't
-	// reported open yet); `checkoutOpen`/`slow`/`finalizing` cover the rest.
-	// Only resync once all of these clear, so the next checkout opens with the
-	// current theme.
-	const appliedThemeRef = useRef(resolved);
-	if (!(checkingOut || checkoutOpen || slow || finalizing)) {
-		appliedThemeRef.current = resolved;
-	}
-	const appliedTheme = appliedThemeRef.current;
-
 	useEffect(() => {
 		if (!config) {
 			return;
@@ -329,14 +306,6 @@ export default function BillingPage({
 					return;
 				}
 				switch (event.name) {
-					case CheckoutEventNames.CHECKOUT_LOADED: {
-						setCheckoutOpen(true);
-						break;
-					}
-					case CheckoutEventNames.CHECKOUT_CLOSED: {
-						setCheckoutOpen(false);
-						break;
-					}
 					case CheckoutEventNames.CHECKOUT_PAYMENT_INITIATED: {
 						// Belt-and-suspenders: either PAYMENT_INITIATED or COMPLETED may
 						// drop on trial-signup redirects. Arm the cooldown timer on
@@ -382,11 +351,7 @@ export default function BillingPage({
 					case CheckoutEventNames.CHECKOUT_ERROR: {
 						// Genuine checkout-level error (not a routine decline) — the frame
 						// may be in a broken state, so close it and surface a message.
-						// Also drop checkoutOpen defensively in case Paddle doesn't follow
-						// this with its own checkout.closed — otherwise the theme freeze
-						// above would stay stuck forever.
 						setCheckingOut(false);
-						setCheckoutOpen(false);
 						setCompletedAt(null);
 						setSlow(false);
 						toast.error("Something went wrong with checkout. Please try again.");
@@ -396,6 +361,11 @@ export default function BillingPage({
 						break;
 				}
 			},
+			// No `theme` here: Paddle's branded-inline-checkout dashboard config
+			// (Paddle > Checkout > Branded inline checkout) is a single static
+			// color set with no light/dark variant — once configured it fully
+			// overrides Paddle's theme-adaptive styling, so `theme` has no effect.
+			// Colors are 100% dashboard-driven.
 			checkout: {
 				settings: isInline
 					? {
@@ -408,12 +378,10 @@ export default function BillingPage({
 							// box. frameInitialHeight covers the initial paint before Paddle
 							// reports the real height. (min-width matches Paddle's own sample.)
 							frameStyle: "width:100%; min-width:312px; background:transparent; border:none;",
-							theme: appliedTheme === "dark" ? "dark" : "light",
 							locale: "en",
 						}
 					: {
 							displayMode: "overlay",
-							theme: appliedTheme === "dark" ? "dark" : "light",
 							locale: "en",
 						},
 			},
@@ -431,7 +399,7 @@ export default function BillingPage({
 			paddleRef.current = undefined;
 			setPaddle(undefined);
 		};
-	}, [config, appliedTheme, qc, isInline]);
+	}, [config, qc, isInline]);
 
 	// Open checkout. In inline mode we set checkingOut first so the mount
 	// div is in the DOM before Paddle tries to find it.
@@ -448,11 +416,6 @@ export default function BillingPage({
 			if (isInline) {
 				setCheckingOut(true);
 			}
-			// Set synchronously at the open() call, not left to wait for Paddle's
-			// async checkout.loaded — otherwise a theme toggle landing in that gap
-			// (network/render latency) sees checkoutOpen still false and tears down
-			// the Paddle instance while the overlay is actively opening.
-			setCheckoutOpen(true);
 			// Paddle finds the .paddle-checkout div by class — the div is rendered
 			// synchronously by the same render cycle as the setCheckingOut update.
 			// React 18 batches state into the same commit, so the DOM is ready by
@@ -542,9 +505,6 @@ export default function BillingPage({
 			const { transaction_id } = await api.get<{ transaction_id: string }>(
 				"/billing/payment-update-transaction",
 			);
-			// Same reasoning as handleStartCheckout: set before open(), not left to
-			// wait for Paddle's async checkout.loaded.
-			setCheckoutOpen(true);
 			paddle.Checkout.open({ transactionId: transaction_id });
 		} catch {
 			toast.error("Could not start the payment update. Please try again.");
@@ -631,7 +591,6 @@ export default function BillingPage({
 								onClick={() => {
 									paddleRef.current?.Checkout.close();
 									setCheckingOut(false);
-									setCheckoutOpen(false);
 									setCompletedAt(null);
 								}}
 								className="text-muted-foreground text-sm underline-offset-4 hover:text-foreground hover:underline"

--- a/frontend/src/onboarding/onboard-billing-page.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.tsx
@@ -20,6 +20,11 @@ export default function OnboardBillingPage() {
 	// True while the inline Paddle checkout view is open — hides our own header +
 	// free link so they don't sit stuck above/below the payment form.
 	const [checkoutActive, setCheckoutActive] = useState(false);
+	// Narrower: true only while the Paddle frame itself is showing. Drives the
+	// card's forced-light background — the slow/finalizing states covered by
+	// checkoutActive render our own theme-aware components and must stay
+	// theme-following, not forced light.
+	const [showingPaddleFrame, setShowingPaddleFrame] = useState(false);
 
 	const onActivated = useCallback(
 		(status: OnboardingStatus) => {
@@ -56,9 +61,11 @@ export default function OnboardBillingPage() {
 				className={cn(
 					"rounded-2xl border p-4 sm:p-8",
 					// Paddle's checkout theme is pinned to light (see billing-page.tsx)
-					// — force this card light too while checkout is showing, so the
-					// Paddle frame doesn't sit on a dark surface behind it.
-					checkoutActive ? "border-gray-200 bg-white" : "border-border bg-background",
+					// — force this card light too while the Paddle frame is showing, so
+					// it doesn't sit on a dark surface behind it. Scoped to
+					// showingPaddleFrame, not the broader checkoutActive, since
+					// slow/finalizing render our own theme-aware components.
+					showingPaddleFrame ? "border-gray-200 bg-white" : "border-border bg-background",
 				)}
 			>
 				{/* Header is hidden once a plan is chosen (checkout view open) so it
@@ -81,6 +88,7 @@ export default function OnboardBillingPage() {
 					onActivated={onActivated}
 					freeOption={{ onContinue: handleContinueFree, loading: freeLoading }}
 					onCheckoutActiveChange={setCheckoutActive}
+					onCheckoutFrameActiveChange={setShowingPaddleFrame}
 				/>
 				{/* Desktop: understated bottom link — also hidden during checkout so it
             doesn't sit stuck below the payment form. */}

--- a/frontend/src/onboarding/onboard-billing-page.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { api } from "../api/client";
 import { type OnboardingStatus, useOnboardingStatus } from "../api/queries";
 import BillingPage from "../billing/billing-page";
@@ -51,7 +52,15 @@ export default function OnboardBillingPage() {
 
 	return (
 		<section className="m-auto max-h-full w-full max-w-2xl overflow-y-auto px-4 pt-5 pb-8 sm:pt-8">
-			<div className="rounded-2xl border border-border bg-background p-4 sm:p-8">
+			<div
+				className={cn(
+					"rounded-2xl border p-4 sm:p-8",
+					// Paddle's checkout theme is pinned to light (see billing-page.tsx)
+					// — force this card light too while checkout is showing, so the
+					// Paddle frame doesn't sit on a dark surface behind it.
+					checkoutActive ? "border-gray-200 bg-white" : "border-border bg-background",
+				)}
+			>
 				{/* Header is hidden once a plan is chosen (checkout view open) so it
             doesn't sit stuck above the Paddle payment form. */}
 				{!checkoutActive && (


### PR DESCRIPTION
## Summary
- Paddle's branded-inline-checkout dashboard config (Paddle > Checkout > Branded inline checkout) is a single static color set with no light/dark variant — following the app's live theme (#1554) produced invisible labels in dark mode since the dashboard palette is tuned for light. Pin `theme: "light"` and `variant: "one-page"` as fixed constants instead of feeding the app's live theme.
- Force the onboarding checkout card (`onboard-billing-page.tsx`) light while checkout is active — `theme: "light"` only styles the Paddle iframe's own contents; the surrounding card (dark in dark mode) still showed through the iframe's transparent `frameStyle`, producing a white form floating in a black card.
- Removes the now-dead `appliedTheme` freeze/resync machinery and `checkoutOpen` state that existed only to feed a dynamic theme value into `Paddle.Initialize()`.

## Test plan
- [x] `bun run tsc --noEmit` clean
- [x] `./node_modules/.bin/biome check` clean
- [x] `bunx vitest run` — full suite (186 files, 1728 tests) passes
- [x] Manual: walked onboarding checkout (sandbox, dark app theme) end-to-end via saas-dev + cloudflared tunnel — labels/inputs legible, card renders light with no dark bleed-through, completed a test purchase (4242 card), confirmed via manually resent Paddle webhook that subscription activation still flows through correctly