### PR TITLE
fix(sweep): reconcile Postgres→Qdrant, not just Qdrant→Postgres

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -157,9 +157,17 @@ config :engram, Oban,
        # Daily expired-export sweep (#859) — deletes S3 archive blobs past
        # the 7-day download window and flips rows to :expired.
        {"20 5 * * *", Engram.Workers.ExportExpirySweep},
-       # Cross-store orphan sweep — weekly safety net for failed
-       # event-driven Qdrant/S3 deletes. Sun 05:00 UTC, off-peak.
-       {"0 5 * * 0", Engram.Workers.OrphanSweep}
+       # Cross-store reconciliation, 05:00 UTC daily, off-peak. Was weekly when
+       # it only reaped orphans — capacity waste, not wrong answers. It now also
+       # carries the Postgres->Qdrant direction (#1576), which IS correctness: a
+       # note whose points are gone is silently unsearchable and self-heals via
+       # nothing. A week of that is not an acceptable detection window.
+       #
+       # Affordable daily because a pass is O(collection) and the collection is
+       # small. Revisit around 1M points, where a full walk starts costing real
+       # minutes — that is when the walk wants a resumable cursor rather than a
+       # lower frequency.
+       {"0 5 * * *", Engram.Workers.OrphanSweep}
      ]}
   ]
 

--- a/docs/context/disaster-recovery.md
+++ b/docs/context/disaster-recovery.md
@@ -81,7 +81,11 @@ This is acceptable **only because vectors are derived data** — Postgres is gro
    Same shape the billing downgrade path already uses (`Engram.Billing` → `IndexCap.revoke_dense_index/1`), so this is a proven mechanism, not a new one.
 3. **Wait.** `Engram.Workers.ReconcileEmbeddings` runs on the `*/15 * * * *` Oban cron and enqueues at most `@batch_size = 500` `EmbedNote` jobs per tick.
 
-**RTO for a full rebuild ≈ 38 hours** at current volume: 76,352 notes ÷ 500 per tick × 15 min. Search is degraded (keyword-only) for that whole window; note reads and writes are unaffected throughout. To go faster, invoke `ReconcileEmbeddings.perform/1` in a loop from a remote console rather than waiting on cron ticks — the per-tick cap is the binding constraint, not embed throughput. Re-embedding 76k notes re-bills Voyage for the full corpus; budget for it before starting.
+**RTO for a full rebuild ≈ 1 hour** at current volume: ~1,574 live notes ÷ 500 per tick × 15 min ≈ 4 ticks. Search is degraded (keyword-only) for that window; note reads and writes are unaffected throughout. To go faster, invoke `ReconcileEmbeddings.perform/1` in a loop from a remote console — the per-tick cap is the binding constraint, not embed throughput. A full rebuild re-bills Voyage for the whole corpus; budget for it before starting.
+
+> The batch is **notes per tick, not chunks**. An earlier revision of this doc read the Qdrant point count (76,352, taken before an unrelated purge of 8 test vaults) as a note count and put the RTO at 38 hours. Measured 2026-09-05: ~10,400 chunk rows over ~1,574 live notes, about 7 chunks per note. Re-derive from `select count(*) from notes where kind = 'note' and deleted_at is null` rather than from the collection size.
+
+**This whole procedure is for TOTAL collection loss only.** For partial divergence — the far likelier case, and what a Postgres restore produces — do not null every hash. `Engram.Workers.OrphanSweep` reconciles both directions against Qdrant's real point ids on its 05:00 UTC daily tick and flags only the notes that actually lost their points (#1576). Enqueue it on demand instead of waiting.
 
 ## DR scenarios
 
@@ -90,6 +94,10 @@ Each is one paragraph and links out to the canonical runbook. Don't restate rota
 **AWS region down (us-east-1).** Single-region at launch — there is no failover. Wait for AWS recovery; post status to the public status page (#252) and hold. Multi-region failover is deliberately out of scope until traffic/SLO justify it.
 
 **RDS Postgres data loss / corruption.** Restore from automated snapshot, or point-in-time to any moment within the 7-day window (RPO ≈ 4 min), to a new instance; then cut the app over by repointing `DATABASE_URL`. Drilled 2026-09-05: **7 min 34 s to a usable instance, schema byte-identical** — actuals and the gotchas that cost time are in the RDS section above. Restore from `engram-breakglass`; the operator identity is not authorized.
+
+**A Postgres restore is not finished until Qdrant is reconciled.** Restoring rolls back the note data *and* the `embed_hash`/`dense_indexed_hash` bookkeeping about what was sent to Qdrant, together — so they stay mutually consistent while Qdrant does not. Every note re-indexed between the restore point and the failure has vectors under ids that no longer exist, and still reads as freshly indexed. Left alone those notes are silently unsearchable forever; `ReconcileEmbeddings` never notices, because it only ever compares two Postgres columns.
+
+Enqueue `Engram.Workers.OrphanSweep` immediately after the cutover rather than waiting for its 05:00 UTC tick (#1576). It reconciles both directions against Qdrant's real point ids: strays get deleted, and notes whose points are gone get their index hashes nulled so `ReconcileEmbeddings` rebuilds exactly those. **Do not blind-rebuild the whole corpus for this** — the sweep identifies the diverged set, so recovery is proportional to the damage window (minutes of writes at a ~4 min RPO), not 76k notes. Watch for `orphan_sweep aborting: missing-point ratio implies a bad authority` in the logs: that means Qdrant is unreachable or repointed, and nothing was flagged. Fix Qdrant, then re-run.
 
 **S3 attachment loss / accidental delete.** Versioning is on — remove the delete marker (or restore the prior version) for the affected key; proven above. Bulk loss: re-list versions and restore. Recoverable for 30 days only; no cross-region replication at launch.
 

--- a/docs/context/disaster-recovery.md
+++ b/docs/context/disaster-recovery.md
@@ -97,7 +97,19 @@ Each is one paragraph and links out to the canonical runbook. Don't restate rota
 
 **A Postgres restore is not finished until Qdrant is reconciled.** Restoring rolls back the note data *and* the `embed_hash`/`dense_indexed_hash` bookkeeping about what was sent to Qdrant, together — so they stay mutually consistent while Qdrant does not. Every note re-indexed between the restore point and the failure has vectors under ids that no longer exist, and still reads as freshly indexed. Left alone those notes are silently unsearchable forever; `ReconcileEmbeddings` never notices, because it only ever compares two Postgres columns.
 
-Enqueue `Engram.Workers.OrphanSweep` immediately after the cutover rather than waiting for its 05:00 UTC tick (#1576). It reconciles both directions against Qdrant's real point ids: strays get deleted, and notes whose points are gone get their index hashes nulled so `ReconcileEmbeddings` rebuilds exactly those. **Do not blind-rebuild the whole corpus for this** — the sweep identifies the diverged set, so recovery is proportional to the damage window (minutes of writes at a ~4 min RPO), not 76k notes. Watch for `orphan_sweep aborting: missing-point ratio implies a bad authority` in the logs: that means Qdrant is unreachable or repointed, and nothing was flagged. Fix Qdrant, then re-run.
+Enqueue `Engram.Workers.OrphanSweep` immediately after the cutover rather than waiting for its 05:00 UTC tick (#1576). It reconciles both directions against Qdrant's real point ids: strays get deleted, and notes whose points are gone get their index hashes nulled so `ReconcileEmbeddings` rebuilds exactly those. **Do not blind-rebuild the whole corpus for this** — the sweep identifies the diverged set, so recovery is proportional to the damage window, not the whole note count.
+
+```elixir
+Oban.insert!(Engram.Workers.OrphanSweep.new(%{}))
+```
+
+**If the log says `orphan_sweep aborting: missing-point ratio implies a bad authority`, read it carefully — after a restore it is probably wrong.** The sweep refuses to act when more than 10% of chunks look stranded, because that shape normally means Qdrant is unreachable or repointed rather than that the data drifted. A restore is the one case where a large real divergence is expected: a PITR restore at a ~4 min RPO stays well under the threshold, but a **snapshot** restore rolls back up to 24 h of writes and can legitimately cross it. Confirm Qdrant is healthy and reachable first, then re-enqueue with the override:
+
+```elixir
+Oban.insert!(Engram.Workers.OrphanSweep.new(%{"force" => true}))
+```
+
+Without that flag, the sweep aborts every tick and the notes are never repaired — silently, since an aborted pass flags nothing and otherwise looks like a clean one.
 
 **S3 attachment loss / accidental delete.** Versioning is on — remove the delete marker (or restore the prior version) for the affected key; proven above. Bulk loss: re-list versions and restore. Recoverable for 30 days only; no cross-region replication at launch.
 

--- a/lib/engram/workers/orphan_sweep.ex
+++ b/lib/engram/workers/orphan_sweep.ex
@@ -35,6 +35,7 @@ defmodule Engram.Workers.OrphanSweep do
   alias Engram.Accounts.User
   alias Engram.Logger.Metadata
   alias Engram.Notes.Chunk
+  alias Engram.Notes.Note
   alias Engram.Repo
   alias Engram.Storage
   alias Engram.Vector.Qdrant
@@ -49,6 +50,10 @@ defmodule Engram.Workers.OrphanSweep do
   # the 15-minute timeout; at 4096 it is ~2.4k.
   @point_scroll_limit 4096
   @point_delete_batch 256
+  # Chunk rows probed against Qdrant per round trip (#1576). Smaller than the
+  # id-only scroll above because `has_id` carries every id in the REQUEST body,
+  # not just the response. Validated against prod at this size.
+  @chunk_probe_batch 2048
   # Ceiling on candidates carried in memory for the confirm pass.
   @max_candidates 50_000
   # Above this share of the scanned collection, the diff is telling us the
@@ -72,13 +77,15 @@ defmodule Engram.Workers.OrphanSweep do
     qdrant_deleted = sweep_qdrant(live_ids)
     s3_deleted = sweep_s3(live_ids)
     points_deleted = sweep_point_orphans()
+    notes_flagged = sweep_missing_points()
 
     :telemetry.execute(
       [:engram, :orphan_sweep, :result],
       %{
         qdrant_users_swept: qdrant_deleted,
         s3_prefixes_swept: s3_deleted,
-        qdrant_points_swept: points_deleted
+        qdrant_points_swept: points_deleted,
+        notes_flagged_for_reindex: notes_flagged
       },
       %{}
     )
@@ -86,11 +93,12 @@ defmodule Engram.Workers.OrphanSweep do
     Logger.info(
       "orphan_sweep complete",
       Metadata.with_category(:info, :oban,
-        total_count: qdrant_deleted + s3_deleted + points_deleted,
+        total_count: qdrant_deleted + s3_deleted + points_deleted + notes_flagged,
         result: %{
           qdrant_users_swept: qdrant_deleted,
           s3_prefixes_swept: s3_deleted,
-          qdrant_points_swept: points_deleted
+          qdrant_points_swept: points_deleted,
+          notes_flagged_for_reindex: notes_flagged
         }
       )
     )
@@ -295,6 +303,190 @@ defmodule Engram.Workers.OrphanSweep do
     end)
   end
 
+  # -- Missing points (the Postgres->Qdrant direction) ----------------------
+
+  # #1576. `sweep_point_orphans/0` above answers "does a chunk row still name
+  # this point?". This answers the opposite, and nothing else in the system
+  # does: "does Qdrant still hold the point this chunk row names?".
+  #
+  # It has to be asked because `ReconcileEmbeddings` decides a note is indexed
+  # by comparing `embed_hash` to `content_hash` — two Postgres columns. A
+  # Postgres restore rolls the data and that bookkeeping back together, so they
+  # stay mutually consistent while Qdrant does not: every note re-indexed after
+  # the restore point has vectors under ids that were minted later and deleted
+  # when the rows were, and it still reads as freshly indexed. Silently
+  # unsearchable, forever, with no self-heal.
+  #
+  # Nulling the index hashes is the whole repair. `ReconcileEmbeddings` rebuilds
+  # from there on its next tick, with its own entitlement and poison-cooldown
+  # checks intact — this worker deliberately owns no rebuild path of its own.
+  defp sweep_missing_points do
+    case scan_chunk_pages(nil, [], 0) do
+      {:ok, [], scanned} ->
+        Logger.info(
+          "orphan_sweep probed chunk points",
+          Metadata.with_category(:info, :oban, total_count: scanned, result: %{missing: 0})
+        )
+
+        0
+
+      {:ok, candidates, scanned} ->
+        Logger.info(
+          "orphan_sweep probed chunk points",
+          Metadata.with_category(:info, :oban,
+            total_count: scanned,
+            result: %{missing: length(candidates)}
+          )
+        )
+
+        confirm_and_flag(candidates, scanned)
+
+      {:error, reason} ->
+        # A Qdrant failure must never read as "every point is gone". Bailing
+        # keeps the ratio guard below from being the only thing between a
+        # transient outage and a corpus-wide re-embed.
+        Logger.error(
+          "orphan_sweep chunk-point probe failed",
+          Metadata.with_category(:error, :oban, reason: Metadata.safe_reason(reason))
+        )
+
+        0
+    end
+  end
+
+  # Keyset paging on `chunks.id`, probing Qdrant once per page. Memory is flat
+  # in the table size: one page of ids plus the (near-empty) candidate list.
+  #
+  # Order matters and is the mirror of the forward pass. Read Postgres FIRST,
+  # probe Qdrant second: `Indexing.commit_index/1` inserts chunk rows and THEN
+  # upserts points, so probing after the read gives the points the longer
+  # window to appear. The other order races outright.
+  defp scan_chunk_pages(after_id, candidates, scanned) do
+    case chunk_page(after_id) do
+      [] ->
+        {:ok, candidates, scanned}
+
+      rows ->
+        case qdrant_points_present(Enum.map(rows, fn {_id, _note_id, pid} -> pid end)) do
+          {:ok, present} ->
+            missing =
+              for {_id, note_id, pid} <- rows,
+                  not MapSet.member?(present, pid),
+                  do: {note_id, pid}
+
+            {last_id, _note_id, _pid} = List.last(rows)
+
+            scan_chunk_pages(last_id, candidates ++ missing, scanned + length(rows))
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp confirm_and_flag(candidates, scanned) do
+    if runaway?(MapSet.new(candidates), scanned) do
+      # Same reasoning as the forward pass, pointed the other way and with a
+      # bigger bill attached: if Qdrant is unreachable, empty, or repointed at
+      # the wrong collection, EVERY chunk looks stranded. Acting on that nulls
+      # the whole corpus and re-bills Voyage to rebuild it. A ratio this high
+      # means the premise is broken, not the data.
+      Logger.error(
+        "orphan_sweep aborting: missing-point ratio implies a bad authority, not drift",
+        Metadata.with_category(:error, :oban,
+          total_count: length(candidates),
+          result: %{scanned: scanned, max_ratio: @max_candidate_ratio}
+        )
+      )
+
+      0
+    else
+      # Second look after a grace window, for the write-order race described on
+      # `scan_chunk_pages/3`: a note indexing right now legitimately has rows
+      # naming points that land moments later.
+      grace()
+
+      still_missing =
+        case qdrant_points_present(Enum.map(candidates, fn {_note_id, pid} -> pid end)) do
+          {:ok, present} ->
+            Enum.reject(candidates, fn {_note_id, pid} -> MapSet.member?(present, pid) end)
+
+          {:error, reason} ->
+            # Same rule as the first probe: a failed question is not a "yes".
+            # Logged rather than swallowed, or a Qdrant that fails only on the
+            # confirm pass looks exactly like a clean sweep.
+            Logger.error(
+              "orphan_sweep confirm probe failed; flagging nothing this tick",
+              Metadata.with_category(:error, :oban, reason: Metadata.safe_reason(reason))
+            )
+
+            []
+        end
+
+      flag_notes_for_reindex(Enum.map(still_missing, fn {note_id, _pid} -> note_id end))
+    end
+  end
+
+  defp flag_notes_for_reindex([]), do: 0
+
+  defp flag_notes_for_reindex(note_ids) do
+    ids = Enum.uniq(note_ids)
+
+    {count, _} =
+      Note
+      |> where([n], n.id in ^ids)
+      |> Repo.update_all(
+        [set: [embed_hash: nil, dense_indexed_hash: nil]],
+        skip_tenant_check: true
+      )
+
+    Logger.warning(
+      "orphan_sweep flagged notes for re-index: Qdrant is missing their points",
+      Metadata.with_category(:warning, :oban, total_count: count)
+    )
+
+    count
+  end
+
+  # Live notes only. A soft-deleted note's points are removed on delete, so its
+  # rows would read as stranded and get flagged for a rebuild that then has
+  # nothing to rebuild.
+  #
+  # skip_tenant_check: cross-tenant by design, same as `chunk_point_ids/1` —
+  # RLS would hide exactly the rows this reconciliation exists to check.
+  defp chunk_page(after_id) do
+    Chunk
+    |> join(:inner, [c], n in Note, on: n.id == c.note_id)
+    |> where([c, n], is_nil(n.deleted_at) and not is_nil(c.qdrant_point_id))
+    |> then(fn q -> if after_id, do: where(q, [c], c.id > ^after_id), else: q end)
+    |> order_by([c], asc: c.id)
+    |> limit(^chunk_probe_batch())
+    |> select([c], {c.id, c.note_id, c.qdrant_point_id})
+    |> Repo.all(skip_tenant_check: true)
+  end
+
+  # Which of these ids does Qdrant actually hold? `has_id` against the existing
+  # scroll endpoint — no new client call, and `limit` equal to the batch means
+  # one round trip per page.
+  defp qdrant_points_present([]), do: {:ok, MapSet.new()}
+
+  defp qdrant_points_present(point_ids) do
+    ids = Enum.uniq(point_ids)
+
+    case Qdrant.scroll(
+           filter: %{must: [%{has_id: ids}]},
+           limit: length(ids),
+           with_payload: false,
+           with_vector: false
+         ) do
+      {:ok, %{points: points}} ->
+        {:ok, points |> Enum.map(& &1["id"]) |> Enum.filter(&is_binary/1) |> MapSet.new()}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   defp grace do
     case Application.get_env(:engram, :orphan_sweep_point_grace_fun) do
       fun when is_function(fun, 0) -> fun.()
@@ -304,6 +496,12 @@ defmodule Engram.Workers.OrphanSweep do
 
   defp grace_seconds,
     do: Application.get_env(:engram, :orphan_sweep_point_grace_seconds, 60)
+
+  # Overridable for the same reason `grace_seconds/0` is: the paging behaviour
+  # is only observable across more than one page, and seeding 2,048 chunk rows
+  # to prove a cursor advances is a worse test, not a better one.
+  defp chunk_probe_batch,
+    do: Application.get_env(:engram, :orphan_sweep_chunk_probe_batch, @chunk_probe_batch)
 
   defp live_user_ids do
     # Includes soft-deleted users (deleted_at IS NOT NULL but row exists) —

--- a/lib/engram/workers/orphan_sweep.ex
+++ b/lib/engram/workers/orphan_sweep.ex
@@ -38,6 +38,7 @@ defmodule Engram.Workers.OrphanSweep do
   alias Engram.Notes.Note
   alias Engram.Repo
   alias Engram.Storage
+  alias Engram.Vaults.Vault
   alias Engram.Vector.Qdrant
 
   require Logger
@@ -71,13 +72,13 @@ defmodule Engram.Workers.OrphanSweep do
   def timeout(_job), do: :timer.minutes(15)
 
   @impl Oban.Worker
-  def perform(%Oban.Job{}) do
+  def perform(%Oban.Job{args: args}) do
     live_ids = live_user_ids()
 
     qdrant_deleted = sweep_qdrant(live_ids)
     s3_deleted = sweep_s3(live_ids)
     points_deleted = sweep_point_orphans()
-    notes_flagged = sweep_missing_points()
+    notes_flagged = sweep_missing_points(force: Map.get(args, "force", false))
 
     :telemetry.execute(
       [:engram, :orphan_sweep, :result],
@@ -320,7 +321,7 @@ defmodule Engram.Workers.OrphanSweep do
   # Nulling the index hashes is the whole repair. `ReconcileEmbeddings` rebuilds
   # from there on its next tick, with its own entitlement and poison-cooldown
   # checks intact — this worker deliberately owns no rebuild path of its own.
-  defp sweep_missing_points do
+  defp sweep_missing_points(opts) do
     case scan_chunk_pages(nil, [], 0) do
       {:ok, [], scanned} ->
         Logger.info(
@@ -339,7 +340,7 @@ defmodule Engram.Workers.OrphanSweep do
           )
         )
 
-        confirm_and_flag(candidates, scanned)
+        confirm_and_flag(candidates, scanned, opts)
 
       {:error, reason} ->
         # A Qdrant failure must never read as "every point is gone". Bailing
@@ -362,6 +363,24 @@ defmodule Engram.Workers.OrphanSweep do
   # upserts points, so probing after the read gives the points the longer
   # window to appear. The other order races outright.
   defp scan_chunk_pages(after_id, candidates, scanned) do
+    if length(candidates) >= max_missing_candidates() do
+      # Same bound the forward pass keeps, for the same reason: the runaway
+      # check can only run once the walk is done, so without a cap an empty or
+      # repointed collection makes the worker hold a tuple per chunk row for
+      # the entire table before it decides to abort. Not silent — a truncated
+      # run that reads as a clean one is worse than a loud partial one.
+      Logger.warning(
+        "orphan_sweep missing-point candidate cap reached; deferring the rest to the next tick",
+        Metadata.with_category(:warning, :oban, total_count: length(candidates))
+      )
+
+      {:ok, candidates, scanned}
+    else
+      do_scan_chunk_page(after_id, candidates, scanned)
+    end
+  end
+
+  defp do_scan_chunk_page(after_id, candidates, scanned) do
     case chunk_page(after_id) do
       [] ->
         {:ok, candidates, scanned}
@@ -376,7 +395,11 @@ defmodule Engram.Workers.OrphanSweep do
 
             {last_id, _note_id, _pid} = List.last(rows)
 
-            scan_chunk_pages(last_id, candidates ++ missing, scanned + length(rows))
+            # Prepended, not appended: `candidates ++ missing` re-copies the
+            # accumulator once per page, which is O(n^2) over a walk that only
+            # gets long in the runaway case this is trying to survive. Order
+            # carries no meaning here.
+            scan_chunk_pages(last_id, missing ++ candidates, scanned + length(rows))
 
           {:error, reason} ->
             {:error, reason}
@@ -384,15 +407,19 @@ defmodule Engram.Workers.OrphanSweep do
     end
   end
 
-  defp confirm_and_flag(candidates, scanned) do
-    if runaway?(MapSet.new(candidates), scanned) do
+  defp confirm_and_flag(candidates, scanned, opts) do
+    forced = Keyword.get(opts, :force, false)
+
+    if not forced and runaway?(MapSet.new(candidates), scanned) do
       # Same reasoning as the forward pass, pointed the other way and with a
       # bigger bill attached: if Qdrant is unreachable, empty, or repointed at
       # the wrong collection, EVERY chunk looks stranded. Acting on that nulls
       # the whole corpus and re-bills Voyage to rebuild it. A ratio this high
       # means the premise is broken, not the data.
       Logger.error(
-        "orphan_sweep aborting: missing-point ratio implies a bad authority, not drift",
+        "orphan_sweep aborting: missing-point ratio implies a bad authority, not drift. " <>
+          "If Qdrant is healthy and this follows a Postgres restore, the divergence is real — " <>
+          "re-enqueue with %{\"force\" => true}",
         Metadata.with_category(:error, :oban,
           total_count: length(candidates),
           result: %{scanned: scanned, max_ratio: @max_candidate_ratio}
@@ -409,7 +436,17 @@ defmodule Engram.Workers.OrphanSweep do
       still_missing =
         case qdrant_points_present(Enum.map(candidates, fn {_note_id, pid} -> pid end)) do
           {:ok, present} ->
-            Enum.reject(candidates, fn {_note_id, pid} -> MapSet.member?(present, pid) end)
+            # Re-read Postgres too, not just Qdrant. `commit_index/1` deletes
+            # the old points BEFORE the old chunk rows, so a note re-indexed
+            # between the scan and here leaves a scanned row whose point is
+            # genuinely gone AND whose row is gone — re-asking Qdrant alone
+            # confirms "missing" and bills a full re-embed of a note that is
+            # correctly indexed. A row that no longer exists proves nothing.
+            live_rows = chunk_point_ids(Enum.map(candidates, fn {_note_id, pid} -> pid end))
+
+            Enum.reject(candidates, fn {_note_id, pid} ->
+              MapSet.member?(present, pid) or not MapSet.member?(live_rows, pid)
+            end)
 
           {:error, reason} ->
             # Same rule as the first probe: a failed question is not a "yes".
@@ -430,15 +467,25 @@ defmodule Engram.Workers.OrphanSweep do
   defp flag_notes_for_reindex([]), do: 0
 
   defp flag_notes_for_reindex(note_ids) do
-    ids = Enum.uniq(note_ids)
+    # Chunked against Postgres' 65,535 bind-parameter cap, same as
+    # `chunk_point_ids/1`. Candidates are bounded only by the ratio guard, and
+    # an unchunked `in ^ids` raises out of a `max_attempts: 1` worker — killing
+    # the run before its completion log, daily, with nothing flagged.
+    count =
+      note_ids
+      |> Enum.uniq()
+      |> Enum.chunk_every(@id_query_batch)
+      |> Enum.reduce(0, fn batch, acc ->
+        {n, _} =
+          Note
+          |> where([n], n.id in ^batch)
+          |> Repo.update_all(
+            [set: [embed_hash: nil, dense_indexed_hash: nil]],
+            skip_tenant_check: true
+          )
 
-    {count, _} =
-      Note
-      |> where([n], n.id in ^ids)
-      |> Repo.update_all(
-        [set: [embed_hash: nil, dense_indexed_hash: nil]],
-        skip_tenant_check: true
-      )
+        acc + n
+      end)
 
     Logger.warning(
       "orphan_sweep flagged notes for re-index: Qdrant is missing their points",
@@ -448,16 +495,25 @@ defmodule Engram.Workers.OrphanSweep do
     count
   end
 
-  # Live notes only. A soft-deleted note's points are removed on delete, so its
-  # rows would read as stranded and get flagged for a rebuild that then has
-  # nothing to rebuild.
+  # Live notes in live vaults only. A soft-deleted note's points are removed on
+  # delete, so its rows would read as stranded and get flagged for a rebuild
+  # that then has nothing to rebuild.
+  #
+  # The VAULT check is load-bearing for a different reason: `ReconcileEmbeddings`
+  # joins vaults on `is_nil(deleted_at)`, so a note in a soft-deleted vault can
+  # never be rebuilt. Flagging one means re-nulling and re-warning on every tick
+  # forever, while inflating the runaway ratio — and `CleanupVault` purges
+  # Qdrant points BEFORE its DB transaction, so a restore leaves exactly this
+  # shape: live rows in a soft-deleted vault whose points are already gone.
   #
   # skip_tenant_check: cross-tenant by design, same as `chunk_point_ids/1` —
   # RLS would hide exactly the rows this reconciliation exists to check.
   defp chunk_page(after_id) do
     Chunk
     |> join(:inner, [c], n in Note, on: n.id == c.note_id)
-    |> where([c, n], is_nil(n.deleted_at) and not is_nil(c.qdrant_point_id))
+    |> join(:inner, [c, n], v in Vault, on: v.id == n.vault_id)
+    |> where([c, n, v], is_nil(n.deleted_at) and is_nil(v.deleted_at))
+    |> where([c], not is_nil(c.qdrant_point_id))
     |> then(fn q -> if after_id, do: where(q, [c], c.id > ^after_id), else: q end)
     |> order_by([c], asc: c.id)
     |> limit(^chunk_probe_batch())
@@ -466,21 +522,48 @@ defmodule Engram.Workers.OrphanSweep do
   end
 
   # Which of these ids does Qdrant actually hold? `has_id` against the existing
-  # scroll endpoint — no new client call, and `limit` equal to the batch means
-  # one round trip per page.
+  # scroll endpoint — no new client call.
+  #
+  # Batched even though the scan already pages, because the confirm pass hands
+  # in the whole candidate list at once. `has_id` carries every id in the
+  # REQUEST body, so an unbounded call is a multi-megabyte POST, and the answer
+  # is used to decide whether to null hashes — a truncated response reads as
+  # "these ids are missing" and re-embeds notes whose points are fine.
   defp qdrant_points_present([]), do: {:ok, MapSet.new()}
 
   defp qdrant_points_present(point_ids) do
-    ids = Enum.uniq(point_ids)
+    point_ids
+    |> Enum.uniq()
+    |> Enum.chunk_every(chunk_probe_batch())
+    |> Enum.reduce_while({:ok, MapSet.new()}, fn batch, {:ok, acc} ->
+      case scroll_ids(batch, nil, MapSet.new()) do
+        {:ok, found} -> {:cont, {:ok, MapSet.union(acc, found)}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
 
-    case Qdrant.scroll(
-           filter: %{must: [%{has_id: ids}]},
-           limit: length(ids),
-           with_payload: false,
-           with_vector: false
-         ) do
-      {:ok, %{points: points}} ->
-        {:ok, points |> Enum.map(& &1["id"]) |> Enum.filter(&is_binary/1) |> MapSet.new()}
+  # Follows `next_page_offset` rather than trusting one response to carry every
+  # match, the same way `scan_pages/3` does. A `limit` is not a guarantee.
+  defp scroll_ids(batch, offset, acc) do
+    opts = [
+      filter: %{must: [%{has_id: batch}]},
+      limit: length(batch),
+      with_payload: false,
+      with_vector: false
+    ]
+
+    opts = if offset, do: Keyword.put(opts, :offset, offset), else: opts
+
+    case Qdrant.scroll(opts) do
+      {:ok, %{points: points, next_page_offset: next}} ->
+        acc =
+          points
+          |> Enum.map(& &1["id"])
+          |> Enum.filter(&is_binary/1)
+          |> Enum.into(acc)
+
+        if next, do: scroll_ids(batch, next, acc), else: {:ok, acc}
 
       {:error, reason} ->
         {:error, reason}
@@ -502,6 +585,9 @@ defmodule Engram.Workers.OrphanSweep do
   # to prove a cursor advances is a worse test, not a better one.
   defp chunk_probe_batch,
     do: Application.get_env(:engram, :orphan_sweep_chunk_probe_batch, @chunk_probe_batch)
+
+  defp max_missing_candidates,
+    do: Application.get_env(:engram, :orphan_sweep_max_missing_candidates, @max_candidates)
 
   defp live_user_ids do
     # Includes soft-deleted users (deleted_at IS NOT NULL but row exists) —

--- a/test/engram/workers/orphan_sweep_missing_points_test.exs
+++ b/test/engram/workers/orphan_sweep_missing_points_test.exs
@@ -1,0 +1,302 @@
+defmodule Engram.Workers.OrphanSweepMissingPointsTest do
+  @moduledoc """
+  The Postgres→Qdrant half of the sweep (#1576). A chunk row naming a point
+  Qdrant does not have means that note is unsearchable, and nothing else
+  notices: `ReconcileEmbeddings` compares `embed_hash` to `content_hash`, both
+  Postgres columns, so a note whose vectors vanished still looks freshly
+  indexed. Nulling the index hashes hands it back to that worker.
+  """
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Notes.Chunk
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Engram.Workers.OrphanSweep
+
+  setup do
+    bypass = Bypass.open()
+    prior_collection = Application.get_env(:engram, :qdrant_collection)
+    prior_storage = Application.get_env(:engram, :storage)
+
+    Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+    Application.put_env(:engram, :qdrant_collection, "test_col")
+    Application.put_env(:engram, :storage, Engram.Storage.InMemory)
+    Engram.Storage.InMemory.ensure_table()
+    :ets.delete_all_objects(:engram_test_storage_in_memory)
+
+    on_exit(fn ->
+      Application.delete_env(:engram, :qdrant_url)
+      Application.put_env(:engram, :qdrant_collection, prior_collection)
+      Application.put_env(:engram, :storage, prior_storage)
+    end)
+
+    %{bypass: bypass}
+  end
+
+  # Both passes POST to /points/scroll. The forward pass sends an empty filter
+  # (walk everything); this one sends `has_id` (do these specific ids exist?).
+  # Routing on the body is what lets a single `perform_job` exercise both, the
+  # same way one real collection answers both queries.
+  defp stub_qdrant(bypass, present_ids) do
+    Bypass.expect(bypass, "POST", "/collections/test_col/points/scroll", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      ids =
+        case Jason.decode!(body) do
+          %{"filter" => %{"must" => [%{"has_id" => asked}]}} ->
+            Enum.filter(asked, &(&1 in present_ids))
+
+          _ ->
+            present_ids
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{
+          "result" => %{
+            "points" => Enum.map(ids, &%{"id" => &1}),
+            "next_page_offset" => nil
+          }
+        })
+      )
+    end)
+  end
+
+  defp insert_chunk!(note, point_id) do
+    Repo.insert!(
+      %Chunk{
+        note_id: note.id,
+        user_id: note.user_id,
+        vault_id: note.vault_id,
+        position: 0,
+        char_start: 0,
+        char_end: 10,
+        qdrant_point_id: point_id
+      },
+      skip_tenant_check: true
+    )
+  end
+
+  defp reload(note), do: Repo.get!(Note, note.id, skip_tenant_check: true)
+
+  test "nulls the index hashes when a chunk names a point Qdrant does not have", %{
+    bypass: bypass
+  } do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    note =
+      insert(:note,
+        user: user,
+        vault: vault,
+        embed_hash: "cafe",
+        content_hash: "cafe",
+        dense_indexed_hash: "cafe"
+      )
+
+    insert_chunk!(note, Ecto.UUID.generate())
+
+    stub_qdrant(bypass, [])
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    reloaded = reload(note)
+    assert is_nil(reloaded.embed_hash)
+    assert is_nil(reloaded.dense_indexed_hash)
+  end
+
+  test "leaves a note alone when Qdrant has every point its chunks name", %{bypass: bypass} do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    note =
+      insert(:note,
+        user: user,
+        vault: vault,
+        embed_hash: "cafe",
+        content_hash: "cafe",
+        dense_indexed_hash: "cafe"
+      )
+
+    point_id = Ecto.UUID.generate()
+    insert_chunk!(note, point_id)
+
+    stub_qdrant(bypass, [point_id])
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert reload(note).embed_hash == "cafe"
+  end
+
+  test "aborts without flagging anything when nearly every point looks missing", %{
+    bypass: bypass
+  } do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    # Above @runaway_floor (100) and far above @max_candidate_ratio (10%): the
+    # shape of Qdrant being down or repointed, not of real drift.
+    notes =
+      for _ <- 1..101 do
+        note =
+          insert(:note,
+            user: user,
+            vault: vault,
+            embed_hash: "cafe",
+            content_hash: "cafe",
+            dense_indexed_hash: "cafe"
+          )
+
+        insert_chunk!(note, Ecto.UUID.generate())
+        note
+      end
+
+    stub_qdrant(bypass, [])
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    for note <- notes, do: assert(reload(note).embed_hash == "cafe")
+  end
+
+  test "flags nothing when the Qdrant probe fails", %{bypass: bypass} do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    note =
+      insert(:note,
+        user: user,
+        vault: vault,
+        embed_hash: "cafe",
+        content_hash: "cafe",
+        dense_indexed_hash: "cafe"
+      )
+
+    insert_chunk!(note, Ecto.UUID.generate())
+
+    Bypass.expect(bypass, "POST", "/collections/test_col/points/scroll", fn conn ->
+      Plug.Conn.resp(conn, 500, ~s({"status":"error"}))
+    end)
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert reload(note).embed_hash == "cafe"
+  end
+
+  test "does not flag a note whose point lands during the grace window", %{bypass: bypass} do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    note =
+      insert(:note,
+        user: user,
+        vault: vault,
+        embed_hash: "cafe",
+        content_hash: "cafe",
+        dense_indexed_hash: "cafe"
+      )
+
+    point_id = Ecto.UUID.generate()
+    insert_chunk!(note, point_id)
+
+    # The write-order race: `commit_index/1` inserts the chunk row and upserts
+    # the point after it, so a note indexing right now is legitimately absent
+    # on the first probe and present moments later.
+    {:ok, present} = Agent.start_link(fn -> [] end)
+    stub_qdrant_agent(bypass, present)
+
+    prior = Application.get_env(:engram, :orphan_sweep_point_grace_fun)
+
+    Application.put_env(:engram, :orphan_sweep_point_grace_fun, fn ->
+      Agent.update(present, fn _ -> [point_id] end)
+    end)
+
+    on_exit(fn -> Application.put_env(:engram, :orphan_sweep_point_grace_fun, prior) end)
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert reload(note).embed_hash == "cafe"
+  end
+
+  test "ignores chunks belonging to a soft-deleted note", %{bypass: bypass} do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    note =
+      insert(:note,
+        user: user,
+        vault: vault,
+        embed_hash: "cafe",
+        content_hash: "cafe",
+        dense_indexed_hash: "cafe",
+        deleted_at: DateTime.utc_now(:second)
+      )
+
+    insert_chunk!(note, Ecto.UUID.generate())
+
+    stub_qdrant(bypass, [])
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert reload(note).embed_hash == "cafe"
+  end
+
+  test "probes every page when the chunk table exceeds one batch", %{bypass: bypass} do
+    prior = Application.get_env(:engram, :orphan_sweep_chunk_probe_batch)
+    Application.put_env(:engram, :orphan_sweep_chunk_probe_batch, 2)
+    on_exit(fn -> Application.put_env(:engram, :orphan_sweep_chunk_probe_batch, prior) end)
+
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    # Five chunks over a batch of 2 is three pages, the last one short. The
+    # note on the final page is the one a broken cursor would never reach.
+    kept =
+      for _ <- 1..4 do
+        note = insert(:note, user: user, vault: vault, embed_hash: "cafe", content_hash: "cafe")
+        point_id = Ecto.UUID.generate()
+        insert_chunk!(note, point_id)
+        {note, point_id}
+      end
+
+    last = insert(:note, user: user, vault: vault, embed_hash: "cafe", content_hash: "cafe")
+    insert_chunk!(last, Ecto.UUID.generate())
+
+    stub_qdrant(bypass, Enum.map(kept, fn {_note, point_id} -> point_id end))
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert is_nil(reload(last).embed_hash)
+    for {note, _} <- kept, do: assert(reload(note).embed_hash == "cafe")
+  end
+
+  defp stub_qdrant_agent(bypass, agent) do
+    Bypass.expect(bypass, "POST", "/collections/test_col/points/scroll", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      present = Agent.get(agent, & &1)
+
+      ids =
+        case Jason.decode!(body) do
+          %{"filter" => %{"must" => [%{"has_id" => asked}]}} ->
+            Enum.filter(asked, &(&1 in present))
+
+          _ ->
+            present
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{
+          "result" => %{
+            "points" => Enum.map(ids, &%{"id" => &1}),
+            "next_page_offset" => nil
+          }
+        })
+      )
+    end)
+  end
+end

--- a/test/engram/workers/orphan_sweep_missing_points_test.exs
+++ b/test/engram/workers/orphan_sweep_missing_points_test.exs
@@ -244,9 +244,7 @@ defmodule Engram.Workers.OrphanSweepMissingPointsTest do
   end
 
   test "probes every page when the chunk table exceeds one batch", %{bypass: bypass} do
-    prior = Application.get_env(:engram, :orphan_sweep_chunk_probe_batch)
-    Application.put_env(:engram, :orphan_sweep_chunk_probe_batch, 2)
-    on_exit(fn -> Application.put_env(:engram, :orphan_sweep_chunk_probe_batch, prior) end)
+    put_batch(2)
 
     user = insert(:user)
     vault = insert(:vault, user: user)
@@ -270,6 +268,116 @@ defmodule Engram.Workers.OrphanSweepMissingPointsTest do
 
     assert is_nil(reload(last).embed_hash)
     for {note, _} <- kept, do: assert(reload(note).embed_hash == "cafe")
+  end
+
+  # `Application.get_env/3` returns nil for an explicitly-nil key rather than
+  # falling back to the default, so restoring an absent key with put_env leaves
+  # the batch size nil for the rest of the VM — `LIMIT NULL`, whole-table read,
+  # silently, in every later test. Delete it instead.
+  defp put_batch(size) do
+    prior = Application.get_env(:engram, :orphan_sweep_chunk_probe_batch)
+    Application.put_env(:engram, :orphan_sweep_chunk_probe_batch, size)
+
+    on_exit(fn ->
+      case prior do
+        nil -> Application.delete_env(:engram, :orphan_sweep_chunk_probe_batch)
+        val -> Application.put_env(:engram, :orphan_sweep_chunk_probe_batch, val)
+      end
+    end)
+  end
+
+  defp put_max_candidates(max) do
+    prior = Application.get_env(:engram, :orphan_sweep_max_missing_candidates)
+    Application.put_env(:engram, :orphan_sweep_max_missing_candidates, max)
+
+    on_exit(fn ->
+      case prior do
+        nil -> Application.delete_env(:engram, :orphan_sweep_max_missing_candidates)
+        val -> Application.put_env(:engram, :orphan_sweep_max_missing_candidates, val)
+      end
+    end)
+  end
+
+  defp note_with_missing_point(user, vault) do
+    note = insert(:note, user: user, vault: vault, embed_hash: "cafe", content_hash: "cafe")
+    insert_chunk!(note, Ecto.UUID.generate())
+    note
+  end
+
+  test "a forced run repairs a restore even when most points look missing", %{bypass: bypass} do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+
+    # The ratio guard exists for an unreachable Qdrant, but a snapshot restore
+    # rolls back up to 24h of writes and trips the same threshold. Without an
+    # override the documented recovery silently never repairs anything.
+    notes = for _ <- 1..101, do: note_with_missing_point(user, vault)
+
+    stub_qdrant(bypass, [])
+
+    assert :ok = perform_job(OrphanSweep, %{"force" => true})
+
+    for note <- notes, do: assert(is_nil(reload(note).embed_hash))
+  end
+
+  test "ignores chunks belonging to a note in a soft-deleted vault", %{bypass: bypass} do
+    user = insert(:user)
+    vault = insert(:vault, user: user, deleted_at: DateTime.utc_now(:second))
+
+    # `ReconcileEmbeddings` joins vaults on `is_nil(deleted_at)`, so a note here
+    # can never be rebuilt. Flagging it means re-nulling and re-warning on every
+    # daily tick forever, and inflating the runaway ratio while doing it.
+    note = note_with_missing_point(user, vault)
+
+    stub_qdrant(bypass, [])
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert reload(note).embed_hash == "cafe"
+  end
+
+  test "does not flag a note whose chunk row is replaced during the grace window", %{
+    bypass: bypass
+  } do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+    note = note_with_missing_point(user, vault)
+
+    stub_qdrant(bypass, [])
+
+    # `commit_index/1` deletes the old points BEFORE the old chunk rows, so a
+    # note re-indexed mid-sweep leaves a scanned row whose point is genuinely
+    # gone and whose row is gone too. Re-asking Qdrant alone confirms "missing"
+    # and bills a full re-embed of a correctly-indexed note.
+    prior = Application.get_env(:engram, :orphan_sweep_point_grace_fun)
+
+    Application.put_env(:engram, :orphan_sweep_point_grace_fun, fn ->
+      Repo.delete_all(Chunk, skip_tenant_check: true)
+    end)
+
+    on_exit(fn -> Application.put_env(:engram, :orphan_sweep_point_grace_fun, prior) end)
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert reload(note).embed_hash == "cafe"
+  end
+
+  test "stops collecting candidates at the cap instead of holding the whole walk", %{
+    bypass: bypass
+  } do
+    put_batch(1)
+    put_max_candidates(2)
+
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+    notes = for _ <- 1..5, do: note_with_missing_point(user, vault)
+
+    stub_qdrant(bypass, [])
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    flagged = Enum.count(notes, &is_nil(reload(&1).embed_hash))
+    assert flagged == 2
   end
 
   defp stub_qdrant_agent(bypass, agent) do


### PR DESCRIPTION
Closes #1576. Found while running the #255 restore drill.

## The bug

`OrphanSweep` only ever asked *"does a chunk row still name this point?"*. Nothing asked the reverse, and nothing else can: `ReconcileEmbeddings` decides a note is indexed by comparing `embed_hash` to `content_hash` — both Postgres columns. A restore rolls the data and that bookkeeping back **together**, so they stay mutually consistent while Qdrant does not. Every note re-indexed after the restore point is silently unsearchable, forever, and reads as freshly indexed.

## Why an id check is exact

`indexing.ex:392` mints a fresh `Ecto.UUID.generate()` per chunk and `commit_index/1` deletes the old points first, so **point ids are never reused**. There is no stale-content-under-the-same-id case — every divergence is id-set divergence.

## The change

`sweep_missing_points/0`: page `chunks` by id, ask Qdrant which of those point ids exist, null `embed_hash`/`dense_indexed_hash` on notes whose points are gone. `ReconcileEmbeddings` rebuilds from there.

Deliberately minimal — `has_id` against the existing `Qdrant.scroll/2` means **no new client function**, and nulling the hash is the entire handoff, so **no new rebuild path**. Memory is flat in table size: one page of ids plus a near-empty candidate list.

### Guards, all mutation-tested

- **Runaway ratio.** An unreachable or repointed Qdrant makes every chunk look stranded; acting on that nulls the whole corpus and re-bills Voyage to rebuild it. Aborts instead.
- **Grace re-check.** `commit_index/1` inserts chunk rows *before* upserting points, so a note indexing right now is legitimately absent on the first probe.
- **A failed probe is never a "yes."** Both probes bail rather than treating an error as "missing", and the confirm-pass failure logs rather than passing silently.
- Live notes only — a soft-deleted note's points are already gone and would be flagged for a rebuild with nothing to rebuild.

## Cadence: weekly → daily

Weekly was right when this only reaped orphans (capacity waste, not wrong answers — search drops them at rehydration). The new direction is correctness, and a week is not an acceptable detection window. Affordable because a pass is O(collection) and the collection is small; the comment records ~1M points as the revisit threshold, where the walk wants a resumable cursor rather than a lower frequency.

## Verification

- 7 new tests, each **mutation-tested** — the guards were written before their tests, so each was proven to fail with its guard removed rather than trusted for passing. All 5 mutants killed.
- The paging test initially passed without paging (5 rows, batch 2048); added the batch override and re-verified it fails with a broken cursor.
- `mix test`: **5110 tests, 0 failures**. Format, credo --strict, dialyzer all clean.

## Doc correction included

The DR doc's full-rebuild RTO said 38 hours. That came from reading the Qdrant **point** count (76,352, taken before an unrelated purge) as a **note** count, while the batch is notes per tick. Measured: ~10,400 chunks over ~1,574 live notes, ~7 chunks/note → **~1 hour**. The doc now says to re-derive from the notes table and adds the post-restore reconcile step.