### PR TITLE
fix(search): cap chunk size so oversized notes stop poisoning embeds

### DIFF
--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -313,11 +313,21 @@ defmodule Engram.Indexing do
 
   defp doc_embed_model, do: Application.get_env(:engram, :doc_embed_model)
 
-  # Voyage caps inputs per request (1,000 texts / token budget); a large
-  # note's chunks in ONE call is a guaranteed 4xx no retry can fix — the
-  # job then churns through ReconcileEmbeddings forever. 128 matches the
-  # documented batch sweet spot and stays far below every API limit.
+  # Voyage caps a request two ways: 1,000 texts AND 120,000 tokens summed over
+  # them. Blowing either is a 400 no retry can fix, so the job churns through
+  # ReconcileEmbeddings forever.
+  #
+  # A count alone does not bound the token sum, because tokens per byte vary
+  # with the content. 128 chunks of ~2KB is ~269KB, which is ~67K tokens of
+  # English (fine) but ~134K of base64 or minified text (over the limit) — and
+  # dense, space-free content is exactly what the chunker's size cap now slices
+  # into full-width chunks. So bound the bytes too.
+  #
+  # 200KB is 100K tokens at 2 bytes/token, the worst density we expect from
+  # base64/random input. English packs the full 128 long before reaching it, so
+  # this costs nothing on ordinary notes.
   @embed_batch_size 128
+  @embed_batch_bytes 200_000
 
   # `false` yields a nil vector per chunk. Kept as an explicit list (not a bare
   # nil) so build_prepared/8 can zip chunks with vectors either way.
@@ -326,7 +336,7 @@ defmodule Engram.Indexing do
 
   defp embed_for_indexing(texts) do
     texts
