### PR TITLE
docs(ci): correct the plan-triage git-push note

### DIFF
--- a/.github/scripts/plan-triage.py
+++ b/.github/scripts/plan-triage.py
@@ -187,14 +187,13 @@ def open_delete_pr(plan: dict) -> None:
         ]
     )
     # ponytail: this push has never run — no plan carries `status:` frontmatter yet, so
-    # nothing ever reaches here. Two things will bite the first time one does:
-    #   1. The runner VMs rewrite github.com/engram-app/ to the LAN git cache
-    #      (system-wide `insteadOf`, applies to push), while actions/checkout keys its
-    #      credential on the pre-rewrite host — so this pushes unauthenticated to a
-    #      read-only mirror. GH_REPO fixes `gh`, not `git`.
-    #   2. The commit above is unsigned, and main requires signed commits.
-    # Fix both together when a plan first goes `status: shipped`; doing it blind now
-    # means shipping an untestable auth change.
+    # nothing reaches here. The push itself is fine despite the runner VMs' LAN git-cache
+    # `insteadOf`: `git push origin` from these runners is proven daily by verify.yml's
+    # ledger-append (ci-ledger) and release-please's release-v* tag push, both on
+    # self-hosted isolated runners.
+    # What WILL bite is the merge — the commit above is unsigned and main requires signed
+    # commits, so the delete-PR opens but cannot be merged. Sign it when a plan first goes
+    # `status: shipped` and this path can actually be exercised.
     sh(["git", "push", "-u", "origin", branch])
     sh(
         [


### PR DESCRIPTION
Follow-up to #1584. While sweeping the rest of the cron jobs for the same `GH_REPO`
bug, I checked the claim I'd left in a comment on `open_delete_pr` — that the runner
VMs' LAN git-cache `insteadOf` would make its `git push origin` land unauthenticated
on a read-only mirror. It's wrong.

`git push origin` from these runners works, daily:

- `verify.yml` job `ledger-append` pushed `ci-ledger` from `fastraid-2`
  (`self-hosted,linux,x64,isolated,light`) on 2026-09-07 — latest ledger commit
  `851453ee`.
- `release-please.yml` pushed `release-v0.25.1` on 2026-09-06, also from a self-hosted
  isolated runner.

"GH_REPO fixes `gh`, not `git`" is true in general — it just doesn't break push here.
The unsigned-commit blocker on that path is real and the note keeps it.

## Sweep result (the reason I was in here)

Clean at both layers, nothing else to fix:

- **No unqualified inline `gh` call in any workflow.** Checked every `run:` block in all
  7 workflows against job/step `env` — each `gh` invocation either inherits `GH_REPO`
  or passes `--repo`/`$REPO`/`$GITHUB_REPOSITORY`.
- **The other cron jobs use no `gh` CLI at all.** `cron.yml` has zero inline `gh` calls;
  its two GitHub-touching steps are `actions/github-script@v9`, which goes through
  octokit + `context.repo` and is immune to the URL rewrite.
- **Script layer swept too** — the gap that let this bug live for two months. Of the
  scripts any workflow invokes, only `plan-triage.py` uses `gh` (fixed in #1584);
  `generate_schema_impact_notes.sh` passes `--repo "${GITHUB_REPOSITORY:-…}"`;
  `update-obsidian.sh` only curls `api.github.com`; the rest touch neither `gh` nor git
  remotes.