### PR TITLE
docs(dr): verify backups against live prod; Qdrant has no backups

### DIFF
--- a/docs/context/disaster-recovery.md
+++ b/docs/context/disaster-recovery.md
@@ -1,24 +1,71 @@
 # Context Doc: Disaster Recovery & Backup Readiness
 
-_Last verified: 2026-06-13 (launch-minimum, AWS prod)_
+_Last verified: 2026-09-05 (live AWS + Qdrant Cloud read, launch-minimum)_
 
 > **Why this exists:** "A backup that's never been restored isn't a backup." This is the launch-minimum DR runbook for engram prod (AWS account `751667630925`, region `us-east-1`). One paragraph per failure scenario; it **links** to the existing rotation runbooks rather than restating them. Tracks issue #255.
 
 ## Prod topology (data stores)
 
-| Store | Identity | Backup mechanism | Verified state (2026-06-13) |
+| Store | Identity | Backup mechanism | Verified state (2026-09-05, live) |
 |-------|----------|------------------|------------------------------|
-| **RDS Postgres** | `engram-prod` (PG 18.3, single-AZ) | Daily automated snapshots, 7-day retention, window 08:00–09:00 UTC | ✅ retention = 7d; latest snapshot `rds:engram-prod-2026-06-13-08-14` **available** |
-| **S3 attachments** | `engram-saas-prod-attachments-751667630925` | Bucket versioning | ✅ versioning **Enabled** (read-verified); active delete→restore proof **pending data-plane creds** |
-| **Qdrant Cloud** | managed free-tier cluster | Provider-managed snapshots | ⏳ retention **pending console confirm**; fallback = full reindex (see below) |
+| **RDS Postgres** | `engram-prod` (PG 18.3, db.t4g.small, 20 GB, single-AZ) | Daily automated snapshots + PITR, 7-day retention, window 08:00–09:00 UTC | ✅ retention = 7d; snapshots present for each of the last 7 days; `LatestRestorableTime` within ~5 min of now |
+| **S3 attachments** | `engram-saas-prod-attachments-751667630925` | Bucket versioning, noncurrent versions expire at 30 days | ✅ versioning **Enabled**; delete→restore proof **PASSED** (see below) |
+| **Qdrant Cloud** | `engram-saas-prod` cluster `0a4bef59-…`, free tier, 1 node, v1.18.2 | **NONE** — free tier has no scheduled backups | ❌ **no backups exist**; recovery is re-embed from Postgres (see below) |
 
 Single-AZ is intentional at launch (RPO/RTO acceptable for a low-customer-count launch; multi-AZ promoted post-launch when traffic/SLO justify it — explicitly out of scope here).
 
 ## Verified backup posture
 
-- **RDS** — Automated snapshots ON, retention 7 days (meets the ≥7-day bar). RPO ≈ up to 24h between automated snapshots + 5-min transaction-log restore granularity (point-in-time recovery within the retention window). RTO: dominated by snapshot-restore-to-new-instance time (single-AZ, small DB → tens of minutes). **Restore drill (restore snapshot → throwaway instance → schema diff → record RPO/RTO actuals) is still outstanding — tracked as the remaining acceptance item on #255.**
-- **S3 attachments** — Versioning Enabled, so overwrites and deletes are recoverable from version history. The delete-then-restore proof requires S3 data-plane perms (`s3:PutObject`/`s3:DeleteObject`), which the `engram-infra-operator` identity deliberately lacks (data plane is the ECS task role only). Run the proof from the task role or via a scoped, time-boxed IAM grant — **do not** broaden the operator policy.
-- **Qdrant** — Vectors are reconstructable from Postgres ground truth at any time, so Qdrant loss is recoverable independent of Qdrant's own snapshots. Confirm managed snapshot retention in the Qdrant Cloud console; the belt-and-suspenders fallback is a full reindex (`mix engram.reindex`, planned in #173 — not yet built).
+### RDS Postgres — automated snapshots + PITR ✅ (restore drill still owed)
+
+Automated snapshots ON, retention 7 days, backup window 08:00–09:00 UTC. Verified live 2026-09-05 via `aws rds describe-db-snapshots --snapshot-type automated`: one `available` snapshot per day for the full window.
+
+- **RPO** ≈ 5 minutes. PITR is enabled by the same retention setting, so the floor is the transaction-log granularity, not the 24 h snapshot cadence. `LatestRestorableTime` tracked ~5 min behind wall clock at verification time.
+- **RTO** — not yet measured. Estimated tens of minutes for a 20 GB single-AZ restore-to-new-instance plus the `DATABASE_URL` cutover, but **estimated is not measured**.
+
+**The restore drill (restore snapshot → throwaway instance → schema diff → record RPO/RTO actuals) is still outstanding.** It is the last open acceptance item on #255 and the only one that provisions billable infrastructure. Paste the actuals into this section when it runs.
+
+### S3 attachments — versioning ✅, delete→restore proof PASSED
+
+Proof run 2026-09-05 against the live prod bucket with the `engram-breakglass` identity (the `engram-infra-operator` identity is control-plane only and gets `AccessDenied` on `s3:PutObject` — that separation is deliberate, do **not** broaden the operator policy):
+
+1. `put-object` a 36-byte test object under `_dr-drill/` → version `QDY5Jd…`
+2. `delete-object` (no version-id) → delete marker `lra2.O3…`; `get-object` then returns `NoSuchKey` ✅
+3. `list-object-versions` shows the original version intact, delete marker latest ✅
+4. `delete-object --version-id <delete-marker>` removes the marker
+5. `get-object` returns the original; **md5 matches the source byte-for-byte** ✅
+6. Test object and its version permanently deleted; bucket left clean (`_dr-drill/` prefix empty)
+
+**Recovery window is 30 days, not forever.** The bucket lifecycle rule `expire-noncurrent-versions` sets `NoncurrentDays: 30`, so a deleted or overwritten attachment is recoverable for 30 days and then gone permanently. No cross-region replication at launch.
+
+### Qdrant Cloud — NO backups; recovery is re-embed from Postgres
+
+Verified live 2026-09-05 via the Qdrant Cloud management API and the cluster data API:
+
+- Cluster config reports `"snapshotStorageClass": "emptyDir"` — snapshot storage is node-ephemeral, so even a manual snapshot does not survive node replacement.
+- The management API's backup / backup-schedule endpoints return `404` for this account. Free tier does not include scheduled backups (see `engram-infra/docs/context/qdrant-prod-cluster.md` — "Standard tier unlocks scheduled backups"; paid tier is the fix if this ever needs to be a real backup).
+- `GET /collections/engram_notes/snapshots` and `GET /snapshots` both return `[]`. **Zero snapshots exist.**
+- Collection `engram_notes` holds **76,352 points**, status `green`.
+
+This is acceptable **only because vectors are derived data** — Postgres is ground truth for note content, and every vector is reconstructable by re-embedding. It is not acceptable to treat Qdrant as a store of record for anything.
+
+**Do not wait on `mix engram.reindex` (#173) — it does not exist.** The recovery path below uses mechanisms that are already deployed.
+
+## Qdrant rebuild procedure (total collection loss)
+
+1. **Clear the per-node collection memo on every running node.** `Engram.Vector.Qdrant.ensure_collection/2` memoises "this collection is ready" in `:persistent_term`. After an out-of-band drop, a running node keeps skipping the create and every upsert fails against a collection that no longer exists. Either run `Engram.Vector.Qdrant.forget_collection_memo()` on each node or force a new deployment/task replacement. **Skipping this step makes the rebuild silently fail.** The collection and its payload indexes are then recreated automatically on the first index call.
+2. **Null the index hashes so the existing sweeper sees every note as stale:**
+
+   ```sql
+   UPDATE notes
+      SET embed_hash = NULL, dense_indexed_hash = NULL
+    WHERE kind = 'note' AND deleted_at IS NULL;
+   ```
+
+   Same shape the billing downgrade path already uses (`Engram.Billing` → `IndexCap.revoke_dense_index/1`), so this is a proven mechanism, not a new one.
+3. **Wait.** `Engram.Workers.ReconcileEmbeddings` runs on the `*/15 * * * *` Oban cron and enqueues at most `@batch_size = 500` `EmbedNote` jobs per tick.
+
+**RTO for a full rebuild ≈ 38 hours** at current volume: 76,352 notes ÷ 500 per tick × 15 min. Search is degraded (keyword-only) for that whole window; note reads and writes are unaffected throughout. To go faster, invoke `ReconcileEmbeddings.perform/1` in a loop from a remote console rather than waiting on cron ticks — the per-tick cap is the binding constraint, not embed throughput. Re-embedding 76k notes re-bills Voyage for the full corpus; budget for it before starting.
 
 ## DR scenarios
 
@@ -26,11 +73,11 @@ Each is one paragraph and links out to the canonical runbook. Don't restate rota
 
 **AWS region down (us-east-1).** Single-region at launch — there is no failover. Wait for AWS recovery; post status to the public status page (#252) and hold. Multi-region failover is deliberately out of scope until traffic/SLO justify it.
 
-**RDS Postgres data loss / corruption.** Restore from automated snapshot (or point-in-time within the 7-day window) to a new instance, then cut the app over by repointing `DATABASE_URL`. The restore drill that proves this end-to-end is the outstanding #255 item; once run, paste the RPO/RTO actuals into this doc.
+**RDS Postgres data loss / corruption.** Restore from automated snapshot, or point-in-time to any moment within the 7-day window (RPO ≈ 5 min), to a new instance; then cut the app over by repointing `DATABASE_URL`. The drill that proves this end-to-end is the outstanding #255 item; once run, paste the RPO/RTO actuals into the RDS section above.
 
-**S3 attachment loss / accidental delete.** Versioning is on — recover the prior version (or remove the delete marker) for the affected key. Bulk loss: re-list versions and restore. No cross-region replication at launch.
+**S3 attachment loss / accidental delete.** Versioning is on — remove the delete marker (or restore the prior version) for the affected key; proven above. Bulk loss: re-list versions and restore. Recoverable for 30 days only; no cross-region replication at launch.
 
-**Qdrant Cloud account compromised or cluster lost.** Rotate the Qdrant API key, then rebuild the collection from Postgres via reindex (`mix engram.reindex`, #173). Search is degraded until reindex completes; reads/writes of note content are unaffected (Postgres is ground truth).
+**Qdrant Cloud cluster lost or account compromised.** Rotate the Qdrant API key (`engram-infra/docs/context/qdrant-prod-cluster.md`), then rebuild via the procedure above — there is nothing to restore from. Search is keyword-only until the rebuild completes; reads and writes of note content are unaffected (Postgres is ground truth).
 
 **Voyage AI key leaked.** Rotate via SOPS — see `engram-infra/docs/context/sops-pattern.md` (atomic env rotation). Embedding pauses until the new key propagates; existing vectors are unaffected.
 
@@ -44,7 +91,8 @@ Multi-region failover drills, cross-AZ HA testing, full simulation of non-RDS sc
 
 ## Remaining acceptance (#255)
 
-- [ ] RDS restore drill → throwaway instance → schema diff → record RPO/RTO actuals here
-- [ ] S3 delete→restore proof (needs data-plane creds: task role or scoped grant)
-- [ ] Qdrant snapshot retention confirmed in console + noted in the table above
-- [ ] Cross-link from `engram-workspace/docs/context/launch-day-procedure.md` pre-flight row 10 + workspace `CLAUDE.md` (separate workspace-repo PR)
+- [x] S3 versioning ON + delete→restore proof (2026-09-05, bytes matched)
+- [x] Qdrant snapshot mechanism verified + retention noted (verdict: none exist; rebuild procedure documented above)
+- [x] RDS snapshot retention verified live (7 days, snapshots present, PITR within ~5 min)
+- [ ] **RDS restore drill → throwaway instance → schema diff → record RPO/RTO actuals here** (billable; needs a human at the keyboard)
+- [x] Cross-linked from `engram-workspace/docs/context/launch-day-procedure.md` pre-flight row 10 + workspace `CLAUDE.md`


### PR DESCRIPTION
Closes the three non-billable acceptance boxes on #255 by checking **live prod** rather than Terraform.

## What was verified

| Store | Result |
|---|---|
| RDS Postgres | ✅ retention 7d, daily snapshots present for the full window, PITR RPO ~5 min. **Restore drill still owed.** |
| S3 attachments | ✅ versioning Enabled, **delete→restore proof PASSED** (bytes matched, artifacts cleaned up) |
| Qdrant Cloud | ❌ **no backups exist at all** |

## The Qdrant finding

Free tier has no scheduled backups, cluster config reports `snapshotStorageClass: emptyDir` (node-ephemeral), the management API's backup endpoints 404, and both snapshot list endpoints return `[]`. Collection holds 76,352 points.

The doc previously pointed at `mix engram.reindex` (#173) as the fallback — **that task does not exist**. Replaced it with a procedure built from already-deployed mechanisms:

1. `Qdrant.forget_collection_memo()` on every node (the `:persistent_term` memo makes a rebuild silently fail otherwise)
2. Null `embed_hash` + `dense_indexed_hash` (same shape the billing downgrade path already uses)
3. `ReconcileEmbeddings` cron drains it — **~38 h RTO** at 500/tick × 15 min

## Also recorded

S3 recovery window is **30 days**, not forever — the `expire-noncurrent-versions` lifecycle rule sets `NoncurrentDays: 30`.

## Remaining

RDS restore drill (restore → throwaway instance → schema diff → RPO/RTO actuals). Only item that provisions billable infra.

Refs #255