-    |> Enum.chunk_every(@embed_batch_size)
+    |> batch_texts()
     |> Enum.reduce_while({:ok, []}, fn batch, {:ok, acc} ->
       case do_embed_batch(batch) do
         {:ok, vectors} -> {:cont, {:ok, [vectors | acc]}}
@@ -340,6 +350,31 @@ defmodule Engram.Indexing do
       other ->
         other
     end
+  end
+
+  # Close a batch on whichever ceiling comes first, count or bytes. A single
+  # text wider than the byte budget still goes out alone rather than looping:
+  # the chunker caps it long before here, and dropping it would silently
+  # unindex the content.
+  defp batch_texts(texts) do
+    Enum.chunk_while(
+      texts,
+      {[], 0, 0},
+      fn text, {batch, count, bytes} ->
+        size = byte_size(text)
+
+        if batch != [] and
+             (count + 1 > @embed_batch_size or bytes + size > @embed_batch_bytes) do
+          {:cont, Enum.reverse(batch), {[text], 1, size}}
+        else
+          {:cont, {[text | batch], count + 1, bytes + size}}
+        end
+      end,
+      fn
+        {[], _count, _bytes} -> {:cont, {[], 0, 0}}
+        {batch, _count, _bytes} -> {:cont, Enum.reverse(batch), {[], 0, 0}}
+      end
+    )
   end
 
   defp do_embed_batch(texts) do

--- a/lib/engram/logger/metadata.ex
+++ b/lib/engram/logger/metadata.ex
@@ -189,7 +189,11 @@ defmodule Engram.Logger.Metadata do
 
   # Letters, digits, spaces and the punctuation a diagnostic sentence needs.
   # No newlines, no `{}[]`, no `#`, no `@` — see the fails-closed note above.
-  @upstream_message ~r/^[A-Za-z0-9 ,.:;()'"\/_-]{3,200}$/
+  #
+  # `\A`/`\z`, not `^`/`$`: `$` also matches before a FINAL newline, so
+  # `"message\n"` satisfied the anchors even though the class rejects `\n`.
+  # A lone trailing newline is harmless, but "no newlines" has to mean it.
+  @upstream_message ~r/\A[A-Za-z0-9 ,.:;()'"\/_-]{3,200}\z/
 
   defp safe_upstream_message(msg) when is_binary(msg) do
     if Regex.match?(@upstream_message, msg), do: msg

--- a/lib/engram/logger/metadata.ex
+++ b/lib/engram/logger/metadata.ex
@@ -158,6 +158,45 @@ defmodule Engram.Logger.Metadata do
 
   def format_location(_other), do: "?"
 
+  @doc """
+  The upstream provider's own error string, or nil.
+
+  `error_kind` + `status` name the CLASS of an upstream failure but not the
+  cause: a Voyage 400 is "batch too large" or "input over the context length"
+  or "bad model", and the status cannot tell them apart. On 2026-09-09 that gap
+  cost a day — six notes sat in an embed poison loop and the only way to guess
+  why was to read the chunker. Surface the provider's own words instead.
+
+  **Fails closed.** The message must be a provider diagnostic, and provider
+  diagnostics are short prose. Anything carrying a newline, a brace, a bracket,
+  a `#` or an `@` is rejected outright rather than truncated, because those are
+  the shapes note content, a URL, an email or an echoed JSON payload take —
+  and `:detail` is NOT in `RedactFilter`'s sensitive-key set, so nothing
+  downstream will scrub what this lets through.
+
+  Only reads a provider's designated error field. It never reaches for an
+  echoed request body: `Engram.Billing.Reconciliation` documents why (a Paddle
+  error body is echoed JSON that can carry customer PII), and that reasoning
+  holds for any provider that mirrors the request back.
+  """
+  @spec upstream_error(term()) :: String.t() | nil
+  def upstream_error({_status, body}), do: upstream_error(body)
+  def upstream_error(%{"detail" => detail}), do: safe_upstream_message(detail)
+  def upstream_error(%{"error" => %{"message" => msg}}), do: safe_upstream_message(msg)
+  def upstream_error(%{"status" => %{"error" => err}}), do: safe_upstream_message(err)
+  def upstream_error(%{"message" => msg}), do: safe_upstream_message(msg)
+  def upstream_error(_other), do: nil
+
+  # Letters, digits, spaces and the punctuation a diagnostic sentence needs.
+  # No newlines, no `{}[]`, no `#`, no `@` — see the fails-closed note above.
+  @upstream_message ~r/^[A-Za-z0-9 ,.:;()'"\/_-]{3,200}$/
+
+  defp safe_upstream_message(msg) when is_binary(msg) do
+    if Regex.match?(@upstream_message, msg), do: msg
+  end
+
+  defp safe_upstream_message(_other), do: nil
+
   # An S3/XML error code, or nil. Accepts ONLY a bare alphabetic identifier, so
   # a message, a URL or a storage key (all of which carry `/`, `.` or spaces)
   # can never qualify.

--- a/lib/engram/parsers/markdown.ex
+++ b/lib/engram/parsers/markdown.ex
@@ -42,7 +42,65 @@ defmodule Engram.Parsers.Markdown do
         |> build_chunks(folder, title)
       end
 
-    body_chunks ++ frontmatter_chunk(content, folder, title, length(body_chunks))
+    (body_chunks ++ frontmatter_chunk(content, folder, title, length(body_chunks)))
+    |> Enum.flat_map(&enforce_size_cap/1)
+    |> Enum.with_index()
+    |> Enum.map(fn {chunk, idx} -> %{chunk | position: idx} end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Size cap (backstop)
+  # ---------------------------------------------------------------------------
+
+  # Every chunk's `context_text` is sent to Voyage, which rejects an oversized
+  # input with a permanent HTTP 400 — no retry fixes it, so EmbedNote parks the
+  # note on a 6h poison cooldown and ReconcileEmbeddings re-tries it forever
+  # (prod, 2026-09-09: six notes from one import, stuck).
+  #
+  # Two paths above emit unbounded text: `split_text/2` splits on spaces, so a
+  # run with none (base64 data URI, long URL, minified blob, CJK) passes through
+  # whole; and `frontmatter_chunk/4` never consulted a limit at all. Capping here
+  # rather than in each one means every chunk — including any a future path adds
+  # — flows through a single limit.
+  defp enforce_size_cap(%{text: text} = chunk) when byte_size(text) <= @max_chunk_chars do
+    [chunk]
+  end
+
+  defp enforce_size_cap(chunk) do
+    # Both construction sites build `context_text` as
+    # `context_prefix <> "\n\n" <> text`, so the leading bytes that are not the
+    # text are exactly the prefix (plus its separator) — reusable as-is.
+    prefix_len = byte_size(chunk.context_text) - byte_size(chunk.text)
+    prefix = binary_part(chunk.context_text, 0, prefix_len)
+
+    chunk.text
+    |> hard_split(@max_chunk_chars)
+    |> Enum.map(&%{chunk | text: &1, context_text: prefix <> &1})
+  end
+
+  # Split at codepoint boundaries into pieces of at most `max_bytes`. Slicing at
+  # a raw byte offset would cut a multibyte character in half and yield invalid
+  # UTF-8 — and space-free multibyte text (CJK) is precisely the input that gets
+  # here, since it offers the word splitter nothing to split on.
+  defp hard_split(text, max_bytes) do
+    {done, current, _size} =
+      text
+      |> String.codepoints()
+      |> Enum.reduce({[], [], 0}, fn codepoint, {done, current, size} ->
+        next_size = size + byte_size(codepoint)
+
+        # `current != []` keeps a lone codepoint wider than the budget moving
+        # instead of looping forever on a piece it can never shrink.
+        if current != [] and next_size > max_bytes do
+          {[current | done], [codepoint], byte_size(codepoint)}
+        else
+          {done, [codepoint | current], next_size}
+        end
+      end)
+
+    [current | done]
+    |> Enum.reverse()
+    |> Enum.map(&(&1 |> Enum.reverse() |> IO.iodata_to_binary()))
   end
 
   # Frontmatter values used to be stripped before indexing, making every key
@@ -242,10 +300,22 @@ defmodule Engram.Parsers.Markdown do
       Enum.reduce(words, {[], ""}, fn word, {done, acc} ->
         candidate = if acc == "", do: word, else: acc <> " " <> word
 
-        if byte_size(candidate) > max_chars and acc != "" do
-          {[acc | done], word}
-        else
-          {done, candidate}
+        cond do
+          byte_size(candidate) <= max_chars ->
+            {done, candidate}
+
+          # The word alone overflows, so flushing `acc` here would strand it as
+          # a runt chunk — a bare "#" when a heading line is followed by a
+          # space-free run — and the word would still need splitting after.
+          # Cut the combined text instead, which fills the current chunk to the
+          # brim and leaves the remainder as the next accumulator. A runt
+          # embeds to a meaningless vector and still costs a Qdrant point.
+          byte_size(word) > max_chars ->
+            [tail | full] = candidate |> hard_split(max_chars) |> Enum.reverse()
+            {full ++ done, tail}
+
+          true ->
+            {[acc | done], word}
         end
       end)
 

--- a/lib/engram/parsers/markdown.ex
+++ b/lib/engram/parsers/markdown.ex
@@ -42,10 +42,10 @@ defmodule Engram.Parsers.Markdown do
         |> build_chunks(folder, title)
       end
 
-    (body_chunks ++ frontmatter_chunk(content, folder, title, length(body_chunks)))
+    (body_chunks ++ frontmatter_chunk(content, folder, title))
     |> Enum.flat_map(&enforce_size_cap/1)
     |> Enum.with_index()
-    |> Enum.map(fn {chunk, idx} -> %{chunk | position: idx} end)
+    |> Enum.map(fn {chunk, idx} -> Map.put(chunk, :position, idx) end)
   end
 
   # ---------------------------------------------------------------------------
@@ -59,7 +59,7 @@ defmodule Engram.Parsers.Markdown do
   #
   # Two paths above emit unbounded text: `split_text/2` splits on spaces, so a
   # run with none (base64 data URI, long URL, minified blob, CJK) passes through
-  # whole; and `frontmatter_chunk/4` never consulted a limit at all. Capping here
+  # whole; and `frontmatter_chunk/3` never consulted a limit at all. Capping here
   # rather than in each one means every chunk — including any a future path adds
   # — flows through a single limit.
   defp enforce_size_cap(%{text: text} = chunk) when byte_size(text) <= @max_chunk_chars do
@@ -67,15 +67,28 @@ defmodule Engram.Parsers.Markdown do
   end
 
   defp enforce_size_cap(chunk) do
-    # Both construction sites build `context_text` as
-    # `context_prefix <> "\n\n" <> text`, so the leading bytes that are not the
-    # text are exactly the prefix (plus its separator) — reusable as-is.
-    prefix_len = byte_size(chunk.context_text) - byte_size(chunk.text)
-    prefix = binary_part(chunk.context_text, 0, prefix_len)
+    prefix = context_prefix_of(chunk)
 
     chunk.text
     |> hard_split(@max_chunk_chars)
     |> Enum.map(&%{chunk | text: &1, context_text: prefix <> &1})
+  end
+
+  # Both construction sites build `context_text` as
+  # `context_prefix <> "\n\n" <> text`, so the leading bytes that are not the
+  # text are exactly the prefix plus its separator — reusable as-is.
+  #
+  # Checked rather than assumed. This cap exists to hold for paths that do not
+  # exist yet, and a subtraction on a path that builds `context_text` some
+  # other way goes negative and raises inside the parser — which fails the
+  # embed, which lands us back in the poison loop the cap is here to prevent.
+  # Losing a prefix degrades one chunk's context; raising breaks the note.
+  defp context_prefix_of(%{context_text: context_text, text: text}) do
+    if String.ends_with?(context_text, text) do
+      binary_part(context_text, 0, byte_size(context_text) - byte_size(text))
+    else
+      ""
+    end
   end
 
   # Split at codepoint boundaries into pieces of at most `max_bytes`. Slicing at
@@ -107,7 +120,7 @@ defmodule Engram.Parsers.Markdown do
   # invisible to keyword search (spec 2026-07-02). One synthetic chunk carries
   # the raw block into the BM25 leg. char offsets are 0/0: the block sits
   # before the post-frontmatter body that offsets are relative to.
-  defp frontmatter_chunk(content, folder, title, position) do
+  defp frontmatter_chunk(content, folder, title) do
     case Engram.Notes.Frontmatter.split(content) do
       {block, _body} when is_binary(block) and block != "" ->
         context_prefix = build_context_prefix(folder, "#{title} > frontmatter")
@@ -118,8 +131,7 @@ defmodule Engram.Parsers.Markdown do
             context_text: context_prefix <> "\n\n" <> block,
             heading_path: "frontmatter",
             char_start: 0,
-            char_end: 0,
-            position: position
+            char_end: 0
           }
         ]
 

--- a/lib/engram/parsers/markdown.ex
+++ b/lib/engram/parsers/markdown.ex
@@ -95,25 +95,42 @@ defmodule Engram.Parsers.Markdown do
   # a raw byte offset would cut a multibyte character in half and yield invalid
   # UTF-8 — and space-free multibyte text (CJK) is precisely the input that gets
   # here, since it offers the word splitter nothing to split on.
-  defp hard_split(text, max_bytes) do
-    {done, current, _size} =
-      text
-      |> String.codepoints()
-      |> Enum.reduce({[], [], 0}, fn codepoint, {done, current, size} ->
-        next_size = size + byte_size(codepoint)
+  # Slices the binary rather than walking `String.codepoints/1`. Materialising
+  # one binary per character costs ~17s of CPU on a 10MB note (measured), and
+  # this runs in an Oban worker at concurrency 5 — the shape of the embed OOM
+  # in #891. Slicing yields sub-binary references and no per-character garbage.
+  defp hard_split(text, max_bytes), do: hard_split(text, max_bytes, [])
 
-        # `current != []` keeps a lone codepoint wider than the budget moving
-        # instead of looping forever on a piece it can never shrink.
-        if current != [] and next_size > max_bytes do
-          {[current | done], [codepoint], byte_size(codepoint)}
-        else
-          {done, [codepoint | current], next_size}
-        end
-      end)
+  defp hard_split(text, max_bytes, acc) when byte_size(text) <= max_bytes do
+    Enum.reverse([text | acc])
+  end
 
-    [current | done]
-    |> Enum.reverse()
-    |> Enum.map(&(&1 |> Enum.reverse() |> IO.iodata_to_binary()))
+  defp hard_split(text, max_bytes, acc) do
+    cut = codepoint_boundary(text, max_bytes)
+    <<piece::binary-size(cut), rest::binary>> = text
+    hard_split(rest, max_bytes, [piece | acc])
+  end
+
+  # Walk back while the cut points INTO a character. UTF-8 continuation bytes
+  # are 0b10xxxxxx, so this is at most 3 steps on valid input.
+  #
+  # Backing all the way to 0 means the whole window is continuation bytes —
+  # only reachable on invalid UTF-8, where there is no boundary to find. Take
+  # one byte rather than loop forever: the parser must not be what breaks a
+  # note. Losslessness is unaffected either way, since this only ever slices.
+  defp codepoint_boundary(text, offset) when offset > 0 do
+    if continuation_byte?(text, offset),
+      do: codepoint_boundary(text, offset - 1),
+      else: offset
+  end
+
+  defp codepoint_boundary(_text, _offset), do: 1
+
+  defp continuation_byte?(text, offset) do
+    case text do
+      <<_::binary-size(offset), byte, _::binary>> -> byte in 0x80..0xBF
+      _ -> false
+    end
   end
 
   # Frontmatter values used to be stripped before indexing, making every key

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -172,6 +172,25 @@ defmodule Engram.Workers.EmbedNote do
   defp embed_error_status({status, _body}) when is_integer(status), do: status
   defp embed_error_status(_), do: nil
 
+  # The provider's own error string. `status` alone cannot distinguish "input
+  # too long" from a bad model name or a malformed point, so a 400 could only be
+  # diagnosed by guessing from the code — which is exactly what the 2026-09-09
+  # oversized-chunk stall cost us. Read from the provider's error field only
+  # (never the echoed input, which is note text) and truncated, so a chatty
+  # upstream cannot turn one log line into a content leak.
+  @error_detail_limit 200
+
+  defp embed_error_detail({_status, %{"detail" => detail}}) when is_binary(detail) do
+    String.slice(detail, 0, @error_detail_limit)
+  end
+
+  # Qdrant's shape.
+  defp embed_error_detail({_status, %{"status" => %{"error" => error}}}) when is_binary(error) do
+    String.slice(error, 0, @error_detail_limit)
+  end
+
+  defp embed_error_detail(_), do: nil
+
   # Pricing v2 §B — block embeds when the user has exhausted their lifetime
   # token budget. Resolver returns nil for Starter/Pro (unmetered), so this is
   # effectively Free-only. Per-user overrides via Billing.UserLimitOverride.
@@ -328,6 +347,7 @@ defmodule Engram.Workers.EmbedNote do
         note_id: note.id,
         error_kind: error_kind,
         status: status,
+        detail: embed_error_detail(reason),
         cooldown_seconds: cooldown
       )
     )
@@ -399,7 +419,8 @@ defmodule Engram.Workers.EmbedNote do
                     vault_id: note.vault_id,
                     note_id: note.id,
                     error_kind: error_kind,
-                    status: status
+                    status: status,
+                    detail: embed_error_detail(reason)
                   )
                 )
 

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -172,25 +172,6 @@ defmodule Engram.Workers.EmbedNote do
   defp embed_error_status({status, _body}) when is_integer(status), do: status
   defp embed_error_status(_), do: nil
 
-  # The provider's own error string. `status` alone cannot distinguish "input
-  # too long" from a bad model name or a malformed point, so a 400 could only be
-  # diagnosed by guessing from the code — which is exactly what the 2026-09-09
-  # oversized-chunk stall cost us. Read from the provider's error field only
-  # (never the echoed input, which is note text) and truncated, so a chatty
-  # upstream cannot turn one log line into a content leak.
-  @error_detail_limit 200
-
-  defp embed_error_detail({_status, %{"detail" => detail}}) when is_binary(detail) do
-    String.slice(detail, 0, @error_detail_limit)
-  end
-
-  # Qdrant's shape.
-  defp embed_error_detail({_status, %{"status" => %{"error" => error}}}) when is_binary(error) do
-    String.slice(error, 0, @error_detail_limit)
-  end
-
-  defp embed_error_detail(_), do: nil
-
   # Pricing v2 §B — block embeds when the user has exhausted their lifetime
   # token budget. Resolver returns nil for Starter/Pro (unmetered), so this is
   # effectively Free-only. Per-user overrides via Billing.UserLimitOverride.
@@ -347,7 +328,7 @@ defmodule Engram.Workers.EmbedNote do
         note_id: note.id,
         error_kind: error_kind,
         status: status,
-        detail: embed_error_detail(reason),
+        detail: Metadata.upstream_error(reason),
         cooldown_seconds: cooldown
       )
     )
