### PR TITLE
feat(billing): pricing v3.1 vault + storage allowances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 > **Workspace:** For cross-project work, open `../engram-workspace/` instead. It provides unified context for both plugin and backend.
 
-Engram — AI-powered personal knowledge base built on Obsidian. Your vault remembers everything. Makes your notes queryable by any AI assistant via MCP. SaaS pricing: Free / Starter $7/mo / Pro $14/mo (v3 reanchored 2026-05-31). Pricing rationale in `../engram-workspace/docs/context/pricing-strategy.md`; billing integration details in `docs/context/paddle-integration.md`.
+Engram — AI-powered personal knowledge base built on Obsidian. Your vault remembers everything. Makes your notes queryable by any AI assistant via MCP. SaaS pricing: Free / Starter $7/mo / Pro $14/mo (v3 reanchored 2026-05-31). Pricing rationale in `../engram-workspace/docs/context/pricing-tiers-v2-decisions.md` (the old `pricing-strategy.md` pointer named a file that does not exist); billing integration details in `docs/context/paddle-integration.md`.
 
 ## Issue Tracker
 
@@ -274,11 +274,24 @@ Design spec: `../engram-workspace/docs/superpowers/specs/2026-06-23-logging-taxo
 
 ## Product Tiers
 
-| Tier | Price | Features |
-|------|-------|----------|
-| **Free** | $0 | 1 vault, 1 device (12h swap cooldown), 1GB attachments, manual sync, 10k notes, 5 AI conversations/day, MCP enabled, 90-day inactivity auto-delete |
-| **Starter** | $7/mo ($70/yr) | 5 vaults, unlimited devices, 3GB attachments, real-time SSE sync, 50k notes, 500 AI queries/day, API write access |
-| **Pro** | $14/mo ($140/yr) | 15 vaults, unlimited devices, 15GB attachments, real-time sync, unlimited notes, unlimited AI (10k/day fair-use), priority support, higher API rate |
+**Free $0 / Starter $7-mo ($70-yr) / Pro $14-mo ($140-yr).** Prices are stable;
+the limit matrix is not.
+
+**`Engram.Billing.LimitKeys` is the only source of truth for limits.** Read the
+`@catalog` there. Do not restate the matrix here and do not trust a matrix you
+find in any other doc.
+
+This section used to carry a full feature table. Every line of it went stale
+without anyone noticing, in three separate waves: the 2026-08-24 revision (Free
+is 2 devices not 1, 24h not 12h cooldown, real-time sync on every tier, API keys
+moved to Pro), the `ai_searches_per_day` consolidation that deleted six AI
+meters, and pricing v3.1 (vaults 1/10/unlimited, attachments 1/10/50 GiB). It
+told agents Starter had API write access for roughly a week after that became
+Pro-only. A duplicated matrix is a matrix that drifts, so there is now one copy
+and it is the code.
+
+Decisions and rationale, including why each number is what it is:
+`../engram-workspace/docs/context/pricing-tiers-v2-decisions.md`.
 
 Self-host (no `PADDLE_API_KEY`): free, no billing wiring. See `docs/context/paddle-integration.md`.
 

--- a/docs/context/rate-limiter-architecture.md
+++ b/docs/context/rate-limiter-architecture.md
@@ -5,7 +5,7 @@ _Last verified: 2026-07-08_
 **TL;DR:** Engram rate limiting is **Postgres + BEAM only, zero Redis**. Two mechanisms, split by limiter character:
 
 - **Short-window abuse/burst limiters** (preauth 60s, auth, `api_rps` 1s, Voyage RPM) → **`EngramWeb.RateLimiter.DistributedETS`**: per-node Hammer ETS counter + `Phoenix.PubSub` broadcast. Eventually consistent, permissive on failure.
-- **Billing-exact daily cap** (`external_ai_searches_per_day` / `inapp_searches_per_day`) → **`Engram.Usage.DailyCap`**: a lazy-refill **token bucket in Postgres** (`usage_buckets`), durable across deploys, with an ETS fast-deny cache.
+- **Billing-exact daily cap** (`ai_searches_per_day`) → **`Engram.Usage.DailyCap`**: a lazy-refill **token bucket in Postgres** (`usage_buckets`), durable across deploys, with an ETS fast-deny cache. Rolling, not calendar-daily: capacity is the allowance and refill is `allowance/86_400` per second, so there is no midnight cliff and no cron. This line used to name `external_ai_searches_per_day` / `inapp_searches_per_day`, which were two of the six keys this single meter replaced.
 
 Backend selection (`EngramWeb.RateLimiter.backend/0`): `:ets` (self-host / dev / test — per-node, no broadcast) | `:distributed_ets` (clustered SaaS prod, keyed on `DNS_CLUSTER_QUERY` in `runtime.exs`).
 

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -709,7 +709,7 @@ export default function BillingPage({
 								<PlanAccordionRow
 									name={PLAN_CATALOG.pro.name}
 									price={formatPlanPrice(PLAN_CATALOG.pro, cadence)}
-									summary="Unlimited vaults · 50 GB · unlimited AI"
+									summary="Unlimited vaults · 50 GB · cross-vault search + API"
 									features={PLAN_CATALOG.pro.features}
 									ctaLabel="Choose Pro"
 									ctaNote="7-day free trial · cancel anytime"

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -709,7 +709,7 @@ export default function BillingPage({
 								<PlanAccordionRow
 									name={PLAN_CATALOG.pro.name}
 									price={formatPlanPrice(PLAN_CATALOG.pro, cadence)}
-									summary="15 vaults · 15 GB · unlimited AI"
+									summary="Unlimited vaults · 50 GB · unlimited AI"
 									features={PLAN_CATALOG.pro.features}
 									ctaLabel="Choose Pro"
 									ctaNote="7-day free trial · cancel anytime"
@@ -722,7 +722,7 @@ export default function BillingPage({
 								<PlanAccordionRow
 									name={PLAN_CATALOG.starter.name}
 									price={formatPlanPrice(PLAN_CATALOG.starter, cadence)}
-									summary="5 vaults · 3 GB · 500 AI queries/day"
+									summary="10 vaults · 10 GB · unlimited AI"
 									features={PLAN_CATALOG.starter.features}
 									ctaLabel="Choose Starter"
 									ctaNote="7-day free trial · cancel anytime"

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -86,12 +86,14 @@ export const PLAN_CATALOG: Record<PlanTier, PlanCardCatalog> = {
 		name: "Pro",
 		monthlyPrice: 14,
 		annualPrice: 140,
-		features: [
-			"Unlimited vaults",
-			"Unlimited devices",
-			"50 GB attachments",
-			"Unlimited AI searches",
-		],
+		// Lead with what is actually Pro-ONLY. Unlimited devices and unlimited
+		// AI searches are true here too, but they are table stakes on paid and
+		// listing them made Pro read as "Starter with more storage" at double
+		// the price. `cross_vault_search` and `api_write_enabled` are the two
+		// keys that are genuinely pro-true in `LimitKeys`. Reranking is also
+		// pro-only but ships with RERANKER_BACKEND unset, so it stays off this
+		// list until the backend is actually deployed.
+		features: ["Unlimited vaults", "50 GB attachments", "Cross-vault search", "API access"],
 	},
 };
 

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -65,8 +65,14 @@ export function formatPlanPrice(
 export const FREE_TIER = {
 	name: "Free",
 	price: "$0",
-	summary: "10k notes · 1 vault · 1 GB attachments",
-	features: ["10k notes", "1 vault", "1 GB attachments", "2 devices"],
+	// "10k notes" was `notes_cap`, which never binds. The limit that actually
+	// binds on Free is `indexed_notes_cap: 2_000`, and per the v3.1 positioning
+	// that coverage number IS the upgrade lever, so it is the one we state.
+	// Do not say "2,000 most recent": `IndexCap` orders `asc: created_at`, so
+	// the indexed set is the OLDEST 2,000 and it is the user's newest notes
+	// that fall outside.
+	summary: "2,000 notes searchable · 1 vault · 1 GB attachments",
+	features: ["2,000 notes searchable", "1 vault", "1 GB attachments", "2 devices"],
 } as const;
 
 // Single catalog source-of-truth: both onboarding (trial signup) and the

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -80,13 +80,18 @@ export const PLAN_CATALOG: Record<PlanTier, PlanCardCatalog> = {
 		name: "Starter",
 		monthlyPrice: 7,
 		annualPrice: 70,
-		features: ["5 vaults", "Unlimited devices", "3 GB attachments", "500 AI queries/day"],
+		features: ["10 vaults", "Unlimited devices", "10 GB attachments", "Unlimited AI searches"],
 	},
 	pro: {
 		name: "Pro",
 		monthlyPrice: 14,
 		annualPrice: 140,
-		features: ["15 vaults", "Unlimited devices", "15 GB attachments", "10,000 AI queries/day"],
+		features: [
+			"Unlimited vaults",
+			"Unlimited devices",
+			"50 GB attachments",
+			"Unlimited AI searches",
+		],
 	},
 };
 

--- a/frontend/src/onboarding/onboard-billing-page.test.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.test.tsx
@@ -441,7 +441,9 @@ describe("OnboardBillingPage — Free tier CTA", () => {
 
 		const btn = await screen.findByRole("button", { name: /continue with free/iu });
 		expect(btn).toBeInTheDocument();
-		expect(screen.getByText(/10k notes · 1 vault · 1 GB attachments/iu)).toBeInTheDocument();
+		expect(
+			screen.getByText(/2,000 notes searchable · 1 vault · 1 GB attachments/iu),
+		).toBeInTheDocument();
 	});
 
 	it("calls POST /api/onboarding/accept_free_tier and navigates to /onboard/vault", async () => {

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -128,9 +128,11 @@ export function ActiveVaultsSection() {
 			{Boolean(atCap) && (
 				<aside className="mb-4 flex items-center justify-between gap-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
 					<p className="text-foreground text-sm">
-						{/* Cap is per-tier (Free 1, Starter 5), so the banner names the
-						    user's actual plan — it hardcoded "Free" and told a Starter
-						    user at 5 vaults that their Free plan allowed 5. */}
+						{/* Cap is per-tier (Free 1, Starter 10, Pro unlimited), so the
+						    banner names the user's actual plan — it hardcoded "Free" and
+						    told a Starter user at their cap that Free allowed that many.
+						    An unlimited cap arrives as null, which `atCap` rejects via its
+						    `typeof === "number"` guard, so this never renders for Pro. */}
 						Your {planLabel} plan allows {vaultsCap} {vaultsCap === 1 ? "vault" : "vaults"}. Upgrade
 						for more vaults.
 					</p>

--- a/lib/engram/billing/limit_keys.ex
+++ b/lib/engram/billing/limit_keys.ex
@@ -14,10 +14,32 @@ defmodule Engram.Billing.LimitKeys do
   @catalog %{
     # Pricing v2 spec §9.2 — 17 keys
     notes_cap: %{type: :integer, defaults: %{free: 10_000, starter: 50_000, pro: nil}},
-    vaults_cap: %{type: :integer, defaults: %{free: 1, starter: 5, pro: 15}},
+    # PACKAGING, NOT A RESOURCE (pricing v3.1, 2026-09-03). An earlier draft
+    # justified a Pro ceiling on per-vault CRDT index-room memory. That was
+    # wrong three ways and is recorded so it is not re-derived:
+    #   * `CrdtIndexDoc.start_link` sets `auto_exit: true` — rooms are
+    #     demand-started and exit on last observer, so a vault nobody is
+    #     connected to holds zero rooms and zero bytes.
+    #   * `CrdtRoomLru.touch/3` only tracks rooms with a positive
+    #     `idle_exit_ms`; the index room sets none, so it is never LRU-tracked
+    #     and cannot evict another user's rooms.
+    #   * Every quota here is per USER (`Billing.effective_limit(user, ...)`,
+    #     `Notes.check_notes_cap/1`), so vault count multiplies nothing.
+    # Residency tracks concurrent connections, which `concurrent_devices`
+    # already bounds. Residual risk is scripted vault-row creation, which
+    # belongs to the rate limiter, not to a pricing tier.
+    vaults_cap: %{type: :integer, defaults: %{free: 1, starter: 10, pro: nil}},
+    # 1 / 10 / 50 GiB. Raised from 1 / 3 / 15 GiB in pricing v3.1.
+    #
+    # THIS IS AN EGRESS CEILING WEARING A STORAGE LABEL. Downloads stream
+    # through `AttachmentsController.show/2`, so every byte here is billed as
+    # data transfer out at ~$0.09/GB — 4x the ~$0.023/GB-mo storage price —
+    # and it is charged per device, per sync. A Pro user filling 50 GiB across
+    # four devices moves 200 GiB on first sync, ~$18 against $14 of revenue.
+    # DO NOT raise past 50 GiB until attachment downloads are edge-cached.
     attachment_bytes_cap: %{
       type: :integer,
-      defaults: %{free: 1_073_741_824, starter: 3_221_225_472, pro: 16_106_127_360}
+      defaults: %{free: 1_073_741_824, starter: 10_737_418_240, pro: 53_687_091_200}
     },
     attachments_enabled: %{type: :boolean, defaults: %{free: true, starter: true, pro: true}},
     # Every tier gets the full MimeWhitelist surface (images, audio, video,

--- a/test/engram/billing/capabilities_test.exs
+++ b/test/engram/billing/capabilities_test.exs
@@ -33,7 +33,7 @@ defmodule Engram.Billing.CapabilitiesTest do
 
     assert caps.tier == "starter"
     assert caps.limits["notes_cap"] == 50_000
-    assert caps.limits["vaults_cap"] == 5
+    assert caps.limits["vaults_cap"] == 10
     # API keys are Pro-only — Starter resolves the same `false` as Free here.
     assert caps.limits["api_write_enabled"] == false
   end

--- a/test/engram/billing/limit_keys_test.exs
+++ b/test/engram/billing/limit_keys_test.exs
@@ -71,8 +71,9 @@ defmodule Engram.Billing.LimitKeysTest do
 
     test "starter tier matrix matches spec §9.2" do
       assert LimitKeys.default_for(:notes_cap, :starter) == 50_000
-      assert LimitKeys.default_for(:vaults_cap, :starter) == 5
-      assert LimitKeys.default_for(:attachment_bytes_cap, :starter) == 3_221_225_472
+      assert LimitKeys.default_for(:vaults_cap, :starter) == 10
+      # 10 GiB. Raised from 3 GiB in pricing v3.1 (2026-09-03).
+      assert LimitKeys.default_for(:attachment_bytes_cap, :starter) == 10_737_418_240
       assert LimitKeys.default_for(:max_file_bytes, :starter) == 209_715_200
       assert LimitKeys.default_for(:lifetime_embed_token_cap, :starter) == nil
       assert LimitKeys.default_for(:search_semantic_enabled, :starter) == true
@@ -85,8 +86,12 @@ defmodule Engram.Billing.LimitKeysTest do
 
     test "pro tier matrix matches spec §9.2" do
       assert LimitKeys.default_for(:notes_cap, :pro) == nil
-      assert LimitKeys.default_for(:vaults_cap, :pro) == 15
-      assert LimitKeys.default_for(:attachment_bytes_cap, :pro) == 16_106_127_360
+      # Unlimited as of pricing v3.1 — vaults are packaging, not a resource.
+      # Rooms are demand-started with `auto_exit`, index rooms are not
+      # LRU-tracked, and every quota is per-user. See the decision log.
+      assert LimitKeys.default_for(:vaults_cap, :pro) == nil
+      # 50 GiB. Raised from 15 GiB in pricing v3.1 (2026-09-03).
+      assert LimitKeys.default_for(:attachment_bytes_cap, :pro) == 53_687_091_200
       assert LimitKeys.default_for(:max_file_bytes, :pro) == 524_288_000
       assert LimitKeys.default_for(:reranker_enabled, :pro) == true
       assert LimitKeys.default_for(:search_semantic_enabled, :pro) == true

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -74,6 +74,38 @@ defmodule Engram.VaultsTest do
       {:ok, _, _} = Vaults.register_vault(user, "Third", Ecto.UUID.generate())
     end
 
+    # Pricing v3.1 moved Pro's `vaults_cap` from 15 to nil. Every unlimited test
+    # above reaches unlimited through the `-1` OVERRIDE sentinel; these two are
+    # the only ones that exercise a TIER DEFAULT, which is the path Pro now
+    # takes. `@no_cap` in `Engram.Billing` happens to list `nil` alongside
+    # `:unlimited` and `-1`, so this works — but nothing proved it, and dropping
+    # `nil` from that list would have silently capped every Pro user at zero
+    # vaults with `check_limit/3` answering `{:error, :limit_reached}` on the
+    # first create.
+    test "pro tier default (nil) is unlimited, not zero", %{user: user} do
+      insert(:subscription, user: user, tier: "pro", status: "active")
+      :ok = OverrideCache.evict(user.id)
+
+      for n <- 1..16 do
+        assert {:ok, _, :created} =
+                 Vaults.register_vault(user, "Vault #{n}", Ecto.UUID.generate()),
+               "pro should not cap at #{n} vaults"
+      end
+    end
+
+    test "starter tier default enforces 10", %{user: user} do
+      insert(:subscription, user: user, tier: "starter", status: "active")
+      :ok = OverrideCache.evict(user.id)
+
+      for n <- 1..10 do
+        assert {:ok, _, :created} =
+                 Vaults.register_vault(user, "Vault #{n}", Ecto.UUID.generate())
+      end
+
+      assert {:error, {:vault_limit_reached, 10, 10}} =
+               Vaults.register_vault(user, "Eleventh", Ecto.UUID.generate())
+    end
+
     test "specific override enforces that exact limit", %{user: user} do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 2})
 


### PR DESCRIPTION
Decision log: engram-app/engram-workspace#191 (`docs/context/pricing-tiers-v2-decisions.md`, REVISED 2026-09-03).

```
vaults_cap            1 / 5 / 15      ->  1 / 10 / unlimited
attachment_bytes_cap  1 / 3 / 15 GiB  ->  1 / 10 / 50 GiB
```

## Vaults are packaging, not a resource

An earlier draft of this change justified a Pro ceiling on per-vault CRDT index-room memory. That was wrong three ways, and the reasons are recorded on the key so they are not re-derived:

- `CrdtIndexDoc.start_link` sets `auto_exit: true`. Rooms are demand-started and exit on last observer, so **a vault nobody is connected to holds zero rooms and zero bytes.**
- `CrdtRoomLru.touch/3` only tracks rooms with a positive `idle_exit_ms`. The index room sets none, so it is never LRU-tracked and cannot evict another user's rooms.
- Every quota resolves **per user** (`Billing.effective_limit(user, ...)`, `Notes.check_notes_cap/1`), so vault count multiplies nothing.

Residency tracks concurrent connections, which `concurrent_devices` already bounds. #1409 reached the same conclusion independently. Residual risk is scripted vault-row creation, which belongs to the rate limiter.

## Storage is an egress ceiling wearing a storage label

Downloads stream through `AttachmentsController.show/2` (`send_resp(200, att.content)`), so every byte here is data transfer out at ~$0.09/GB, four times the ~$0.023/GB-mo storage price, charged **per device, per sync**. A Pro user filling 50 GiB across four devices moves 200 GiB on first sync, roughly $18 against $14 of monthly revenue.

**Do not raise past 50 GiB until attachment downloads are edge-cached.** Noted on the key.

## In-app plan copy was stale on three counts

`plan-cards.tsx` and `billing-page.tsx` hardcode tier summaries. They were wrong about vaults and storage, and also advertised "500 AI queries/day" and "10,000 AI queries/day" — keys that no longer exist. `ai_searches_per_day` replaced six keys and paid tiers are unlimited, so the cards now say so.

## Unlimited caps were already handled

Pro's `vaults_cap` becomes `nil`, a state the vaults banner never had to handle before. It already does: `atCap` requires `typeof vaultsCap === "number"`, so an unlimited cap renders no banner, and the title suffix guards on `=== null` so there is no `(3 / null)`. Comment updated to match; no behaviour change needed.

## Verification

- `mix test` on billing, vaults, attachments, billing_controller — **327 tests, 0 failures**
- `mix credo --strict` — no issues, 5149 mods/funs across 863 files
- `mix format`
- `tsc --noEmit` clean, `biome check` clean
- `vitest` on billing / settings / onboarding — **164 tests, 0 failures**

## Not in this PR

- **`search_semantic_enabled` for Free.** Ships with the "N of your notes aren't searchable" annotation or not at all. Flipping it alone makes Free strictly worse: search becomes excellent on the oldest 2,000 notes and silently blind to this month's.
- **The Voyage reranker.** Blocked on an open decision — paid tiers turn out to have no search cap for it to inherit, so its per-search cost is currently unbounded by anything but `PreAuthRateLimit`.

## Note on a flaky test

`frontend/src/onboarding/agreement-page.flow.test.tsx` failed once in a 28-file parallel run, then passed on two subsequent full runs and in isolation both with and without these changes. It is a `waitFor` on a redirect timing out at 3.8s under load. Not a regression from this PR, but it is load-sensitive.

Refs #1565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp