### PR TITLE
fix(ci): fan obsidian-update out over both runner hosts

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -192,15 +192,29 @@ jobs:
           echo "=== /tmp ==="
           du -sh /tmp/ 2>/dev/null || true
 
-  # ── Keeps the self-hosted runner's pre-extracted Obsidian AppImage at the
-  # latest released version so E2E tests exercise up-to-date Obsidian.
+  # ── Keeps the runner pool's pre-extracted Obsidian AppImage at the latest
+  # released version so E2E tests exercise up-to-date Obsidian.
   # Weekly check (Obsidian ships every 2-4 weeks). `force` input re-downloads
   # even when version matches (used after install corruption).
+  #
+  # One leg per HOST, not per runner. The pool is ~9 runner agents across two
+  # machines (fastraid-N are `fastraid`+`light`, runner-N are `slowraid`+`heavy`),
+  # and all agents on a machine run as the same uid with the same `/home/runner`
+  # — see gotcha #21 in the runner-vm-setup context doc. The script writes to
+  # `$HOME/Applications`, so updating one agent per host updates every agent on
+  # that host. Two legs = full coverage; nine would just be seven no-ops racing
+  # for distinct runners, which `runs-on` can't guarantee anyway (no per-runner
+  # labels). An unpinned single job silently covered only whichever host it
+  # happened to land on, leaving the other stranded on an old version.
   obsidian-update:
     if: |
       github.event.schedule == '0 4 * * 1'
       || github.event.inputs.task == 'obsidian-update'
-    runs-on: [self-hosted, linux, x64, isolated]
+    strategy:
+      fail-fast: false  # one host being wedged must not skip the other
+      matrix:
+        host: [fastraid, slowraid]
+    runs-on: [self-hosted, linux, x64, isolated, "${{ matrix.host }}"]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Follow-up to #1584.

`obsidian-update` pinned only `[self-hosted, linux, x64, isolated]`, so each weekly
firing landed on one arbitrary runner and updated **that machine alone**. Confirmed
today when I dispatched it post-merge:

```
Updating Obsidian: 1.12.7 → 1.13.7
```

1.13.7 has been current for a while — the host that leg happened to land on was a full
minor behind, and e2e was running against whichever version its host was carrying.

## One leg per host, not per runner

The pool is ~9 agents across two machines:

```
fastraid-1..5   self-hosted,Linux,X64,isolated,fastraid,light
runner-1,2,3,5  self-hosted,Linux,X64,isolated,heavy,slowraid
```

All agents on a machine run as the same uid with the same `/home/runner`
(runner-vm-setup gotcha #21), and `update-obsidian.sh` writes to `$HOME/Applications`.
So one run per host updates every agent on that host — two legs is full coverage.

Nine legs would be seven no-ops racing for distinct runners, which `runs-on` can't
guarantee anyway: there are no per-runner labels, so the scheduler is free to put
several legs on the same agent as earlier ones finish.

`fail-fast: false` so a wedged host doesn't skip the other. `alert-cron-failure`
needs no change — a matrix job aggregates to a single `needs.*.result`.

## Verification

Will dispatch after merge and confirm both legs run and report a version.