### PR TITLE
test(folders): actually test the vault scoping the name claimed

### DIFF
--- a/test/engram_web/controllers/folders_controller_test.exs
+++ b/test/engram_web/controllers/folders_controller_test.exs
@@ -53,8 +53,63 @@ defmodule EngramWeb.FoldersControllerTest do
       assert [%{"path" => "Projects/a.md", "id" => _}] = body["notes"]
     end
 
-    test "404 when marker doesn't belong to caller's vault", %{conn: conn} do
+    # This describe block used to hold ONE negative case, named "404 when marker
+    # doesn't belong to caller's vault" but passing a freshly generated UUID —
+    # an id belonging to NO vault. That proves the not-found path, not the
+    # scoping one: a controller that looked markers up globally and ignored the
+    # caller's vault entirely would still have passed it. The two cases the
+    # name actually claims are below, and neither was covered.
+    test "404 for a marker id that does not exist" do
+      %{conn: conn} = authed_api_conn(%{conn: build_conn()})
+
       conn |> get(~p"/api/folders/by-id/#{Ecto.UUID.generate()}/notes") |> json_response(404)
+    end
+
+    # Defended by RLS (`Repo.with_tenant/2`), not by the query's vault
+    # predicate — verified by mutation: dropping `vault_id` from
+    # `get_folder_marker_by_id/3` leaves this test green. Kept anyway as the
+    # boundary marker for THIS endpoint (multi_tenant_test.exs covers notes,
+    # folders, tags and the manifest, but not folder-notes-by-id).
+    test "404 when the marker belongs to another user's vault" do
+      %{conn: conn} = authed_api_conn(%{conn: build_conn()})
+      %{user: other_user, vault: other_vault} = authed_api_conn(%{conn: build_conn()})
+
+      {:ok, marker} = Engram.Notes.create_folder_marker(other_user, other_vault, "Theirs")
+
+      {:ok, _} =
+        Engram.Notes.upsert_note(other_user, other_vault, %{
+          path: "Theirs/secret.md",
+          content: "# Secret"
+        })
+
+      conn |> get(~p"/api/folders/by-id/#{marker.id}/notes") |> json_response(404)
+    end
+
+    # The subtler half, and the one the old test's name pointed at most
+    # directly: same owner, different vault. Tenant scoping alone (user_id /
+    # RLS) does NOT catch this — both vaults belong to the caller — so this is
+    # the ONLY test here that exercises the vault predicate itself.
+    #
+    # Verified by mutation: rewriting `get_folder_marker_by_id/3` to scope by
+    # `user_id` alone (a realistic dropped-clause bug, and the exact shape
+    # `tenant_scope_lint_test.exs` exists to catch elsewhere) turns this into a
+    # 200 with the other vault's folder listing. The other two cases in this
+    # block stay green under that mutation.
+    test "404 when the marker belongs to another vault of the same user", %{
+      conn: conn,
+      user: user
+    } do
+      other_vault = Engram.Factory.insert(:vault, user: user, is_default: false)
+
+      {:ok, marker} = Engram.Notes.create_folder_marker(user, other_vault, "OtherVault")
+
+      {:ok, _} =
+        Engram.Notes.upsert_note(user, other_vault, %{
+          path: "OtherVault/a.md",
+          content: "# A"
+        })
+
+      conn |> get(~p"/api/folders/by-id/#{marker.id}/notes") |> json_response(404)
     end
   end
 end


### PR DESCRIPTION
Found while double-checking claims from the CI reliability work (#1559, #1561).

`GET /api/folders/by-id/:id/notes` had one negative case:

```elixir
test "404 when marker doesn't belong to caller's vault", %{conn: conn} do
  conn |> get(~p"/api/folders/by-id/#{Ecto.UUID.generate()}/notes") |> json_response(404)
end
```

The name claims vault scoping. The body passes a freshly generated UUID — an id belonging to **no** vault. It proves the not-found path, not the scoping one: a controller that looked markers up globally and ignored the caller's vault entirely would have passed it unchanged.

Same class as the fan-out helper in #1559 — a test that proves less than its name claims — just much smaller.

## What changed

Three cases now, two of them new:

| case | what defends it |
|---|---|
| marker id does not exist | the not-found path (original test, renamed honestly) |
| marker in another **user's** vault | RLS, via `Repo.with_tenant/2` |
| marker in another vault of the **same user** | the query's `vault_id` predicate |

The third is the one that matters. Tenant scoping does not catch it — both vaults belong to the caller — so it is the only test here that exercises the vault predicate itself.

## Verified by mutation, not assumed

Rewriting `get_folder_marker_by_id/3` to scope by `user_id` alone — a dropped-clause bug, and the exact shape `tenant_scope_lint_test.exs` exists to catch elsewhere:

```
1) test 404 when the marker belongs to another vault of the same user
   ** (RuntimeError) expected response with status 404, got: 200, with body:
   "{\"notes\":[]}"
```

The other two stay green under that mutation, which is why the same-user case had to be added specifically.

**No product change — the scoping was already correct.** This closes a coverage gap, it does not fix a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp