### PR TITLE
test(e2e): assert the plugin surface the harness reaches for

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -17,6 +17,7 @@ files triggers the plugin's file watcher, causing unexpected sync events.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import secrets
@@ -61,6 +62,66 @@ def pytest_configure(config):
             "Clerk-gated tests would silently skip. Fix the secret wiring.",
             returncode=1,
         )
+
+# ---------------------------------------------------------------------------
+# Plugin surface contract — what the harness is allowed to reach for
+# ---------------------------------------------------------------------------
+# A helper that names a plugin symbol which has since been RENAMED does not
+# fail. It silently does nothing, and every test built on it goes green while
+# proving nothing. That is not hypothetical; it has happened twice:
+#
+#   * `suppress_fanout_backstops` stubbed three cold-apply method names that had
+#     ALL been retired from the plugin. Its `typeof` guard skipped each missing
+#     one, so it stubbed NOTHING and four "TRUE fan-out proof" tests ran green
+#     with the fan-out dead, for an unknown number of runs (#1503, #1559).
+#   * `accelerate_echo_expiry` reached for `syncEngine.recentlyPushed` after that
+#     path-keyed Map was consolidated into the private `files` TTL store. Dead on
+#     arrival; survivable only because nothing called it (deleted in this change).
+#
+# Asserting the surface once per session is cheaper than debugging a 120s
+# timeout that looks like a product bug. When you add a CDP call touching a new
+# syncEngine member, add it HERE — that is the whole contract, and
+# `e2e/unit/test_plugin_surface_contract.py` fails if the harness drifts from
+# these lists.
+#
+# Hard failure, not a warning, and deliberately so: pairing e2e against a plugin
+# branch missing one of these makes the whole run meaningless, and failing at
+# session start with the symbol named beats a TypeError forty tests deep.
+REQUIRED_ENGINE_METHODS = [
+    "applyPushedNoteUpdate",
+    "catchUp",
+    "flushQueue",
+    "fullSync",
+    "getCatchupSeq",
+    "getLastSync",
+    "getStatus",
+    "goOffline",
+    "goOnline",
+    "handleDelete",
+    "handleModify",
+    "handleRename",
+    "handleStreamEvent",
+    "isRecentlyPushed",
+    "isSyncBlocked",
+    "pullAll",
+    "pushAll",
+    "pushFile",
+    "setSyncBlocked",
+]
+
+REQUIRED_ENGINE_PROPS = [
+    "api",
+    "crdt",
+    "crdtEnrollment",
+    "debounceTimers",
+    "issues",
+    "lastError",
+    "lastSync",
+    "noteIdMap",
+    "offline",
+    "queue",
+    "ready",
+]
 
 # ---------------------------------------------------------------------------
 # Infra circuit breaker — stop the suite when the stack is provably dead
@@ -849,15 +910,22 @@ async def _assert_plugin_surfaces(cdp_a):
             if (typeof p.markSyncGateAccepted !== 'function') missing.push('markSyncGateAccepted');
             if (typeof p.registerVault !== 'function') missing.push('plugin.registerVault');
             if (typeof p.api?.registerVault !== 'function') missing.push('api.registerVault');
-            if (typeof p.syncEngine?.isRecentlyPushed !== 'function') missing.push('isRecentlyPushed');
-            if (typeof p.syncEngine?.handleStreamEvent !== 'function') missing.push('handleStreamEvent');
             if (!(p.syncEngine?.syncState instanceof Map)) missing.push('syncState:Map');
-            // NOT checked here: applyPushedNoteUpdate, the fan-out apply that
-            // arm_fanout_counter() wraps. It belongs to 4 crdt tests, and this
-            // fixture is session-scoped autouse across every suite — a rename
-            // would fail the ~110-test clerk session for a reason with no
-            // bearing on it. The helper raises on its own instead, which is the
-            // same protection scoped to the tests that need it.
+
+            // Lists come from REQUIRED_ENGINE_METHODS / _PROPS in this module —
+            // see their docstrings for why this check exists.
+            for (const m of """ + json.dumps(REQUIRED_ENGINE_METHODS) + """) {
+                if (typeof p.syncEngine?.[m] !== 'function') missing.push(`syncEngine.${m}()`);
+            }
+            // Presence only, and STRICTLY `=== undefined`: `lastSync` is "",
+            // `ready` is false and `noteIdMap` is null in a freshly constructed
+            // engine, so anything looser (falsy, == null) would fail every suite
+            // at session start. Undefined is the failure that matters — a
+            // renamed field reads as undefined and every access downstream
+            // silently no-ops or throws mid-suite.
+            for (const f of """ + json.dumps(REQUIRED_ENGINE_PROPS) + """) {
+                if (p.syncEngine?.[f] === undefined) missing.push(`syncEngine.${f}`);
+            }
             for (const id of cmds) {
                 if (!app.commands.findCommand(`engram-vault-sync:${id}`)) {
                     missing.push(`command:${id}`);

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -757,40 +757,6 @@ class CdpClient:
         result = await self.evaluate(f"{ENGINE_PATH}.getCatchupSeq()")
         return result if isinstance(result, int) else 0
 
-    async def accelerate_echo_expiry(self, path: str, ms: int = 200) -> None:
-        """Replace the pending recentlyPushed timer for ``path`` with a short one.
-
-        ``markRecentlyPushed`` arms a ``setTimeout(ECHO_COOLDOWN_MS=5000)`` to
-        clear the entry. Tests that just want to drive the expiry branch should
-        not sleep for the full production cooldown — shorten the timer so the
-        same clear path runs in tens of ms.
-
-        The timer-fires-and-clears mechanism is preserved (we install a real
-        ``setTimeout``, not a synchronous ``delete``), so assertions on
-        ``isRecentlyPushed`` going False still exercise the production code path.
-        Raises CdpError when no timer is armed for ``path``.
-        """
-        escaped = json.dumps(path)
-        result = await self.evaluate(
-            f"""
-            (() => {{
-                const m = {ENGINE_PATH}.recentlyPushed;
-                const t = m.get({escaped});
-                if (t === undefined) return 'no-timer';
-                window.clearTimeout(t);
-                const newT = window.setTimeout(
-                    () => m.delete({escaped}), {int(ms)}
-                );
-                m.set({escaped}, newT);
-                return 'rearmed';
-            }})()
-            """
-        )
-        if result != "rearmed":
-            raise CdpError(
-                f"accelerate_echo_expiry: no recentlyPushed timer for {path!r}"
-            )
-
     async def check_stream_connected(self) -> bool:
         """Check if the plugin's real-time stream (WebSocket channel) is connected."""
         result = await self.evaluate(f"{PLUGIN_PATH}.isLiveConnected()")

--- a/e2e/unit/test_plugin_surface_contract.py
+++ b/e2e/unit/test_plugin_surface_contract.py
@@ -1,0 +1,132 @@
+"""The harness may not reach for a plugin symbol the surface check doesn't assert.
+
+Stack-free. Guards the #1503 class at its root.
+
+A CDP helper that names a plugin symbol which has since been renamed does not
+fail — it silently does nothing, and every test built on it goes green while
+proving nothing. `conftest.REQUIRED_ENGINE_METHODS` / `_PROPS` fix that by
+asserting the surface once per session, but only for symbols someone remembered
+to add. A helper reaching for a symbol *absent from those lists* is back to the
+original failure mode.
+
+So: scan the harness for `syncEngine` member accesses and require every one to
+be declared. The lists stay honest without anyone remembering to update them,
+because forgetting turns this red.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_E2E = Path(__file__).resolve().parents[1]
+_HARNESS = [_E2E / "helpers" / "cdp.py", _E2E / "conftest.py"]
+
+# `{ENGINE_PATH}.foo`, `se.foo` (the local alias inside evaluated JS), and
+# `syncEngine.foo` / `syncEngine?.foo`.
+_ACCESS = re.compile(
+    r"(?:\{ENGINE_PATH\}|\bse|\bsyncEngine\??)\.([A-Za-z_]\w*)",
+)
+
+# Names that are not plugin surface:
+#   __*      test-injected bookkeeping the harness itself installs
+#   _orig*   saved originals from a wrap/restore pair
+_HARNESS_OWNED = re.compile(r"^(__|_orig)")
+
+# Asserted by conftest under a STRONGER predicate than mere presence, so
+# re-declaring them in the lists would only double-check them weakly.
+_CHECKED_ELSEWHERE = {
+    "syncState",  # asserted `instanceof Map`, not just defined
+}
+
+
+def _strip_comments(text: str) -> str:
+    """Drop whole comment lines, Python and JS alike.
+
+    Both this repo's incident write-ups and the conftest check itself NAME the
+    symbols in prose (`syncEngine.recentlyPushed` appears in a comment
+    explaining why it was removed). Scanning raw text reports those as live
+    reaches, which would make this test fail on documentation.
+
+    Whole lines only, deliberately: parsing `//` inside a string would have to
+    understand `http://`, and a trailing comment after real code still leaves
+    that code scanned, which is the correct outcome.
+    """
+    out = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#") or stripped.startswith("//"):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def _load_conftest():
+    sys.path.insert(0, str(_E2E))
+    try:
+        spec = importlib.util.spec_from_file_location("_e2e_conftest", _E2E / "conftest.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.fixture(scope="module")
+def declared() -> set[str]:
+    c = _load_conftest()
+    return set(c.REQUIRED_ENGINE_METHODS) | set(c.REQUIRED_ENGINE_PROPS)
+
+
+def _reached() -> set[str]:
+    found: set[str] = set()
+    for path in _HARNESS:
+        for name in _ACCESS.findall(_strip_comments(path.read_text())):
+            if _HARNESS_OWNED.match(name) or name in _CHECKED_ELSEWHERE:
+                continue
+            found.add(name)
+    return found
+
+
+def test_every_reached_symbol_is_declared(declared):
+    """A helper reaching for an undeclared symbol is the original bug, again."""
+    undeclared = sorted(_reached() - declared)
+
+    assert not undeclared, (
+        f"the harness reaches for syncEngine members the session-start surface "
+        f"check does not assert: {undeclared}. A rename of any of these fails "
+        f"silently and takes its tests green with it — which is exactly how "
+        f"four fan-out tests ran against a dead feature (#1503). Add them to "
+        f"REQUIRED_ENGINE_METHODS or REQUIRED_ENGINE_PROPS in e2e/conftest.py, "
+        f"or to _CHECKED_ELSEWHERE here with a reason."
+    )
+
+
+def test_the_scanner_actually_finds_things(declared):
+    """Guard the guard: a regex that matched nothing would make this file inert.
+
+    Without this, breaking `_ACCESS` turns the check above into a permanent
+    green that asserts `set() - declared == []` — the same false-green shape
+    the whole contract exists to prevent.
+    """
+    reached = _reached()
+
+    assert len(reached) > 20, (
+        f"the harness scanner found only {len(reached)} syncEngine members "
+        f"({sorted(reached)}). It found 30 when written, so the regex has "
+        f"almost certainly stopped matching — this file is now inert."
+    )
+    # Anchor on a symbol the harness has reached for since the fan-out rework.
+    assert "applyPushedNoteUpdate" in reached
+
+
+def test_declared_lists_are_disjoint(declared):
+    """A name in both lists gets checked as a function AND a property."""
+    c = _load_conftest()
+    overlap = set(c.REQUIRED_ENGINE_METHODS) & set(c.REQUIRED_ENGINE_PROPS)
+
+    assert not overlap, f"declared as both method and property: {sorted(overlap)}"


### PR DESCRIPTION
Action #1 from the retrospective. Companion to #1563 (which writes down the rules); this one enforces the part that can be enforced.

## The bug class

A CDP helper naming a plugin symbol that has since been renamed **does not fail**. It silently does nothing, and every test built on it goes green while proving nothing.

Twice now:

- `suppress_fanout_backstops` stubbed three cold-apply method names that had **all** been retired from the plugin. Its `typeof` guard skipped each missing one, so it stubbed nothing and four "TRUE fan-out proof" tests ran with the fan-out dead, for an unknown number of runs (#1503, fixed in #1559).
- `accelerate_echo_expiry` reached for `syncEngine.recentlyPushed` after that path-keyed Map was consolidated into the private `files` TTL store. Dead on arrival, survivable only because nothing called it. **Found by writing this check**; deleted here.

## What changed

`conftest`'s session-start probe already had the right mechanism — it's why the fan-out rename was survivable at all. It just covered **3 of the 31** syncEngine members the harness actually touches.

The lists become `REQUIRED_ENGINE_METHODS` / `REQUIRED_ENGINE_PROPS` constants, and all 31 are asserted once per session. Every name was verified present in plugin `origin/main`'s `src/sync.ts` before being added, so this cannot fail against a current plugin.

Properties use a strict `=== undefined`, not a falsy check — a fresh engine has `lastSync === ""`, `ready === false` and `noteIdMap === null`, so anything looser would fail every suite at session start.

## Keeping the list honest

A hand-maintained list rots the moment someone adds a helper without updating it. `e2e/unit/test_plugin_surface_contract.py` (stack-free tier) scans the harness for `syncEngine` member accesses and fails if any is undeclared.

It carries its own guard-the-guard test, because a scanner regex that stops matching turns the contract into a permanent green — the exact false-green shape this all exists to prevent.

## Verified by mutation, both directions

```
drop "pushFile" from REQUIRED_ENGINE_METHODS:
  AssertionError: the harness reaches for syncEngine members the session-start
  surface check does not assert: ['pushFile']

break the _ACCESS regex:
  AssertionError: the harness scanner found only 0 syncEngine members ([]).
  It found 30 when written, so the regex has almost certainly stopped
  matching — this file is now inert.
```

`e2e/unit` is 64 passed, ruff clean.

Refs #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp