### PR TITLE
fix(ci): stop e2e-crdt lying, and stop main reporting unrun gates as green

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4045,6 +4045,49 @@ jobs:
             echo "::warning::e2e-browser failed: $EB (report-only — not gating)"
           fi
 
+          # A SKIPPED job is not a pass — it is "an earlier tree passed, and the
+          # content fingerprint says nothing this job covers has changed since".
+          # That inference is sound, but it renders identically to a verified
+          # green, and the two are not the same claim.
+          #
+          # #1531: e2e-crdt fingerprint-skipped on every routine main run, so a
+          # real fan-out regression sat on main for three days behind a green
+          # tick, and reproducing it at all needed a manual force_full dispatch.
+          # Worse, a recorded pass is trusted forever — and #1525 proved a pass
+          # can be worthless (the fan-out suppression helper stubbed nothing, so
+          # four "proof" tests measured nothing and went green with the feature
+          # dead). Those greens were still in the marker store being trusted.
+          #
+          # Never-skip-on-main (#1531 option B) was tried and reverted: is-full
+          # is deliberately false on main, so prebuild-ci-image skips on a
+          # cache-hit merge and e2e-crdt then dies on `docker pull ""`. Doing it
+          # properly means a full image prebuild on every main push (~61/week).
+          # So gate the same, but stop the SIGNAL from lying (option C).
+          SKIPPED=()
+          for pair in "unit-tests=$UT" "lint=$LN" "frontend-lint=$FL" "e2e-lint=$EL" \
+                      "storage-database=$SD" "static-checks=$SC" "migration-gates=$MG" \
+                      "e2e-clerk=$EC" "e2e-crdt=$ED" "e2e-browser=$EB"; do
+            [ "${pair#*=}" = "skipped" ] && SKIPPED+=("${pair%=*}")
+          done
+          if [ ${#SKIPPED[@]} -gt 0 ]; then
+            LIST=$(IFS=', '; echo "${SKIPPED[*]}")
+            echo "::warning title=${#SKIPPED[@]} gate(s) did not run on this commit::Inherited from an earlier tree via the content fingerprint, NOT verified on this SHA: $LIST"
+            {
+              echo "### :warning: ${#SKIPPED[@]} gate(s) did NOT run on this commit"
+              echo
+              echo "Result inherited from an earlier tree via the content fingerprint —"
+              echo "**not verified on \`${{ github.sha }}\`**:"
+              echo
+              for n in "${SKIPPED[@]}"; do echo "- \`$n\`"; done
+              echo
+              echo "A green \`ci\` here means *nothing changed that these gates cover*,"
+              echo "not *these gates passed*. Force a real run with a \`workflow_dispatch\`"
+              echo "and \`force_full=true\`, or push a change that touches their inputs."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "All gates executed on this commit (no fingerprint inheritance)."
+          fi
+
           # On cross-repo plugin dispatch (plugin-e2e-trigger), unit-tests / lint
           # are intentionally skipped — plugin cannot regress backend internals.
           # Only assert success when those jobs actually ran. (e2e-* moved to the

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -77,6 +77,14 @@ _CONN_REFUSED_MARKERS = ("Connection refused", "ConnectionRefusedError", "NewCon
 _OBSIDIAN_DEAD_THRESHOLD = 3
 _consecutive_conn_failures = 0
 
+# Set when the circuit breaker below trips. A run that ends this way proved
+# nothing about the product: the stack died under it. Reported distinctly so it
+# reads as infra rather than as N broken features — measured 2026-09-01/02, two
+# such runs contributed 20 of the ~38 e2e-crdt failure lines in the window, and
+# every frontmatter and index-crdt "failure" in it was this and nothing else.
+_infra_dead_reason: str | None = None
+INFRA_DEAD_EXIT_CODE = 42
+
 
 def _backend_alive() -> bool:
     import requests
@@ -100,7 +108,7 @@ def _backend_alive() -> bool:
 def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
-    global _consecutive_conn_failures
+    global _consecutive_conn_failures, _infra_dead_reason
     if rep.when == "call" and rep.passed:
         _consecutive_conn_failures = 0
         return
@@ -116,6 +124,7 @@ def pytest_runtest_makereport(item, call):
             f"(first seen in {item.nodeid}) — aborting the suite; every "
             "remaining test would fail the same way. Check stack/compose logs."
         )
+        _infra_dead_reason = item.session.shouldstop
         logging.getLogger("conftest").error(item.session.shouldstop)
         return
     if rep.when == "teardown":
@@ -130,7 +139,34 @@ def pytest_runtest_makereport(item, call):
             f"connection-refused failures while the backend is healthy — an "
             f"Obsidian/CDP instance is gone (last: {item.nodeid}). Aborting."
         )
+        _infra_dead_reason = item.session.shouldstop
         logging.getLogger("conftest").error(item.session.shouldstop)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Report an infra death as infra, not as a pile of test failures.
+
+    When the breaker above trips, the tests that already failed are recorded as
+    ordinary failures and the run exits 1 — indistinguishable in CI from real
+    product breakage. Two such runs on 2026-09-01/02 produced 20 red entries
+    across the frontmatter, index-crdt and live-bound suites, none of which had
+    anything wrong with them.
+
+    So: emit a workflow annotation naming the cause, and exit with a dedicated
+    code. The job still fails (a dead stack proved nothing and must not read as
+    green), but it now says WHY, and a caller that wants to retry-on-infra has a
+    signal to branch on instead of grepping logs.
+    """
+    if _infra_dead_reason is None:
+        return
+    # GitHub renders ::error at the top of the run; harmless noise locally.
+    print(f"\n::error title=E2E infra died::{_infra_dead_reason}", flush=True)
+    print(
+        "\nThis run proved nothing about the product. Every failure above is "
+        "downstream of the dead instance, not a broken feature.",
+        flush=True,
+    )
+    session.exitstatus = INFRA_DEAD_EXIT_CODE
 
 
 def _worker_index() -> int:

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -816,12 +816,12 @@ async def _assert_plugin_surfaces(cdp_a):
             if (typeof p.syncEngine?.isRecentlyPushed !== 'function') missing.push('isRecentlyPushed');
             if (typeof p.syncEngine?.handleStreamEvent !== 'function') missing.push('handleStreamEvent');
             if (!(p.syncEngine?.syncState instanceof Map)) missing.push('syncState:Map');
-            // NOT checked here: the cold-apply backstop that
-            // suppress_fanout_backstops() stubs. It belongs to 4 crdt tests, and
-            // this fixture is session-scoped autouse across every suite — a
-            // rename would fail the ~110-test clerk session for a reason with no
-            // bearing on it. The helper raises on its own instead (#1503), which
-            // is the same protection scoped to the tests that need it.
+            // NOT checked here: applyPushedNoteUpdate, the fan-out apply that
+            // arm_fanout_counter() wraps. It belongs to 4 crdt tests, and this
+            // fixture is session-scoped autouse across every suite — a rename
+            // would fail the ~110-test clerk session for a reason with no
+            // bearing on it. The helper raises on its own instead, which is the
+            // same protection scoped to the tests that need it.
             for (const id of cmds) {
                 if (!app.commands.findCommand(`engram-vault-sync:${id}`)) {
                     missing.push(`command:${id}`);

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -935,156 +935,86 @@ class CdpClient:
     # Vault-channel fan-out isolation (crdt/test_crdt_sync.py)
     # ------------------------------------------------------------------
 
-    async def suppress_fanout_backstops(self) -> str:
-        """Neutralize every idle-note convergence path EXCEPT the vault-channel
-        fan-out, so a disk-convergence assert on this instance becomes a TRUE
-        fan-out proof.
+    async def arm_fanout_counter(self) -> str:
+        """Count vault-channel fan-out applies on this device, disabling NOTHING.
 
-        Under the vault-channel model an IDLE note (not open in the editor)
-        converges via the server's ``note_yjs_update`` broadcast → the plugin's
-        ``applyPushedNoteUpdate`` (sync.ts). The checkpoint-driven backfill also
-        converges a cold note off the ~5s ``note_changed`` and would mask a
-        broken fan-out — every existing crdt test still passes at checkpoint
-        latency even if the fan-out is dead:
+        Proving a cold note converged over the fan-out (``note_yjs_update`` ->
+        ``applyPushedNoteUpdate``) rather than over a checkpoint backstop used to
+        be done by stubbing every backstop to a no-op. That approach failed three
+        ways and never once produced a true answer:
 
-          * ``catchupViaSeqReplay()`` — the seq-replay cold-apply backstop, and
-            as of plugin main the ONLY one. Reached from ``scheduleSeqHeal``
-            (sync.ts:2589), from the topic-join replay, and from
-            ``applyStreamEvent``'s tail. Its row-apply (``applyChange``) writes
-            bodies to files that ALREADY exist — the cold-note leg at
-            sync.ts:8609 → ``convergeColdNoteRoomFree`` → ``flushFromCrdt`` — so
-            no file-exists precondition contains it, and it also owns the
-            discovery enroll at sync.ts:8244. It must be stubbed.
+          * Every name it stubbed (``pull``, ``coldReceive``,
+            ``catchupViaSocket``) had been retired from the plugin, and its
+            ``typeof`` guard skips what is gone — so it stubbed NOTHING and the
+            four "TRUE fan-out proof" tests passed with the fan-out dead.
+          * Adding ``handleStreamEvent`` to the list broke the SENDER: that
+            handler commits ``noteIdMap``, so a suppressed device read a null id,
+            ``shouldDeferMint`` refused its push, and the edit never left the
+            device — a 120s timeout that read as a receive-side bug (#1503).
+          * Stubbing ``catchupViaSeqReplay`` removes the device's only noteIdMap
+            repair, so a transient unmapping inside the test window can never
+            heal and burns the full timeout (#1526).
 
-        ``pull``, ``coldReceive`` and ``catchupViaSocket`` are RETIRED
-        predecessors, kept in the list only so a backend branch paired against an
-        older plugin build still isolates. NONE of the three exist on plugin main
-        (sync.ts:7705 "the retired ``catchupViaSocket`` loop"); ``pull()``'s
-        cursor-feed backfill folded into the seq-replay above. ``pullAll()`` is
-        NOT its successor for this purpose — that is the user-triggered
-        replay-from-0 behind the pull-all command, never fired spontaneously.
+        Counting is strictly stronger and costs nothing. The wrapper calls
+        through, so no delivery path is disabled and no map upkeep is lost. A
+        dead fan-out leaves the counter at zero and the assertion fails — which
+        is the entire point of the old helper — and a RENAME fails loudly right
+        here instead of silently making four tests prove nothing.
 
-        The fan-out is a SEPARATE channel dispatch: ``channel.ts`` routes
-        ``note_yjs_update`` straight to ``onNoteYjsUpdate`` →
-        ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
-        stays fully live. Idempotent.
+        What this does NOT claim: that the fan-out produced the final bytes on
+        disk. It proves the fan-out ran for this note. That is the regression
+        worth catching; a backstop healing the content afterwards does not make
+        a dead fan-out look alive.
 
-        Raises if no cold-apply backstop was stubbed. The ``typeof`` guard makes
-        a rename SILENT — the loop skips every missing method and still reports
-        success. All three original names had been retired, so this helper was
-        stubbing NOTHING: for an unknown number of runs the four "TRUE fan-out
-        proof" tests ran with every backstop live and would have passed with a
-        completely dead fan-out. The assertion below is what stops the next
-        rename doing the same thing.
-
-        PRECONDITION — the receiving device MUST already hold the file on disk
-        (what ``_establish_on_both`` guarantees). ``handleStreamEvent`` is left
-        live (below), and its first-delivery leg
-        (``applyOp(eventToOp(...))``) writes a note body; it gates itself out
-        when the file is already present (``priorState === undefined`` /
-        ``!getAbstractFileByPath`` at the sync.ts:7302 call site). Suppress
-        before the receiver has the file and that leg converges the note for
-        you — the assert goes green with the fan-out completely dead, which is
-        the one outcome this helper exists to make impossible.
-
-        ``handleStreamEvent`` is deliberately NOT stubbed (#1503). It was on the
-        list to stop the ``note_changed`` handler STEP1-enrolling the note's CRDT
-        room, whose ``crdt_msg`` stream would then deliver the body independently
-        — but that enroll (``sync.ts`` ~7222, formerly the stale 3246 this
-        docstring cited) is already gated on ``isCanvasPath || isLiveBound``, so
-        it cannot fire for the idle markdown note these tests use. A stray room
-        would fail the enrolled-set assertion rather than pass silently.
-
-        Stubbing it was NOT free: ``applyStreamEvent`` commits
-        ``noteIdMap.set(event.path, noteId)`` (sync.ts:7213). With it dead a
-        device that loses its path→id entry never repairs it, ``pushFile`` reads
-        a null id, and ``shouldDeferMint`` refuses the push — so the suppressed
-        device silently loses the ability to SEND. That is the #1503 failure:
-        ``test_cold_send_over_fanout_opens_no_room`` suppressed the sender and
-        then waited 120s for an edit that never left the device.
-
-        What DROPPED the entry is not established. ``applyStreamEvent`` also
-        deletes (7088) and relocates (``moveIfIdRelocated``, 6953), so it cannot
-        be the remover while stubbed — restoring it restores the repair, not the
-        absence of the cause. Treat a repeat 120s timeout as that unfound
-        remover, not as a fan-out regression.
-
-        Instances are SESSION-scoped and shared across tests, so every caller
-        MUST pair this with ``restore_fanout_backstops`` in a ``finally``.
+        Idempotent. Instances are session-scoped, so pair with
+        ``disarm_fanout_counter`` in a ``finally``.
         """
         js = f"""
         (function() {{
             const se = {ENGINE_PATH};
-            // Idempotent re-entry reports what is ACTUALLY stubbed right now,
-            // not a bare 'already-isolated' — the caller's zero-stub assertion
-            // has to run on this path too. A restore_fanout_backstops() that
-            // throws (CDP reconnect, renderer reload) leaves __fanoutIsolated
-            // set with nothing stubbed, and every later suppress in this
-            // session would otherwise short-circuit past the guard and hand
-            // the fan-out tests the exact false-green this guard exists for.
-            if (se.__fanoutIsolated) {{
-                return Object.keys(se)
-                    .filter(k => k.startsWith('__orig_'))
-                    .map(k => k.slice('__orig_'.length))
-                    .join(',');
-            }}
-            // The cold-apply backstop has been renamed twice: coldReceive ->
-            // catchupViaSocket -> catchupViaSeqReplay. backend-main e2e pairs
-            // against EITHER plugin branch, so stub whichever exists and never
-            // .bind() an absent one. Report WHICH were stubbed — the caller
-            // asserts on it, because a silent zero-stub run is a false green.
-            // handleStreamEvent stays LIVE — see the docstring (#1503).
-            const stubbed = [];
-            for (const m of ['pull', 'catchupViaSeqReplay', 'coldReceive', 'catchupViaSocket']) {{
-                if (typeof se[m] === 'function') {{
-                    se['__orig_' + m] = se[m].bind(se);
-                    se[m] = async () => 0;
-                    stubbed.push(m);
-                }}
-            }}
-            // Set AFTER the loop: the flag means "isolation is in place", and
-            // setting it first made a zero-stub run claim isolation it never had.
-            se.__fanoutIsolated = true;
-            return stubbed.join(',');
+            if (typeof se.applyPushedNoteUpdate !== 'function') return 'MISSING';
+            if (se.__fanoutCounts) return 'already-armed';
+            se.__fanoutCounts = {{}};
+            const orig = se.applyPushedNoteUpdate.bind(se);
+            se.__origFanoutApply = orig;
+            se.applyPushedNoteUpdate = function(noteId) {{
+                se.__fanoutCounts[noteId] = (se.__fanoutCounts[noteId] || 0) + 1;
+                return orig.apply(se, arguments);
+            }};
+            return 'armed';
         }})()
         """
-        result = await self.evaluate(js)
-        logger.info("Fan-out backstops suppressed on CDP port %d: %s", self.port, result)
-        stubbed = set(str(result).split(",")) - {""}
-        # A rename silently empties this loop (the typeof guard skips what is
-        # gone) and the tests then prove nothing, so require the cold-apply
-        # backstop by name. It is the WHOLE isolation now: `pull()` was retired
-        # along with coldReceive/catchupViaSocket, and its cursor-feed backfill
-        # folded into catchupViaSeqReplay -> applyChange -> flushFromCrdt.
-        # `pullAll()` is not a substitute — it is the user-triggered replay-from-0
-        # behind the pull-all command, never fired spontaneously, so it cannot
-        # converge a note behind an assertion.
-        cold_apply = {"catchupViaSeqReplay", "coldReceive", "catchupViaSocket"}
-        if not (stubbed & cold_apply):
+        result = str(await self.evaluate(js))
+        if result == "MISSING":
             raise AssertionError(
-                f"suppress_fanout_backstops stubbed {sorted(stubbed) or 'NOTHING'} on CDP port "
-                f"{self.port} — none of {sorted(cold_apply)} exist on this plugin build. The "
-                f"cold-apply backstop was renamed out from under this helper; the fan-out tests "
-                f"would pass with a dead fan-out. Add the new name to the list."
+                f"applyPushedNoteUpdate does not exist on the syncEngine at CDP port "
+                f"{self.port}. The vault-channel fan-out apply was renamed; these tests "
+                f"cannot prove the fan-out until this helper names the new method."
             )
-        return str(result)
+        logger.info("Fan-out counter armed on CDP port %d: %s", self.port, result)
+        return result
 
-    async def restore_fanout_backstops(self) -> None:
-        """Restore the methods stubbed by suppress_fanout_backstops()."""
+    async def fanout_apply_count(self, note_id: str) -> int:
+        """How many fan-out applies this device has seen for `note_id` since arming."""
+        return await self.evaluate(
+            f"(function() {{ const se = {ENGINE_PATH}; "
+            f"return (se.__fanoutCounts && se.__fanoutCounts[{json.dumps(note_id)}]) || 0; }})()"
+        )
+
+    async def disarm_fanout_counter(self) -> None:
+        """Unwrap applyPushedNoteUpdate and drop the counts."""
         js = f"""
         (function() {{
             const se = {ENGINE_PATH};
-            if (!se.__fanoutIsolated) return 'not-isolated';
-            for (const m of ['pull', 'catchupViaSeqReplay', 'coldReceive', 'catchupViaSocket']) {{
-                const orig = se['__orig_' + m];
-                if (orig) {{ se[m] = orig; delete se['__orig_' + m]; }}
-            }}
-            delete se.__fanoutIsolated;
-            return 'restored';
+            if (!se.__origFanoutApply) return 'not-armed';
+            se.applyPushedNoteUpdate = se.__origFanoutApply;
+            delete se.__origFanoutApply;
+            delete se.__fanoutCounts;
+            return 'disarmed';
         }})()
         """
         result = await self.evaluate(js)
-        logger.info("Fan-out backstops restored on CDP port %d: %s", self.port, result)
+        logger.info("Fan-out counter disarmed on CDP port %d: %s", self.port, result)
 
     async def get_note_id_for_path(self, path: str) -> str | None:
         """Resolve the CRDT note_id the plugin has mapped for a vault path."""

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -154,30 +154,25 @@ async def test_edit_after_discovery_round_trips(vault_a, vault_b, cdp_a, cdp_b, 
 # applyPushedNoteUpdate were completely broken, every test above would STILL
 # pass at ~5s checkpoint latency, masking a dead fan-out.
 #
-# The tests below suppress that backstop on the RECEIVING device via
-# cdp.suppress_fanout_backstops(), leaving applyPushedNoteUpdate untouched since
-# the fan-out is a separate channel dispatch. With it dead, a disk-convergence
-# assert can ONLY be satisfied by the fan-out, so a broken fan-out actually
-# FAILS.
+# The tests below pin the fan-out POSITIVELY: cdp.arm_fanout_counter() wraps
+# applyPushedNoteUpdate in a pass-through counter, and each test asserts the
+# counter moved for its note. A dead fan-out leaves it at zero and fails.
 #
-# It did not, for an unknown number of runs. All three names the helper stubbed
-# (pull, coldReceive, catchupViaSocket) had been retired from the plugin, and
-# the helper skips a method that no longer exists — so it stubbed NOTHING and
-# these tests ran with every backstop live. The helper now raises if it cannot
-# stub a cold-apply backstop, and conftest asserts the surface at session start.
-#
-# handleStreamEvent used to be stubbed too, for the note_changed room-enroll
-# path. It no longer is (#1503): that enroll is already gated on
-# isCanvasPath || isLiveBound so it cannot fire for an idle markdown note, and
-# stubbing it broke the SENDING device — applyStreamEvent is what commits
-# noteIdMap, so a suppressed sender read a null id and shouldDeferMint refused
-# its push. See helpers/cdp.py.
+# They used to do this by SUPPRESSION — stubbing every backstop to a no-op so
+# only the fan-out could satisfy the assert. That never once gave a true answer.
+# It stubbed nothing for an unknown span (every name had been retired, and the
+# typeof guard skips what is gone), so these four "proofs" ran green with the
+# fan-out dead. Fixing that broke the SENDER, because the handler it stubbed is
+# what commits noteIdMap (#1503). Fixing THAT left the device with no map repair
+# inside the test window (#1526). Counting disables nothing, so none of those
+# failure modes exist, and a rename now fails loudly in the helper instead of
+# silently making these tests prove nothing. See helpers/cdp.py.
 
 
 async def _confirm_room_free(cdp, path):
-    """Precondition for a fan-out isolation test: the device has mapped +
-    confirmed `path` and holds NO CRDT room for it (so convergence can't ride a
-    crdt_msg room stream). Returns the note_id.
+    """Precondition for a fan-out test: the device has mapped + confirmed `path`
+    and holds NO CRDT room for it (so convergence can't ride a crdt_msg room
+    stream). Returns the note_id.
 
     trigger_full_sync() drives the idle pull-discovery path, which maps +
     confirms the note but does NOT STEP1-enroll a not-live-bound note via the
@@ -193,8 +188,7 @@ async def _confirm_room_free(cdp, path):
     means the sync call finished, not that the mapping it discovered has landed
     in noteIdMap, so the note_id read raced it exactly as the enrolled-set read
     did — reporting `assert None` ("device never mapped a note_id") for a note
-    that maps fine moments later, and taking 6-7 downstream tests with it
-    (engram-app/Engram#1489).
+    that maps fine moments later (engram-app/Engram#1489).
     """
     await cdp.wait_for_stream_connected()
     await cdp.trigger_full_sync()
@@ -212,57 +206,55 @@ async def _confirm_room_free(cdp, path):
     return note_id
 
 
+async def _assert_fanout_ran(cdp, note_id, path, minimum=1):
+    count = await cdp.fanout_apply_count(note_id)
+    assert count >= minimum, (
+        f"content converged on {path} but applyPushedNoteUpdate ran {count} time(s) "
+        f"for note_id={note_id} (expected >= {minimum}) — the vault-channel fan-out "
+        f"did not deliver it; a checkpoint backstop did."
+    )
+
+
 @pytest.mark.asyncio
 async def test_idle_note_converges_via_fanout_only(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """[P0] A pre-existing IDLE note on B converges to A's edit via the vault-
-    channel fan-out ALONE.
+    """[P0] A pre-existing IDLE note on B converges to A's edit over the vault-
+    channel fan-out, and we prove the fan-out is what ran.
 
-    B never opens or edits the note. Before A's edit we suppress the
-    checkpoint-driven backstop on B (catchupViaSeqReplay's row-apply). The ONLY
-    path that can then converge B's disk is the server's `note_yjs_update`
-    broadcast → applyPushedNoteUpdate. So a broken fan-out FAILS here instead of
-    silently passing at checkpoint latency.
-
-    B already holds the file (`_establish_on_both`), which is what keeps
-    handleStreamEvent's own content-writing legs out of the picture — see the
-    precondition in suppress_fanout_backstops().
+    B never opens or edits the note. The counter on B pins that the server's
+    `note_yjs_update` broadcast → applyPushedNoteUpdate actually fired, so a
+    dead fan-out fails here instead of passing at checkpoint latency.
     """
     path = "E2E/Crdt/FanoutPassive.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "shared base\n", "shared base")
-    await _confirm_room_free(cdp_b, path)
+    note_id_b = await _confirm_room_free(cdp_b, path)
     try:
-        await cdp_b.suppress_fanout_backstops()
+        await cdp_b.arm_fanout_counter()
 
-        # A edits. With B's backstops dead, delivery can ONLY be the fan-out.
         write_note(vault_a, path, "shared base\nFANOUT_ONLY\n")
         b_final = wait_for_content(vault_b, path, "FANOUT_ONLY", timeout=CRDT_TIMEOUT)
         assert "shared base" in b_final, f"base content lost on B: {b_final!r}"
+        await _assert_fanout_ran(cdp_b, note_id_b, path)
     finally:
-        await cdp_b.restore_fanout_backstops()
+        await cdp_b.disarm_fanout_counter()
 
 
 @pytest.mark.asyncio
 async def test_concurrent_cold_edits_survive_over_fanout(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """[P0] A and B concurrently edit the SAME note while NEITHER opens it, with
-    the checkpoint backstops suppressed on BOTH devices. Both edits survive on
-    both disks — proving the CRDT merge rides the vault-channel fan-out, not the
-    pull/coldReceive backstop.
+    """[P0] A and B concurrently edit the SAME note while NEITHER opens it. Both
+    edits survive on both disks, and both devices took delivery over the fan-out.
 
-    New test — does NOT weaken test_concurrent_edits_both_survive (which permits
-    a backstop to converge); this is the strictly-fan-out variant.
+    Does NOT weaken test_concurrent_edits_both_survive (which permits a backstop
+    to converge); this is the strictly-fan-out variant.
     """
     path = "E2E/Crdt/FanoutMerge.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "shared base\n", "shared base")
-    await _confirm_room_free(cdp_a, path)
-    await _confirm_room_free(cdp_b, path)
+    note_id_a = await _confirm_room_free(cdp_a, path)
+    note_id_b = await _confirm_room_free(cdp_b, path)
     try:
-        await cdp_a.suppress_fanout_backstops()
-        await cdp_b.suppress_fanout_backstops()
+        await cdp_a.arm_fanout_counter()
+        await cdp_b.arm_fanout_counter()
 
         # Independent edits, close together so neither has seen the other's yet.
-        # Each side SENDS via handleModify/pushFile (untouched by suppression) and
-        # RECEIVES the other's over the fan-out (applyPushedNoteUpdate merges the
-        # remote delta after capturing local disk drift — both edits survive).
         write_note(vault_a, path, "shared base\nFROM_A\n")
         write_note(vault_b, path, "shared base\nFROM_B\n")
 
@@ -270,76 +262,45 @@ async def test_concurrent_cold_edits_survive_over_fanout(vault_a, vault_b, cdp_a
         b_final = wait_for_content(vault_b, path, "FROM_A", timeout=CRDT_TIMEOUT)
         assert "FROM_A" in a_final and "FROM_B" in a_final, f"A lost an edit: {a_final!r}"
         assert "FROM_A" in b_final and "FROM_B" in b_final, f"B lost an edit: {b_final!r}"
+        await _assert_fanout_ran(cdp_a, note_id_a, path)
+        await _assert_fanout_ran(cdp_b, note_id_b, path)
     finally:
-        await cdp_a.restore_fanout_backstops()
-        await cdp_b.restore_fanout_backstops()
+        await cdp_a.disarm_fanout_counter()
+        await cdp_b.disarm_fanout_counter()
 
 
 @pytest.mark.asyncio
 async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """[P1] B edits a CLOSED note → A receives it via the fan-out, and B does NOT
-    STEP1-enroll a CRDT room for the note it cold-sent.
+    """[P1] B edits a CLOSED note → A receives it over the fan-out, and B does
+    NOT STEP1-enroll a CRDT room for the note it cold-sent.
 
     An idle SEND ships its edit channel-up / as a durable /updates entry and is
     never required to enroll (sync.ts isCrdtManagedOffline: "Enrollment (STEP1)
-    is only the down-sync pull, never required to SEND"). We suppress backstops
-    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B to
-    keep anything from opening a room there and breaking the negative assertion.
-    TWO paths would: catchupViaSeqReplay's discovery enroll (applyChange, sync.ts:8244, and the
-    un-gated cold-note re-handshake `_confirm_room_free` documents), and
-    catchupViaSeqReplay → convergeColdNoteRoomFree, which falls back to
-    socketConverge → fireCrdtReHandshake (sync.ts:6288) when the room-free
-    converge fails — deliberately NOT gated on isLiveBound, so stubbing pull()
-    alone does not close it. Both are in the suppression list. That assertion is
-    a direct read of B's CrdtEnrollment.enrolled set (deterministic, no
-    log-flush timing dependency).
+    is only the down-sync pull, never required to SEND"). The negative half is a
+    direct read of B's CrdtEnrollment.enrolled set; the positive half is A's
+    fan-out counter.
 
-    #1503: suppression used to stub handleStreamEvent as well. With it dead B's
-    `pushFile` read a null id from noteIdMap, shouldDeferMint refused the push,
-    and the edit never left the device — a 120s timeout that read as a
-    receive-side fan-out bug. Restoring the handler fixes it, and the room-enroll
-    it was stubbed to prevent is already gated on isCanvasPath || isLiveBound.
-
-    Nothing deletes B's map entry (#1526): a full sync REBUILDS noteIdMap and
-    leaves the path transiently unmapped, and this test triggers one on B via
-    _confirm_room_free immediately before writing on B. The write lands in that
-    window, shouldDeferMint refuses the push, and the edit falls to the flush
-    queue's ~107s recovery. Measured twice at 109s and 108s, against a 120s
-    deadline — a coin-flip, not a fan-out failure. The re-poll below closes it.
-
-    Tension worth knowing: catchupViaSeqReplay reaches applyChange, which is a
-    noteIdMap writer, and B runs with it stubbed for the enroll reason above. So
-    from suppression until restore, B has NO map repair. Everything that needs a
-    settled map must therefore happen before suppression — which is why the poll
-    is ordered above the try block and not inside it.
+    This test was the #1 source of e2e-crdt red for weeks, across three distinct
+    failure regimes, none of them a real fan-out bug: suppression stubbed nothing
+    (false green), then broke B's push via noteIdMap (#1503), then removed B's
+    map repair so a transient unmapping burned the full timeout (#1526). All
+    three were artifacts of DISABLING paths on a live client. Counting disables
+    nothing, so the pre-write mapping re-poll #1526 needed is gone too — nothing
+    in the window can drop a mapping that cannot then heal.
     """
-    # ponytail: B holds no map repair while suppressed. Keep the window between
-    # suppression and the write empty — anything added in there that can drop or
-    # await a mapping has no way to recover, and burns the full timeout.
     path = "E2E/Crdt/FanoutColdSend.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin\n", "origin")
     note_id_b = await _confirm_room_free(cdp_b, path)
-    await _confirm_room_free(cdp_a, path)
-    # B's map must hold the path at WRITE time, and this poll must happen
-    # BEFORE suppression, not after (#1526). `shouldDeferMint` refuses a push on
-    # `unmapped + engine-flushed` (sync.ts:5292), and the path can be
-    # transiently unmapped after the full sync `_confirm_room_free` triggers.
-    # The repair is `catchupViaSeqReplay` -> `applyChange`, a noteIdMap writer —
-    # which suppress_fanout_backstops() stubs. Polling after suppression waits
-    # for a repair that suppression has just disabled, so a transiently unmapped
-    # path never recovers and the poll burns its full timeout. Ordered this way
-    # the map is proven present while the repair is still live, and the window
-    # between here and the write holds nothing that can drop it.
-    await cdp_b.wait_for_note_id_for_path(path, timeout=CRDT_TIMEOUT)
+    note_id_a = await _confirm_room_free(cdp_a, path)
     try:
-        await cdp_a.suppress_fanout_backstops()
-        await cdp_b.suppress_fanout_backstops()
+        await cdp_a.arm_fanout_counter()
 
         # B edits the CLOSED note (never opened in the editor).
         write_note(vault_b, path, "origin\nCOLD_SEND_FROM_B\n")
 
         a_final = wait_for_content(vault_a, path, "COLD_SEND_FROM_B", timeout=CRDT_TIMEOUT)
         assert "origin" in a_final, f"base lost on A: {a_final!r}"
+        await _assert_fanout_ran(cdp_a, note_id_a, path)
 
         enrolled = await cdp_b.get_enrolled_note_ids()
         assert note_id_b not in enrolled, (
@@ -347,8 +308,7 @@ async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_
             f"an idle send must stay room-free. enrolled={enrolled}"
         )
     finally:
-        await cdp_a.restore_fanout_backstops()
-        await cdp_b.restore_fanout_backstops()
+        await cdp_a.disarm_fanout_counter()
 
 
 @pytest.mark.asyncio
@@ -356,19 +316,22 @@ async def test_fanout_sequential_edits_converge_preserving_prior_state(
     vault_a, vault_b, cdp_a, cdp_b, api_sync
 ):
     """[P1] Two SEQUENTIAL remote edits to an idle note both converge on B over
-    the fan-out alone, the second preserving the first.
+    the fan-out, the second preserving the first.
 
     (Was ``test_fanout_receive_after_hibernate_rehydrates``: the Relay-model
     persistent-doc engine NEVER frees an idle Y.Doc — ``closeDoc`` /
     ``hibernateIfIdle`` are no-ops now, so there is no free-then-rehydrate step to
     assert. The residual guarantee — a second fan-out apply merges onto the doc
     the first left behind, no state lost — still matters and is what this pins.)
+
+    The counter asserts >= 2: EDIT_ONE is confirmed on B's disk before EDIT_TWO
+    is written, so the two applies cannot coalesce into one.
     """
     path = "E2E/Crdt/FanoutSequential.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "base\n", "base")
-    await _confirm_room_free(cdp_b, path)
+    note_id_b = await _confirm_room_free(cdp_b, path)
     try:
-        await cdp_b.suppress_fanout_backstops()
+        await cdp_b.arm_fanout_counter()
 
         # First remote edit converges via the fan-out.
         write_note(vault_a, path, "base\nEDIT_ONE\n")
@@ -380,5 +343,6 @@ async def test_fanout_sequential_edits_converge_preserving_prior_state(
         assert "EDIT_ONE" in b_final and "base" in b_final, (
             f"second fan-out apply lost prior state: {b_final!r}"
         )
+        await _assert_fanout_ran(cdp_b, note_id_b, path, minimum=2)
     finally:
-        await cdp_b.restore_fanout_backstops()
+        await cdp_b.disarm_fanout_counter()

--- a/e2e/unit/test_infra_breaker_exit.py
+++ b/e2e/unit/test_infra_breaker_exit.py
@@ -1,0 +1,90 @@
+"""Unit tests for the infra circuit breaker's exit reporting — no CI stack needed.
+
+Regression lock for the cascade class: when an Obsidian/CDP instance dies
+mid-suite, the tests that already failed are recorded as ordinary failures and
+the run exits 1 — indistinguishable in CI from real product breakage. Two such
+runs on 2026-09-01/02 produced 20 red entries across the frontmatter,
+index-crdt and live-bound suites, and every one of them was downstream of the
+dead instance rather than a broken feature.
+
+The breaker must therefore report distinctly: a dedicated exit code so the run
+says "infra", not "20 features are broken". It must NOT go green — a dead stack
+proved nothing — and it must stay silent on a normal run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_CONFTEST = Path(__file__).resolve().parents[1] / "conftest.py"
+
+
+def _load_conftest():
+    """Import e2e/conftest.py as a module without pytest collecting it.
+
+    e2e/unit has its own rootdir, so the parent conftest is not otherwise
+    importable here. Its import-time body only reads env vars.
+    """
+    sys.path.insert(0, str(_CONFTEST.parent))
+    try:
+        spec = importlib.util.spec_from_file_location("_e2e_conftest", _CONFTEST)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.pop(0)
+
+
+class _FakeSession:
+    def __init__(self, exitstatus: int = 1) -> None:
+        self.exitstatus = exitstatus
+
+
+@pytest.fixture
+def conftest():
+    module = _load_conftest()
+    module._infra_dead_reason = None
+    return module
+
+
+def test_normal_run_exit_status_is_untouched(conftest):
+    """No infra death: the hook must not rewrite a real pass or a real failure."""
+    for original in (0, 1):
+        session = _FakeSession(original)
+        conftest.pytest_sessionfinish(session, original)
+        assert session.exitstatus == original, (
+            "the breaker rewrote the exit status of a run it never tripped on — "
+            "real test failures would be reported as infra deaths"
+        )
+
+
+def test_infra_death_gets_its_own_exit_code(conftest, capsys):
+    """Breaker tripped: distinct exit code, and an annotation naming the cause."""
+    conftest._infra_dead_reason = "INFRA DEAD: an Obsidian/CDP instance is gone (last: test_x)."
+
+    session = _FakeSession(1)
+    conftest.pytest_sessionfinish(session, 1)
+
+    assert session.exitstatus == conftest.INFRA_DEAD_EXIT_CODE
+    out = capsys.readouterr().out
+    assert "::error title=E2E infra died::" in out, (
+        "no workflow annotation — the run still reads as N broken features in the UI"
+    )
+    assert "an Obsidian/CDP instance is gone" in out, "annotation dropped the cause"
+
+
+def test_infra_death_never_reports_success(conftest):
+    """A dead stack proved nothing. It must not exit 0 under any circumstance."""
+    conftest._infra_dead_reason = "INFRA DEAD: backend refuses connections."
+
+    # Worst case: the breaker trips on the very last test and pytest was
+    # otherwise about to report a clean pass.
+    session = _FakeSession(0)
+    conftest.pytest_sessionfinish(session, 0)
+
+    assert session.exitstatus != 0, "an infra death reported as a green run"
+    assert session.exitstatus == conftest.INFRA_DEAD_EXIT_CODE


### PR DESCRIPTION
CI pass rate fell 77% → 61% over four weeks (all runs, W33→W36). This fixes the three causes that account for most of it. Zero product-code changes.

## What was actually wrong

Measured over 300 runs / 154 failed jobs / the nightly flake ledger:

- **`e2e-crdt` is 43% of all failed jobs.** The nightly ledger localizes the regression to week 34; `e2e-clerk` went the *other* way over the same period (25% → 100%), so the earlier stabilization work held.
- Post-fix, non-cascade failures come from **three tests**, and `test_cold_send_over_fanout_opens_no_room` alone was 8 of 15.
- **Two runs that aborted on `INFRA DEAD` produced 20 red entries** across the frontmatter, index-crdt and live-bound suites. Every single frontmatter "flake" in the window was this. The frontmatter suite never independently failed once.
- **`unit-tests` did not execute on 9 of the last 12 main pushes**, and reported success each time.

## 1. Count fan-out applies instead of suppressing backstops

The four "TRUE fan-out proof" crdt tests proved the fan-out by stubbing every other delivery path to a no-op. That never once produced a true answer:

1. Every name it stubbed (`pull`, `coldReceive`, `catchupViaSocket`) had been retired from the plugin, and the `typeof` guard skips what is gone — so it stubbed **nothing**, and all four tests ran green with the fan-out dead.
2. Fixing (1) broke the **sender**: `handleStreamEvent` commits `noteIdMap`, so a suppressed device read a null id, `shouldDeferMint` refused its push, and the edit never left the device (#1503).
3. Fixing (2) left the device with no `noteIdMap` repair inside the test window, so a transient unmapping could never heal (#1526) and burned the full 120s timeout.

All three are artifacts of **disabling paths on a live client**, not fan-out bugs. Counting calls through: nothing is disabled, no map upkeep is lost, a dead fan-out still fails (counter stays zero), and a rename now fails loudly in the helper instead of silently making four tests prove nothing. The #1526 pre-write re-poll goes away with it.

## 2. An infra death reports as infra

The breaker already aborts, but pre-abort failures record as ordinary failures and pytest exits 1 — indistinguishable from real breakage. Now: a workflow annotation naming the cause and a dedicated exit code. The job still fails (a dead stack proved nothing and must not read as green).

Covered by three new `e2e/unit` tests. The first run of them caught a genuine `SyntaxError` in this change.

## 3. A fingerprint-skipped gate reads as skipped

The `ci` aggregate treats `skipped` as passing, silently. Sound inference, but it renders identically to a verified green and it cost three days on #1503.

The gate is unchanged — never-skip-on-main was tried and reverted (`is-full` is false on main, so `e2e-crdt` dies on `docker pull ""`). Only the signal changes: `ci` now lists every gate that did not execute and says a green means *nothing changed that these gates cover*, not *these gates passed*.

This also closes #1531's option A without touching the marker registry: the fingerprint hashes `verify.yml` and the `e2e/` tree, so these commits invalidate every backend and e2e marker by construction — including the poisoned greens recorded while the suppression helper was stubbing nothing.

## What I did NOT do, and why

Porting the `api_only` tier (80 tests, 3,828 lines) to ExUnit was on the list. Both its justifications turned out to be wrong:

- **Wall clock:** `verify.yml:1323` documents that the api_only step runs hidden behind the plugin build and Playwright install — "~0 extra wall-clock".
- **Blast radius:** fixed by (2) above.

Not worth a 3,828-line translation. Same conclusion for the per-test speed trims I'd flagged: the four heavy jobs (`e2e-clerk` 458s, `unit-tests` 450s, `e2e-crdt` 420s, `e2e-browser` 350s) run concurrently, so shaving seconds off any one of them saves nothing. Real speed work has to target `e2e-clerk`.

## Still open, not addressed here

- Two remaining e2e-crdt failure clusters: `test_fanout_sequential_edits_converge_preserving_prior_state` + `test_drifted_map_self_heals_on_inbound_edit` fail **together, 5 of 5 times**, never separately. Both depend on an inbound apply resolving id→path with the map repairer unavailable. Shared mechanism, not yet root-caused.
- Whether two `e2e-crdt` runs with `run_number`s congruent mod 15 can share an Xvfb display band (there is no concurrency lock; the `heavy` label replaced it). **Unproven** — I could not confirm concurrent runner count.

Refs #1503, #1522, #1526, #1531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp