### PR TITLE
fix(crdt): name the resync trigger so a refocus is not read as a disconnect

### DIFF
--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -491,7 +491,7 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 	// re-sync) and reconciles the structural views a gap could have staled —
 	// snapshot-diff, like the plugin.
 	socket.onOpen(() => {
-		resyncOpenDocs();
+		resyncOpenDocs("reconnect");
 		backfillStructural(queryClient, vaultId);
 	});
 

--- a/frontend/src/crdt/session.test.ts
+++ b/frontend/src/crdt/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { remoteLog } from "../observability/remote-log";
 import {
 	__isNoteOpen,
 	clearRehandshakeBackoff,
@@ -115,6 +116,29 @@ describe("crdt session", () => {
 		window.dispatchEvent(new Event("focus"));
 		await new Promise((r) => setTimeout(r, 20));
 		expect(push).not.toHaveBeenCalled();
+	});
+
+	// A refocus and a dropped socket are very different incidents, and this line
+	// is the only trace either leaves in `client_logs`. Emitting the same text
+	// for both means prod triage reads a benign tab switch as a disconnect.
+	it("names the trigger so a refocus is not read as a dropped socket", async () => {
+		const lines: string[] = [];
+		const spy = vi
+			.spyOn(remoteLog, "log")
+			.mockImplementation((_lvl, _cat, message) => lines.push(message));
+
+		startCrdtSession({ vaultId: VAULT, push: () => {} });
+		await openDoc("note.md");
+
+		const remove = installCrdtResyncTriggers();
+		window.dispatchEvent(new Event("focus"));
+		await vi.waitFor(() => expect(lines.length).toBeGreaterThan(0));
+
+		expect(lines.some((l) => l.includes("refocus resync"))).toBe(true);
+		expect(lines.some((l) => l.includes("reconnect resync"))).toBe(false);
+
+		remove();
+		spy.mockRestore();
 	});
 
 	// Finding 1: flattenIfBloated must be skipped for an open note

--- a/frontend/src/crdt/session.test.ts
+++ b/frontend/src/crdt/session.test.ts
@@ -131,14 +131,20 @@ describe("crdt session", () => {
 		await openDoc("note.md");
 
 		const remove = installCrdtResyncTriggers();
-		window.dispatchEvent(new Event("focus"));
-		await vi.waitFor(() => expect(lines.length).toBeGreaterThan(0));
+		// try/finally, not trailing cleanup: this config sets no restoreMocks, so
+		// a failed assertion here would leave remoteLog mocked and the focus
+		// listener attached for every later test in the file — one real failure
+		// cascading into unrelated ones and hiding its own cause.
+		try {
+			window.dispatchEvent(new Event("focus"));
+			await vi.waitFor(() => expect(lines.length).toBeGreaterThan(0));
 
-		expect(lines.some((l) => l.includes("refocus resync"))).toBe(true);
-		expect(lines.some((l) => l.includes("reconnect resync"))).toBe(false);
-
-		remove();
-		spy.mockRestore();
+			expect(lines.some((l) => l.includes("refocus resync"))).toBe(true);
+			expect(lines.some((l) => l.includes("reconnect resync"))).toBe(false);
+		} finally {
+			remove();
+			spy.mockRestore();
+		}
 	});
 
 	// Finding 1: flattenIfBloated must be skipped for an open note
@@ -475,6 +481,58 @@ describe("crdt session", () => {
 				resyncOpenDocs();
 				await vi.waitFor(() => expect(frames.length).toBe(afterFirst + 1));
 				closeDoc("note-th");
+			} finally {
+				nowSpy.mockRestore();
+			}
+		});
+
+		// On a laptop wake both listener sets fire: the crdt triggers resync
+		// synchronously as "refocus", then `installSocketHealthTriggers` coalesces
+		// at 500ms and forces a real reconnect whose `socket.onOpen` lands inside
+		// the same 3s window. Throttling that away sends STEP1 only over the OLD
+		// socket and leaves open docs unhandshaked on the fresh one — deaf until
+		// some later trigger, which never comes if the user stays in the tab.
+		it("lets a real reconnect through a window a refocus already claimed", async () => {
+			const nowSpy = vi.spyOn(Date, "now").mockReturnValue(2_000_000);
+			try {
+				const frames: string[] = [];
+				startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+				await openDoc("note-wake");
+
+				resyncOpenDocs("refocus");
+				await vi.waitFor(() => expect(frames.length).toBeGreaterThan(0));
+				const afterRefocus = frames.length;
+
+				nowSpy.mockReturnValue(2_000_000 + 800); // well inside the 3s window
+				resyncOpenDocs("reconnect");
+				await vi.waitFor(() => expect(frames.length).toBe(afterRefocus + 1));
+
+				closeDoc("note-wake");
+			} finally {
+				nowSpy.mockRestore();
+			}
+		});
+
+		// The escape hatch above must not become the storm the throttle exists to
+		// stop: onOpen fires many times per second in a reconnect storm.
+		it("still throttles reconnect after reconnect", async () => {
+			const nowSpy = vi.spyOn(Date, "now").mockReturnValue(3_000_000);
+			try {
+				const frames: string[] = [];
+				startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+				await openDoc("note-storm");
+
+				resyncOpenDocs("reconnect");
+				await vi.waitFor(() => expect(frames.length).toBeGreaterThan(0));
+				const afterFirst = frames.length;
+
+				nowSpy.mockReturnValue(3_000_000 + 100);
+				resyncOpenDocs("reconnect");
+				resyncOpenDocs("reconnect");
+				await new Promise((r) => setTimeout(r, 20));
+				expect(frames.length).toBe(afterFirst);
+
+				closeDoc("note-storm");
 			} finally {
 				nowSpy.mockRestore();
 			}

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -309,11 +309,18 @@ export async function handleFrame(noteId: string, b64: string): Promise<void> {
 	await session.channel.handleFrame(noteId, b64);
 }
 
+/** What woke the resync. Both paths do identical work, but they are very
+ *  different incidents: `reconnect` means the socket actually dropped, while
+ *  `refocus` is a tab regaining visibility with a healthy socket. This line is
+ *  the only trace either leaves in `client_logs`, so one shared wording makes a
+ *  benign tab switch read as a disconnect during prod triage. */
+export type ResyncTrigger = "reconnect" | "refocus";
+
 /** On socket reconnect: clear each open doc's handshake guard and re-enroll it
  *  so a fresh STEP1 is sent. Removes the dependency on the server re-firing
  *  crdt_doc_ready. Open docs are those with a live Awareness entry (created by
  *  openDoc, removed by closeDoc). */
-export function resyncOpenDocs(): void {
+export function resyncOpenDocs(trigger: ResyncTrigger = "reconnect"): void {
 	if (!session) {
 		return;
 	}
@@ -332,7 +339,7 @@ export function resyncOpenDocs(): void {
 	rehandshakeAttempts.clear();
 	const ids = [...session.awareness.keys()];
 	if (ids.length > 0) {
-		rlog().info("crdt", `reconnect resync: re-enrolling ${ids.length} open doc(s)`);
+		rlog().info("crdt", `${trigger} resync: re-enrolling ${ids.length} open doc(s)`);
 	}
 	for (const id of ids) {
 		session.enrollment.reset(id); // clears enrolled set + CrdtChannel.initiated guard
@@ -354,15 +361,20 @@ export function resyncOpenDocs(): void {
 export function installCrdtResyncTriggers(): () => void {
 	const onVisible = () => {
 		if (document.visibilityState === "visible") {
-			resyncOpenDocs();
+			resyncOpenDocs("refocus");
 		}
 	};
+	// Named, and NOT `resyncOpenDocs` passed directly: a listener is called with
+	// the Event, which would arrive as the trigger argument and log a FocusEvent.
+	// It also has to be the same reference for removeEventListener to detach it —
+	// an inline arrow here would leak the listener on every cleanup.
+	const onFocus = () => resyncOpenDocs("refocus");
 	// visibilitychange targets document, not window (does not bubble).
 	document.addEventListener("visibilitychange", onVisible);
-	window.addEventListener("focus", resyncOpenDocs);
+	window.addEventListener("focus", onFocus);
 	return () => {
 		document.removeEventListener("visibilitychange", onVisible);
-		window.removeEventListener("focus", resyncOpenDocs);
+		window.removeEventListener("focus", onFocus);
 	};
 }
 

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -52,6 +52,14 @@ const REHANDSHAKE_MAX_DELAY_MS = 30_000;
  *  the first call in a session always passes. */
 const RESYNC_MIN_INTERVAL_MS = 3000;
 let lastResyncAt = Number.NEGATIVE_INFINITY;
+// What claimed the current window. A `refocus` must not swallow a `reconnect`
+// that follows it: on a laptop wake the crdt triggers resync synchronously,
+// then `installSocketHealthTriggers` coalesces at 500ms and forces a real
+// reconnect whose `socket.onOpen` lands inside the same window. Throttling that
+// away sends STEP1 only over the OLD socket and leaves open docs unhandshaked
+// on the fresh one — deaf until a later trigger that never comes if the user
+// stays in the tab.
+let lastResyncTrigger: ResyncTrigger = "reconnect";
 
 function bumpEpoch(noteId: string): void {
 	docEpochs.set(noteId, (docEpochs.get(noteId) ?? 0) + 1);
@@ -156,6 +164,7 @@ export function stopCrdtSession(): void {
 	rehandshakeTimers.clear();
 	rehandshakeAttempts.clear();
 	lastResyncAt = Number.NEGATIVE_INFINITY;
+	lastResyncTrigger = "reconnect";
 	session.manager.destroy().catch((e) => console.warn("CRDT session teardown error", e));
 	session = null;
 }
@@ -327,10 +336,16 @@ export function resyncOpenDocs(trigger: ResyncTrigger = "reconnect"): void {
 	// Throttle: a reconnect storm fires this many times per second; one full
 	// re-enroll per window recovers, the rest just amplifies the storm.
 	const now = Date.now();
-	if (now - lastResyncAt < RESYNC_MIN_INTERVAL_MS) {
+	// A reconnect always beats a window claimed by a refocus — the two are not
+	// interchangeable, and only the reconnect knows the socket underneath it
+	// changed. Reconnect-after-reconnect stays throttled: that is the storm this
+	// exists to bound.
+	const upgrades = trigger === "reconnect" && lastResyncTrigger === "refocus";
+	if (!upgrades && now - lastResyncAt < RESYNC_MIN_INTERVAL_MS) {
 		return;
 	}
 	lastResyncAt = now;
+	lastResyncTrigger = trigger;
 	// A reconnect (or a tab refocus) is a new connectivity epoch: attempts racked
 	// up against the OLD socket say nothing about this one. Clear the whole map so
 	// every open doc re-handshakes with a full budget — mirrors the plugin's


### PR DESCRIPTION
Found while investigating a new signup's first session.

## The problem

`resyncOpenDocs` has two call sites:

- `channel.ts` `socket.onOpen` — the socket **actually dropped**
- `session.ts` `installCrdtResyncTriggers` — `visibilitychange` / `window.focus`, a healthy tab regaining visibility

Both logged the identical line, and it named the alarming one:

```
reconnect resync: re-enrolling 1 open doc(s)
```

That line is the only trace either event leaves in `client_logs`, so clicking back into the browser window is indistinguishable from a disconnect.

**This already caused a misdiagnosis.** A user who signed up today had two of these in their only session, and I reported it as the socket dropping twice. It almost certainly wasn't: prod shipped **zero** backend log lines during the entire window (no drain, no auth rejection, no channel error), and the token was ~35s old so it wasn't the frozen-token loop from `spa-stale-socket-token-loop.md` either. Two window-focus events fit the evidence; a disconnect doesn't.

## The change

`resyncOpenDocs(trigger: ResyncTrigger = "reconnect")`, logging `reconnect resync` or `refocus resync`. Behaviour is otherwise identical — both paths still do the same work.

Also fixes the focus listener while here: it passed `resyncOpenDocs` **directly** to `addEventListener`, so with a first parameter the `FocusEvent` would have arrived as the trigger and been interpolated into the log. Now a named const — which `removeEventListener` needs anyway to detach it.

## Verification

New test watched failing first, asserting a focus event produces `refocus resync` and never `reconnect resync`. Full frontend suite: **1757 tests, 187 files, all passing**. `tsc --noEmit` and `biome ci` clean. Grepped `e2e/` and the plugin repo — nothing asserts on the old string.