@@ -420,7 +401,7 @@ defmodule Engram.Workers.EmbedNote do
                     note_id: note.id,
                     error_kind: error_kind,
                     status: status,
-                    detail: embed_error_detail(reason)
+                    detail: Metadata.upstream_error(reason)
                   )
                 )
 

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -156,6 +156,57 @@ defmodule Engram.IndexingTest do
       assert Enum.all?(batches, &(&1 <= 128)), "oversized embed batch: #{inspect(batches)}"
     end
 
+    test "closes an embed batch on the byte budget, not just the count", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
+      # Voyage caps a request at 120,000 tokens summed over its inputs, and a
+      # count cannot bound that — tokens per byte swing with the content. 128
+      # full-width chunks of dense, space-free text (base64, minified) is
+      # ~269KB, which is ~134K tokens at 2 bytes/token: a 400 no retry fixes.
+      # A space-free blob is exactly what the chunker's cap now slices into
+      # full-width chunks, so it is the shape that would regress.
+      {:ok, dense_note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Big/Dense.md",
+          "content" => "# Dense\n\n" <> String.duplicate("A", 300_000),
+          "mtime" => 1_000.0
+        })
+
+      test_pid = self()
+
+      Engram.MockEmbedder
+      |> stub(:embed_texts, fn texts ->
+        send(
+          test_pid,
+          {:embed_batch, {length(texts), texts |> Enum.map(&byte_size/1) |> Enum.sum()}}
+        )
+
+        {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)}
+      end)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": true}))
+      end)
+
+      assert {:ok, _chunk_count} = Indexing.index_note(dense_note, vault)
+
+      batches = collect_messages(:embed_batch)
+      assert length(batches) >= 2
+
+      Enum.each(batches, fn {count, bytes} ->
+        assert bytes <= 200_000, "embed batch of #{bytes} bytes exceeds the budget"
+        assert count <= 128
+      end)
+
+      # The byte ceiling must be the binding one here — if the count still
+      # closed every batch, the token limit is as unguarded as before.
+      assert Enum.any?(batches, fn {count, _bytes} -> count < 128 end)
+    end
+
     test "upserts Qdrant points in batches of at most 256", %{
       bypass: bypass,
       user: user,

--- a/test/engram/logger/metadata_test.exs
+++ b/test/engram/logger/metadata_test.exs
@@ -94,4 +94,49 @@ defmodule Engram.Logger.MetadataTest do
       refute Keyword.has_key?(md, :span_id)
     end
   end
+
+  describe "upstream_error/1" do
+    test "surfaces a provider diagnostic from each provider's error field" do
+      # The three shapes that cost us a day of guessing on 2026-09-09.
+      assert Metadata.upstream_error(
+               {400, %{"detail" => "Total number of tokens in the batch exceeds the limit"}}
+             ) == "Total number of tokens in the batch exceeds the limit"
+
+      assert Metadata.upstream_error(
+               {400, %{"status" => %{"error" => "Wrong input: expected dim: 1024, got: 512"}}}
+             ) == "Wrong input: expected dim: 1024, got: 512"
+
+      assert Metadata.upstream_error({400, %{"error" => %{"message" => "Invalid model name"}}}) ==
+               "Invalid model name"
+    end
+
+    test "fails closed on anything shaped like content rather than a diagnostic" do
+      # `:detail` is not in RedactFilter's key set, so nothing downstream
+      # scrubs what this lets through — it has to reject, not truncate.
+      for leaky <- [
+            "# My Private Note\n\nPatient notes follow",
+            "failed on {\"content\": \"secret\"}",
+            "could not embed todd@example.com",
+            "[[Wikilink To A Private Note]]",
+            String.duplicate("a", 201)
+          ] do
+        assert Metadata.upstream_error({400, %{"detail" => leaky}}) == nil,
+               "leaked: #{inspect(leaky)}"
+      end
+    end
+
+    test "returns nil for transport errors and unrecognised bodies" do
+      assert Metadata.upstream_error(%Req.TransportError{reason: :timeout}) == nil
+      assert Metadata.upstream_error({500, "plain string body"}) == nil
+      assert Metadata.upstream_error({400, %{"unexpected" => "shape"}}) == nil
+      assert Metadata.upstream_error(:timeout) == nil
+    end
+
+    test "never reaches into an echoed request body" do
+      # Paddle's shape — Reconciliation documents that the echoed body can
+      # carry customer PII, so this must not mine it.
+      assert Metadata.upstream_error({:paddle_error, 400, %{"customer_email" => "a@b.com"}}) ==
+               nil
+    end
+  end
 end

--- a/test/engram/logger/metadata_test.exs
+++ b/test/engram/logger/metadata_test.exs
@@ -118,7 +118,9 @@ defmodule Engram.Logger.MetadataTest do
             "failed on {\"content\": \"secret\"}",
             "could not embed todd@example.com",
             "[[Wikilink To A Private Note]]",
-            String.duplicate("a", 201)
+            String.duplicate("a", 201),
+            # `$` matches before a final newline; only `\z` actually rejects it.
+            "looks fine but ends with a newline\n"
           ] do
         assert Metadata.upstream_error({400, %{"detail" => leaky}}) == nil,
                "leaked: #{inspect(leaky)}"

--- a/test/engram/logger/redact_filter_test.exs
+++ b/test/engram/logger/redact_filter_test.exs
@@ -3,6 +3,11 @@ defmodule Engram.Logger.RedactFilterTest do
 
   alias Engram.Logger.RedactFilter
 
+  # Per-module: `:logger` primary filters are a node-wide registry keyed by
+  # name, and `RescueReasonSinkTest` installs one too. Sharing the literal
+  # meant either module's `on_exit` unregistered the other's filter mid-test.
+  @primary_filter :"engram_redact_#{__MODULE__}"
+
   @sentinel "user-content-XYZZYZ-LOGTEST-SECRET"
 
   describe "filter/2" do
@@ -128,8 +133,8 @@ defmodule Engram.Logger.RedactFilterTest do
 
   describe "integration with :logger primary filter" do
     setup do
-      :logger.add_primary_filter(:engram_redact_test, {&RedactFilter.filter/2, []})
-      on_exit(fn -> :logger.remove_primary_filter(:engram_redact_test) end)
+      :logger.add_primary_filter(@primary_filter, {&RedactFilter.filter/2, []})
+      on_exit(fn -> :logger.remove_primary_filter(@primary_filter) end)
       :ok
     end
 

--- a/test/engram/logger/rescue_reason_sink_test.exs
+++ b/test/engram/logger/rescue_reason_sink_test.exs
@@ -19,6 +19,15 @@ defmodule Engram.Logger.RescueReasonSinkTest do
   alias Engram.Logger.Metadata
   alias Engram.Logger.RedactFilter
 
+  # Per-module, because `:logger`'s primary filters are a NODE-WIDE registry
+  # keyed by name and this module is `async: true`. `RedactFilterTest` installed
+  # the same literal `:engram_redact_test`, so whichever module finished first
+  # ran `remove_primary_filter/1` on the other's still-running assertions —
+  # `installed?/0` then went false and this file failed with nothing wrong in
+  # the code under test. Deriving the name means a third module cannot
+  # reintroduce the collision by copying the setup block.
+  @primary_filter :"engram_redact_#{__MODULE__}"
+
   @secret "Dear diary, the biopsy came back positive."
 
   defp prod_line(meta, message) do
@@ -241,12 +250,12 @@ defmodule Engram.Logger.RescueReasonSinkTest do
   # These install the real filter and drive the real `:logger` API.
   describe "the primary filter survives everything :logger can hand it" do
     setup do
-      :logger.add_primary_filter(:engram_redact_test, {&RedactFilter.filter/2, []})
-      on_exit(fn -> :logger.remove_primary_filter(:engram_redact_test) end)
+      :logger.add_primary_filter(@primary_filter, {&RedactFilter.filter/2, []})
+      on_exit(fn -> :logger.remove_primary_filter(@primary_filter) end)
       :ok
     end
 
-    defp installed?, do: :engram_redact_test in Keyword.keys(:logger.get_primary_config().filters)
+    defp installed?, do: @primary_filter in Keyword.keys(:logger.get_primary_config().filters)
 
     test "a struct metadata does not remove the filter" do
       assert installed?()

--- a/test/engram/parsers/markdown_test.exs
+++ b/test/engram/parsers/markdown_test.exs
@@ -211,4 +211,82 @@ defmodule Engram.Parsers.MarkdownTest do
       assert length(heading_paths) == 1
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Hard size cap
+  #
+  # Every chunk's text is embedded by Voyage, which rejects an oversized input
+  # with a permanent HTTP 400 — no retry fixes it, so the note is parked on a
+  # 6h poison cooldown and re-tried forever (prod, 2026-09-09). The word-boundary
+  # splitter is best-effort; these cases have no word boundary to split on, so
+  # the cap has to hold regardless of the input's shape.
+  # ---------------------------------------------------------------------------
+
+  describe "chunk size cap" do
+    @max_chunk_chars 2048
+
+    defp assert_all_capped(chunks) do
+      refute chunks == []
+
+      for chunk <- chunks do
+        assert byte_size(chunk.text) <= @max_chunk_chars,
+               "chunk text is #{byte_size(chunk.text)} bytes, over the #{@max_chunk_chars} cap"
+
+        assert String.valid?(chunk.text), "chunk text was split mid-codepoint"
+      end
+    end
+
+    test "caps a space-free run (base64 data URI, long URL, minified blob)" do
+      blob = String.duplicate("A", 60_000)
+
+      "# Title\n\n![img](data:image/png;base64,#{blob})\n"
+      |> Markdown.parse("Test/Blob.md")
+      |> assert_all_capped()
+    end
+
+    test "caps an oversized frontmatter block" do
+      ("---\nnote: " <> String.duplicate("x y ", 30_000) <> "\n---\n\n# T\n\nbody\n")
+      |> Markdown.parse("Test/Frontmatter.md")
+      |> assert_all_capped()
+    end
+
+    test "caps space-free multibyte text without splitting mid-codepoint" do
+      # CJK has no spaces to split on, and each char is 3 bytes — a
+      # grapheme-counted cap would overshoot the byte budget ~3x.
+      ("# 見出し\n\n" <> String.duplicate("日本語", 20_000))
+      |> Markdown.parse("Test/CJK.md")
+      |> assert_all_capped()
+    end
+
+    # Scoped to a body with no spaces, so the word splitter has no boundary to
+    # drop — packing at word boundaries is lossy by design (it collapses the
+    # space it split on), and that predates the cap. What must not lose or
+    # duplicate a byte is the hard split itself.
+    # The heading line stays in the chunk text on purpose — the BM25 leg indexes
+    # `text`, not `context_text`, so stripping it would make headings invisible
+    # to keyword search. What must not happen is the packer flushing it alone:
+    # a bare "#" embeds to a meaningless vector and still costs a Qdrant point.
+    test "a heading before an oversized run does not leave a runt chunk" do
+      for body <- [
+            String.duplicate("A", 10_000),
+            "https://x.example/" <> String.duplicate("a", 5_000)
+          ] do
+        chunks = Markdown.parse("# Heading\n\n" <> body, "Test/Runt.md")
+
+        assert length(chunks) > 1
+
+        refute Enum.any?(chunks, &(byte_size(&1.text) < 20)),
+               "runt chunks: #{inspect(Enum.filter(chunks, &(byte_size(&1.text) < 20)) |> Enum.map(& &1.text))}"
+      end
+    end
+
+    test "hard split preserves every byte of a space-free body" do
+      for body <- [String.duplicate("A", 10_000), String.duplicate("日本語", 5_000)] do
+        chunks = Markdown.parse(body, "Test/Blob.md")
+
+        assert length(chunks) > 1
+        assert Enum.map_join(chunks, & &1.text) == body
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What broke

Six notes from one prod import were stuck in a permanent loop as of 2026-09-09: Voyage rejected them with HTTP 400, `EmbedNote` parked each on a 6h `embed_retry_after` cooldown, `ReconcileEmbeddings` re-enqueued them when it lapsed, Voyage rejected them again. Surfaced as repeated `engram-prod-loki-embed-poison` alerts.

~74 wasted Voyage calls/day, 6 notes unsearchable. The *bug* burned no tokens — a 400 costs nothing. See "Cost change" below for what the *fix* costs.

## Root cause

The chunker bounds chunks at 2048 bytes, but two paths skipped the limit. Measured against the real chunker:

| Input shape | Largest chunk before |
|---|---|
| space-free run (base64 URI, long URL, minified blob) | 60 KB |
| oversized frontmatter block | 120 KB |
| CJK (no spaces, 3 bytes/char) | 180 KB |
| normal prose (control) | 2047 bytes — cap working |

`split_text/2` packs at word boundaries, so a run containing no space passes through whole. `frontmatter_chunk/3` never consulted a limit at all.

## The fix

Voyage enforces **two** limits, and this PR now respects both:

- **32,000 tokens per input** — enforced once in `parse/2`, where every chunk flows through, including any a future path adds. Teaching each path its own limit is the failure mode that produced this bug twice over. Splits at codepoint boundaries; a raw byte offset would cut a multibyte character in half, and space-free multibyte text is precisely what reaches here.
- **120,000 tokens per request** — batches now close on 200KB *or* 128 texts, whichever first. A count cannot bound a token sum: 128 chunks of ~2KB is ~67K tokens of English but ~134K of base64. Dense content is exactly what the size cap slices into full-width chunks, so capping alone made its own worst case more likely.

Riding along:

- **No runt chunks.** A heading followed by an oversized run used to leave a bare `"#"` as its own chunk — a meaningless vector that still costs a Qdrant point. The heading stays *in* the chunk text on purpose: the BM25 leg indexes `text`, not `context_text`, so stripping it would make headings invisible to keyword search.
- **`Metadata.upstream_error/1`** — log the provider's own error string. Only `status: 400` was recorded, so diagnosing this meant inferring the cause from the code. **Fails closed:** `:detail` is not in `RedactFilter`'s key set, and `Billing.Reconciliation` documents that an echoed provider body can carry customer PII. Reads only a provider's designated error field, and only when the value carries no newline, brace, bracket, `#` or `@`. Never wired to Paddle.

## Cost change — please read

A 10 MB space-free note (the `@max_note_bytes` ceiling) goes from **1 chunk, rejected, 0 tokens billed** to **5,120 chunks, ~2.6M tokens billed**. Measured.

That is the correct behaviour — the note *should* index — but it is a new spend path, and there is no per-note chunk ceiling. I deliberately did **not** add one: a silent truncation cap leaves notes partially indexed and invisibly wrong. Worth pairing with #1481 (per-user embed-token alerting; Pro has no ceiling).

## Verification

- `mix format`, `mix credo --strict` (no issues), `mix dialyzer` (0 unnecessary skips) — clean
- 221 tests / 0 failures, **5 consecutive runs**
- **Red check:** with `markdown.ex` reverted and the tests kept, the cap tests fail at exactly 60,037 / 120,007 / 180,011 bytes. The byte-budget test asserts the byte ceiling is the *binding* one, so a regression to count-only fails.

### Unrelated drive-by

`RescueReasonSinkTest` and `RedactFilterTest` are both `async: true` and both installed a `:logger` primary filter named `:engram_redact_test`. Filter names are a node-wide registry, so whichever module finished first unregistered the other's filter mid-assertion — an intermittent failure with nothing wrong in the code under test. Each module now derives its own name.

Confirmed not caused by this branch: the failing seed reruns clean with these changes in.

## Rollout

The six parked notes need no manual repair. `ReconcileEmbeddings` selects on `is_nil(embed_hash)`, which they still are, so they re-embed within 6h of this deploying.

**Still unknown:** we never saw Voyage's actual error body, so the specific rejection reason remains inferred. `upstream_error/1` is what will confirm it on the next failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)