### PR TITLE
docs: the container gate recipe leaves root-owned files in the worktree

### DIFF
--- a/docs/context/local-backend-testing.md
+++ b/docs/context/local-backend-testing.md
@@ -40,17 +40,43 @@ Runs from the main checkout OR any worktree (it resolves its own repo dir).
   docker run --rm --network host -v "$PWD":/app -w /app \
     -v /tmp/engram-bld:/bld -e MIX_BUILD_PATH=/bld/test -e MIX_ENV=test \
     -e HEX_HOME=/tmp/hex -e MIX_HOME=/tmp/mixhome \
+    -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
     hexpm/elixir:1.17.3-erlang-27.3.4.14-debian-bookworm-20260623-slim \
     bash -c 'apt-get update -qq && apt-get install -y -qq build-essential git &&
              mix local.hex --force && mix local.rebar --force &&
-             mix deps.get && mix test'
+             mix deps.get && mix test
+             rc=$?; chown -R "$HOST_UID:$HOST_GID" /app; exit $rc'
   ```
 
-  Two things that bite here: the bare `hexpm/elixir` image ships **no C
-  toolchain**, so NIF deps (`bcrypt_elixir`, `y_ex`) die on `"make" not found`
-  until you `apt-get install build-essential`; and `MIX_BUILD_PATH` must point
-  somewhere outside the repo or the container's artifacts clobber your host
-  `_build`. `--network host` is what lets it reach `backend-postgres-1`.
+  Three things bite here.
+
+  **No C toolchain.** The bare `hexpm/elixir` image ships none, so NIF deps
+  (`bcrypt_elixir`, `y_ex`) die on `"make" not found` until you
+  `apt-get install build-essential`. `verify.yml` carries the same note.
+
+  **`MIX_BUILD_PATH` must point outside the repo**, or the container's artifacts
+  clobber your host `_build`.
+
+  **The container runs as root and `/app` is your working tree.** Anything Mix
+  writes back into the repo — `deps/`, `tmp/`, `priv/plts/` — lands root-owned.
+  All of it is gitignored so nothing shows in `git status`, and you will not
+  notice until:
+
+  ```
+  $ git worktree remove .worktrees/foo --force
+  error: failed to delete '.../.worktrees/foo': Permission denied
+  ```
+
+  …at which point the only way out is `sudo rm -rf`. Hence the trailing
+  `chown -R` above, which must run **after** the gate and preserve its exit code
+  — a bare `&& chown` swallows the failure you were testing for.
+
+  `--network host` is what lets it reach `backend-postgres-1`.
+
+  > The main checkout is safe even though the post-checkout hook hardlinks
+  > `deps/` into every worktree: `mix deps.get` replaces files rather than
+  > writing through the shared inode, so only the worktree's copies flip owner.
+  > Verified — `find deps ! -user "$(id -un)"` in the main checkout returned 0.
 - **Postgres on `localhost:5432`, creds `engram/engram`** — these are the
   defaults baked into `config/test.exs` (used only when `DATABASE_URL` is
   unset). The `backend-postgres-1` docker container already serves this; start


### PR DESCRIPTION
Fixes a landmine in the recipe #1596 just added to `docs/context/local-backend-testing.md`.

The container runs as root with your working tree bind-mounted at `/app`, so everything Mix writes back into the repo — `deps/`, `tmp/`, `priv/plts/` — comes back root-owned. All three are gitignored, so `git status` stays clean and there is no symptom at all until:

```
$ git worktree remove .worktrees/otp27-toolchain --force
error: failed to delete '.../.worktrees/otp27-toolchain': Permission denied
```

4084 files in my case, recoverable only with `sudo rm -rf`. Hit it cleaning up after #1596.

Adds a trailing `chown -R` to the documented recipe. It runs *after* the gate and preserves the exit code — a bare `&& chown` would swallow the failure you were running the gate to find.

Also records the reassuring half: the post-checkout hook hardlinks `deps/` into every worktree, but `mix deps.get` replaces files rather than writing through the shared inode, so the main checkout does not get dragged along. Verified — `find deps ! -user "$(id -un)"` there returned 0.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZU8U3d3gxBK8wi2qR6jfc