### PR TITLE
fix(search): bound embed inputs by bytes, not a density guess

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -231,3 +231,12 @@ config :opentelemetry,
 # deleting. Zero in tests: no suite should pay a real minute of sleep, and the
 # race it guards is exercised directly via `:orphan_sweep_point_grace_fun`.
 config :engram, :orphan_sweep_point_grace_seconds, 0
+
+# `Qdrant.ensure_collection/2` memoises "this collection is ready" in
+# :persistent_term, keyed on the base URL — which under test is a Bypass port.
+# Ports are recycled: Bypass frees one on test exit and the OS reissues it, so a
+# later test inherits an earlier test's marker, skips the HTTP call entirely and
+# fails Bypass's exit check with "No HTTP request arrived at Bypass" — nowhere
+# near the test that actually caused it. Off here so no marker is ever written.
+# `QdrantEnsureCollectionMemoTest` re-enables it for its own cases.
+config :engram, :ensure_collection_memo, false

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -467,15 +467,31 @@ defmodule Engram.Indexing do
   # 143,526 tokens is 1.39 bytes/token, well under the assumed floor of 2.
   #
   # So do not guess the density. A token never spans less than one byte, so a
-  # batch bounded at 120,000 BYTES is bounded at 120,000 tokens for any content
-  # and any tokenizer — no assumption left to be wrong a third time.
+  # byte ceiling bounds the token sum for any content and any tokenizer.
   #
-  # This costs requests, not money: Voyage bills tokens, and ordinary English
-  # (~4 bytes/token) now packs ~30K tokens per request instead of filling the
-  # allowance. These are background Oban jobs, so the extra round trips are
-  # cheaper than another poison loop.
+  # 118KB rather than a flush 120KB because `tokens <= bytes` covers tokens
+  # DERIVED from content, not ones the tokenizer INSERTS: BERT-family models add
+  # ~2 per input ([CLS]/[SEP]), which at 128 inputs is 120,256 — over the line
+  # by a hair that only opens at 1.0 bytes/token. Prod's worst measured is 1.39,
+  # so this is margin against a case we have never seen rather than one we have.
+  # It costs nothing to be actually correct instead of nearly correct.
+  #
+  # The ceiling only binds because `Markdown.enforce_size_cap/1` bounds
+  # `context_text` — text AND prefix. Do not weaken that to a `text`-only cap:
+  # `batch_texts/1` lets a single over-budget input through alone, so one
+  # unbounded `context_text` bypasses this ceiling entirely.
+  #
+  # Cost is requests, not money — Voyage bills tokens. But they are not free:
+  # the byte cap now closes a batch whenever the average chunk exceeds ~937
+  # bytes (120,000/128), which is ordinary prose, not just the base64 case
+  # above; under 200KB that threshold was ~1,562. Prod runs `VOYAGE_RPM=1600`
+  # through the client-side throttle in `Embedders.Voyage.throttle_check/1`,
+  # which synthesizes a 429 that `EmbedNote` answers with a 60s snooze
+  # (`EMBED_429_SNOOZE_SECONDS`). So a bulk import trades wall-clock for
+  # correctness here. That is the right trade against a permanent poison loop,
+  # and the RPM is the knob if it ever bites.
   @embed_batch_size 128
-  @embed_batch_bytes 120_000
+  @embed_batch_bytes 118_000
 
   # `false` yields a nil vector per chunk. Kept as an explicit list (not a bare
   # nil) so build_prepared/8 can zip chunks with vectors either way.
@@ -501,9 +517,16 @@ defmodule Engram.Indexing do
   end
 
   # Close a batch on whichever ceiling comes first, count or bytes. A single
-  # text wider than the byte budget still goes out alone rather than looping:
-  # the chunker caps it long before here, and dropping it would silently
-  # unindex the content.
+  # text wider than the byte budget still goes out alone rather than looping,
+  # because dropping it would silently unindex the content.
+  #
+  # That escape hatch is a REAL hole, not a formality, and the only thing
+  # closing it is `Markdown.enforce_size_cap/1` bounding `context_text` to
+  # ~2.5KB. An earlier version of this comment claimed "the chunker caps it long
+  # before here" while the chunker capped only `text` — so a 200KB heading
+  # prefix rode straight past this ceiling, one oversized batch per chunk. If
+  # that cap ever loosens, this line stops being a safety valve and becomes the
+  # bypass.
   defp batch_texts(texts) do
     Enum.chunk_while(
       texts,

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -459,11 +459,23 @@ defmodule Engram.Indexing do
   # dense, space-free content is exactly what the chunker's size cap now slices
   # into full-width chunks. So bound the bytes too.
   #
-  # 200KB is 100K tokens at 2 bytes/token, the worst density we expect from
-  # base64/random input. English packs the full 128 long before reaching it, so
-  # this costs nothing on ordinary notes.
+  # The byte ceiling is 120KB, and it is NOT a density estimate. A previous
+  # version of this comment picked 200KB as "100K tokens at 2 bytes/token, the
+  # worst density we expect" — prod disproved it within a day. Six notes from
+  # one import kept failing with `batch has 143526 tokens after truncation`
+  # against the 120,000 ceiling; a batch of at most 200,000 bytes producing
+  # 143,526 tokens is 1.39 bytes/token, well under the assumed floor of 2.
+  #
+  # So do not guess the density. A token never spans less than one byte, so a
+  # batch bounded at 120,000 BYTES is bounded at 120,000 tokens for any content
+  # and any tokenizer — no assumption left to be wrong a third time.
+  #
+  # This costs requests, not money: Voyage bills tokens, and ordinary English
+  # (~4 bytes/token) now packs ~30K tokens per request instead of filling the
+  # allowance. These are background Oban jobs, so the extra round trips are
+  # cheaper than another poison loop.
   @embed_batch_size 128
-  @embed_batch_bytes 200_000
+  @embed_batch_bytes 120_000
 
   # `false` yields a nil vector per chunk. Kept as an explicit list (not a bare
   # nil) so build_prepared/8 can zip chunks with vectors either way.

--- a/lib/engram/parsers/markdown.ex
+++ b/lib/engram/parsers/markdown.ex
@@ -10,6 +10,7 @@ defmodule Engram.Parsers.Markdown do
 
   # ~4 chars per token; 512 tokens ≈ 2048 chars
   @max_chunk_chars 2048
+  @max_prefix_bytes 512
 
   @doc """
   Parse markdown content into indexable chunks.
@@ -62,16 +63,41 @@ defmodule Engram.Parsers.Markdown do
   # whole; and `frontmatter_chunk/3` never consulted a limit at all. Capping here
   # rather than in each one means every chunk — including any a future path adds
   # — flows through a single limit.
-  defp enforce_size_cap(%{text: text} = chunk) when byte_size(text) <= @max_chunk_chars do
+  #
+  # The cap covers `context_text`, NOT just `text`, and that distinction is the
+  # whole point: `text` is never what gets embedded. Bounding only `text` left
+  # the prefix — `folder > title > heading_path`, built from a `.+` match on one
+  # heading line and truncated nowhere — free to be arbitrary. A note whose H1
+  # is a 200KB pasted blob gave every one of its 99 chunks a 202KB
+  # `context_text` with a correctly-capped 2048-byte `text`, so each shipped as
+  # its own oversized single-input batch and 400'd on both the per-input and
+  # per-request token limits. Same poison loop, one field to the left.
+  defp enforce_size_cap(%{text: text, context_text: context_text} = chunk)
+       when byte_size(text) <= @max_chunk_chars and
+              byte_size(context_text) - byte_size(text) <= @max_prefix_bytes do
     [chunk]
   end
 
   defp enforce_size_cap(chunk) do
-    prefix = context_prefix_of(chunk)
+    prefix = chunk |> context_prefix_of() |> cap_prefix()
 
     chunk.text
     |> hard_split(@max_chunk_chars)
     |> Enum.map(&%{chunk | text: &1, context_text: prefix <> &1})
+  end
+
+  # A prefix is a breadcrumb, so 512 bytes is already far past any real
+  # `folder > title > h1 > h2`; anything longer is a pathological heading, not
+  # context worth keeping. Truncation goes through `hard_split/2` for the same
+  # reason the text cap does — a raw `binary_part` would halve a multibyte
+  # character, and CJK headings are exactly the input that reaches here.
+  #
+  # The separator is re-appended because `context_prefix_of/1` returns the
+  # prefix WITH its trailing "\n\n", which the truncation cuts off.
+  defp cap_prefix(prefix) when byte_size(prefix) <= @max_prefix_bytes, do: prefix
+
+  defp cap_prefix(prefix) do
+    (prefix |> hard_split(@max_prefix_bytes) |> hd()) <> "\n\n"
   end
 
   # Both construction sites build `context_text` as

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -132,8 +132,23 @@ defmodule Engram.Vector.Qdrant do
     # against 853 upserts, a 1:1:1 ratio, inside the slowest queue we have
     # (embed averages 738 ms). See #1501.
     #
-    # Keyed on the resolved base URL, not just the collection name, so the
-    # async Bypass suites stay isolated: each test's port is its own key.
+    # Keyed on the resolved base URL, not just the collection name. That was
+    # meant to keep the Bypass suites isolated — "each test's port is its own
+    # key" — and it does not, which is why the memo is OFF under `:test` (see
+    # `memo_enabled?/0`). A port is only unique while it is held: Bypass
+    # releases it on test exit and the OS hands the same number to a later
+    # `Bypass.open/0`, whose key then hits a marker the earlier test wrote.
+    # `ensure_collection/2` returns `:ok` having issued no request at all, and
+    # any test whose only HTTP comes from here dies in `Bypass`'s exit
+    # verification with "No HTTP request arrived at Bypass" — far from the
+    # cause, in a test that did nothing wrong. Measured directly: 8 requests on
+    # a cold memo, 0 after reopening Bypass on the same port.
+    #
+    # A blanket `forget_collection_memo/0` in shared setup is NOT the fix. It
+    # erases the whole namespace, so one async test would clear another's
+    # marker mid-run and add unexpected requests — and `indexing_test.exs` and
+    # `search_test.exs` both use `Bypass.expect_once`. That trades a
+    # missing-request flake for a surplus-request one.
     #
     # ONLY success is memoised. A failure erases the entry so the next caller
     # retries — otherwise one transient Qdrant blip would be cached for the
@@ -146,21 +161,32 @@ defmodule Engram.Vector.Qdrant do
     # transient Qdrant blip into several. Writing only on success closes that
     # window rather than cleaning up after it. Same `{__MODULE__, key}`
     # namespace, so `pt_erase_all/0` still finds these.
-    case :persistent_term.get({__MODULE__, key}, :__miss__) do
-      :ok ->
-        :ok
+    if memo_enabled?() do
+      case :persistent_term.get({__MODULE__, key}, :__miss__) do
+        :ok ->
+          :ok
 
-      :__miss__ ->
-        case do_ensure_collection(col, dims) do
-          :ok ->
-            :persistent_term.put({__MODULE__, key}, :ok)
-            :ok
+        :__miss__ ->
+          case do_ensure_collection(col, dims) do
+            :ok ->
+              :persistent_term.put({__MODULE__, key}, :ok)
+              :ok
 
-          {:error, _} = error ->
-            error
-        end
+            {:error, _} = error ->
+              error
+          end
+      end
+    else
+      do_ensure_collection(col, dims)
     end
   end
+
+  # Defaults to on, so prod and dev keep #1501's saving; `config/test.exs`
+  # turns it off. Switched rather than cleared because a switch cannot be
+  # defeated by test ordering — there is no marker to leak in the first place,
+  # so no async test can observe or erase another's. The one suite that exists
+  # to test the memo turns it back on for itself.
+  defp memo_enabled?, do: Application.get_env(:engram, :ensure_collection_memo, true)
 
   @doc """
   Drop the memoised "this collection is ready" marker for the current node.

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -164,9 +164,14 @@ defmodule Engram.IndexingTest do
       # Voyage caps a request at 120,000 tokens summed over its inputs, and a
       # count cannot bound that — tokens per byte swing with the content. 128
       # full-width chunks of dense, space-free text (base64, minified) is
-      # ~269KB, which is ~134K tokens at 2 bytes/token: a 400 no retry fixes.
-      # A space-free blob is exactly what the chunker's cap now slices into
-      # full-width chunks, so it is the shape that would regress.
+      # ~269KB: a 400 no retry fixes. A space-free blob is exactly what the
+      # chunker's cap slices into full-width chunks, so it is the shape that
+      # would regress.
+      #
+      # The ceiling asserted below is 120,000 BYTES, matching the token limit
+      # 1:1 on purpose. A token never spans less than one byte, so that bound
+      # holds for any content. The earlier 200,000 assumed 2 bytes/token and
+      # prod shipped batches at 1.39 — see the constant's comment.
       {:ok, dense_note} =
         Notes.upsert_note(user, vault, %{
           "path" => "Big/Dense.md",
@@ -198,7 +203,7 @@ defmodule Engram.IndexingTest do
       assert length(batches) >= 2
 
       Enum.each(batches, fn {count, bytes} ->
-        assert bytes <= 200_000, "embed batch of #{bytes} bytes exceeds the budget"
+        assert bytes <= 120_000, "embed batch of #{bytes} bytes exceeds the budget"
         assert count <= 128
       end)
 

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -168,7 +168,7 @@ defmodule Engram.IndexingTest do
       # chunker's cap slices into full-width chunks, so it is the shape that
       # would regress.
       #
-      # The ceiling asserted below is 120,000 BYTES, matching the token limit
+      # The ceiling asserted below is 118,000 BYTES, just under the token limit
       # 1:1 on purpose. A token never spans less than one byte, so that bound
       # holds for any content. The earlier 200,000 assumed 2 bytes/token and
       # prod shipped batches at 1.39 — see the constant's comment.
@@ -203,13 +203,69 @@ defmodule Engram.IndexingTest do
       assert length(batches) >= 2
 
       Enum.each(batches, fn {count, bytes} ->
-        assert bytes <= 120_000, "embed batch of #{bytes} bytes exceeds the budget"
+        assert bytes <= 118_000, "embed batch of #{bytes} bytes exceeds the budget"
         assert count <= 128
       end)
 
       # The byte ceiling must be the binding one here — if the count still
       # closed every batch, the token limit is as unguarded as before.
       assert Enum.any?(batches, fn {count, _bytes} -> count < 128 end)
+    end
+
+    test "an oversized heading cannot smuggle a chunk past the byte budget", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
+      # The batcher lets a single over-budget input through ALONE rather than
+      # dropping it, so anything that inflates one `context_text` past the
+      # ceiling bypasses the ceiling completely — one oversized request per
+      # chunk, 400 on both Voyage limits, poison loop.
+      #
+      # `context_text` is `folder > title > heading_path` + text, and the
+      # heading is a `.+` match on one line. Capping only `text` (as the first
+      # version of the chunk cap did) leaves the prefix unbounded: measured 99
+      # chunks each carrying a 202KB `context_text` behind a correctly-capped
+      # 2048-byte `text`. This asserts the cap covers the prefix too.
+      {:ok, heading_note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Big/Heading.md",
+          "content" =>
+            "# " <>
+              String.duplicate("A", 200_000) <>
+              "\n\nshort body.\n\n## Sub\n\nanother short body.\n",
+          "mtime" => 1_000.0
+        })
+
+      test_pid = self()
+
+      Engram.MockEmbedder
+      |> stub(:embed_texts, fn texts ->
+        send(test_pid, {:embed_batch, {length(texts), Enum.map(texts, &byte_size/1)}})
+        {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)}
+      end)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": true}))
+      end)
+
+      assert {:ok, _chunk_count} = Indexing.index_note(heading_note, vault)
+
+      batches = collect_messages(:embed_batch)
+      assert batches != []
+
+      # No SINGLE input may exceed the budget — that is the escape hatch, and
+      # asserting only on the batch sum would pass while it is wide open.
+      Enum.each(batches, fn {_count, sizes} ->
+        widest = Enum.max(sizes)
+
+        assert widest <= 118_000,
+               "a single embed input of #{widest} bytes bypasses the batch budget"
+
+        assert Enum.sum(sizes) <= 118_000
+      end)
     end
 
     test "upserts Qdrant points in batches of at most 256", %{

--- a/test/engram/vector/qdrant_ensure_collection_memo_test.exs
+++ b/test/engram/vector/qdrant_ensure_collection_memo_test.exs
@@ -19,6 +19,13 @@ defmodule Engram.Vector.QdrantEnsureCollectionMemoTest do
   alias Engram.Vector.Qdrant
 
   setup do
+    # The memo is OFF for the suite at large (`config/test.exs`) because its
+    # base-URL key is a recycled Bypass port, which leaks a "ready" marker
+    # between unrelated tests. This is the one module that exists to test the
+    # memo, so it opts itself back in.
+    Application.put_env(:engram, :ensure_collection_memo, true)
+    on_exit(fn -> Application.put_env(:engram, :ensure_collection_memo, false) end)
+
     # Node-wide memo: clear it around each test so ordering cannot leak a
     # "ready" marker from one case into another.
     Qdrant.forget_collection_memo()

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -1337,7 +1337,21 @@ defmodule EngramWeb.CrdtChannelTest do
       assert CrdtRegistry.lookup(doc_id) == room,
              "the room-free write evicted a room a live client was still using"
 
-      assert_note_content_eventually(user, vault, doc_id, "LIVE-base")
+      # Routed INTO a resident room, the write lands in the room's doc and the
+      # plaintext column converges on the room's checkpoint TIMER, not on the
+      # write. The handshake above sets no activity, so this first write takes
+      # the eager path: a fixed `@default_eager_ms` (250ms) before the
+      # checkpoint even starts. The default 500ms wait left 250ms for the
+      # schedule, the checkpoint transaction and the poll, and a loaded full
+      # suite blew it. Same convergence deadline the roomed leg of the genesis
+      # test already uses; the assertion itself is unchanged.
+      assert_note_content_eventually(
+        user,
+        vault,
+        doc_id,
+        "LIVE-base",
+        System.monotonic_time(:millisecond) + 2_000
+      )
     end
 
     test "rejects an unknown note_id with the same signal crdt_msg sends", %{socket: socket} do


### PR DESCRIPTION
## The problem

The six notes #1591 was meant to fix are **still poisoning after 0.26.0 deployed**. Prod, on worker task def `engram-worker-prod:11` (ECR digest tagged `sha-4791c55`, the 0.26.0 release commit):

| time (UTC) | tokens in batch | ceiling |
|---|---|---|
| 21:17:38 | 143,526 | 120,000 |
| 21:32:32 | 134,607 | 120,000 |
| 21:32:32 | 129,509 | 120,000 |

The `detail` field #1591 added is what named it — before that we only had `status: 400`:

```
Request to model 'voyage-4-large' failed. The max allowed tokens per submitted
batch is 120000. Your batch has 143526 tokens after truncation. Please lower
the number of tokens in the batch.
```

## Two bugs, same shape

**1. The batch ceiling was a density guess.** #1591 added a per-request byte ceiling of 200KB, justified as *"100K tokens at 2 bytes/token, the worst density we expect from base64/random input."* Prod disproved it within a day: a batch of at most 200,000 bytes produced 143,526 tokens — **1.39 bytes/token**.

Raising 2.0 to 1.4 just moves the guess. A token never spans less than one byte, so a byte ceiling bounds the token sum for any content and any tokenizer. Set to **118,000** rather than a flush 120,000 because `tokens <= bytes` covers tokens *derived* from content, not ones a tokenizer *inserts* — `[CLS]`/`[SEP]` at ~2 per input is 120,256 across 128 inputs.

**2. The ceiling had a bypass, found in review.** `Markdown.enforce_size_cap/1` returned early whenever `text` fit in 2048 bytes and never inspected `context_text` — but `context_text` is what `embed_texts/1` collects and what Voyage receives. Its prefix is `folder > title > heading_path`, built from a `.+` match on one heading line and truncated nowhere.

Measured on a note whose H1 is a 200KB pasted blob:

```
[85] text=2048B  context_text=202059B
[97] text=1369B  context_text=201380B
[98] text=27B    context_text=200044B
worst context_text: 202059 bytes
```

All 99 chunks. Each exceeds the ceiling alone, and `batch_texts/1` ships a single over-budget input **alone** rather than dropping it — so that note produced 99 oversized single-input requests, 400ing on both the per-input and per-request limits. The ceiling wasn't lowered past the problem; the problem walked around it.

The cap now covers the prefix (`@max_prefix_bytes 512`, truncated through `hard_split/2` so a CJK heading isn't halved mid-character), bounding `context_text` at ~2.5KB.

## Cost

Requests, not money — Voyage bills tokens. But not free: the byte cap now closes a batch whenever the average chunk exceeds ~937 bytes (`118,000/128`), which is ordinary prose, not just base64; under 200KB that threshold was ~1,562. Prod runs `VOYAGE_RPM=1600` through `Embedders.Voyage.throttle_check/1`, which synthesizes a 429 that `EmbedNote` answers with a 60s snooze (`EMBED_429_SNOOZE_SECONDS`). A bulk import trades wall-clock for correctness; the RPM is the knob if it bites.

## Tests

Both are verified load-bearing rather than assumed:

- Batch ceiling — with the constant back at `200_000`: `embed batch of 199917 bytes exceeds the budget`. Independently confirms batches really do reach ~200KB.
- Prefix cap — with the cap disabled: `a single embed input of 202056 bytes bypasses the batch budget`. Asserts on the **widest single input**, not the batch sum; a sum-only assertion passes with the escape hatch wide open.

`batch_texts/1`'s comment previously claimed "the chunker caps it long before here" — the assertion that hid bug 2. It now states the hatch is real and held shut only by the `context_text` cap.

## Recovery

No manual repair. `ReconcileEmbeddings` selects on `is_nil(embed_hash)`, which the parked notes still are, so they re-embed within 6h of deploy.

## Two unit-suite flakes fixed on the way

This PR's CI went red on tests it doesn't touch. Both turned out to be real bugs in the test setup, not bad luck, so they're fixed here rather than re-run.

**1. `IndexingLanguageTest`: "No HTTP request arrived at Bypass"** (`42d4febf`)

`Qdrant.ensure_collection/2` memoises "collection ready" in `:persistent_term`, keyed on the base URL. Under test, that URL contains a Bypass port. Bypass frees the port when a test exits and the OS hands it to a later test. That later test inherits the earlier marker and issues no request at all, so it fails Bypass's exit check.

Measured directly: 8 requests with a cold memo, 0 after reopening Bypass on the same port.

The memo now sits behind `:ensure_collection_memo`. It defaults to true, so prod keeps the #1501 saving, and `config/test.exs` sets it false. `QdrantEnsureCollectionMemoTest` turns it back on for its own tests. A blanket `forget_collection_memo/0` in shared setup was rejected: it wipes the whole namespace mid-run, which adds requests to async tests that use `Bypass.expect_once` (`indexing_test`, `search_test`).

**2. `CrdtChannelTest` "an ALREADY-resident room takes the update": `wait_until ... within 500ms`** (`5adeee79`)

This write goes into a resident room, so the note's plaintext column updates on the room's checkpoint timer, not when the write lands. The handshake records no activity, so the first write takes the eager path: a fixed 250ms `@default_eager_ms` before the checkpoint even starts. The 500ms default wait left 250ms for scheduling, the checkpoint transaction and polling.

Proven with `eager_ms: 480`: the old deadline fails every time with the CI error string, and the new 2,000ms deadline passes. That's the deadline the genesis test's roomed leg already uses, and the assertion is unchanged. I swept the whole file at `eager_ms: 480` and all 101 tests pass, so no other wait depends on the eager timer at 500ms.

## Verification

`mix format`, `mix credo --strict` (no issues), `mix dialyzer` (passed, 6 skipped / 0 unnecessary).

Full local suite on `5adeee79`: **5,195 tests, 0 failures**. It's the first clean full run on this branch. Before the flake fixes, the same suite failed 1 of 5,195 on each of the two tests above.

Refs #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGn1VTY4YQjg3xS5Xy98LS
