### PR TITLE
fix(search): chunking and embedding audit fixes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2393,6 +2393,18 @@ jobs:
           docker logs "$QDRANT_CONTAINER" 2>&1 | tail -20
           exit 1
 
+      # The container answered healthz and was still present at teardown, yet
+      # every test got econnrefused minutes later, so it went away in between
+      # and `docker rm -fv` destroyed the evidence. Capture state + logs at the
+      # moment it matters instead of guessing again.
+      - name: Qdrant state before tests
+        run: |
+          docker inspect --format 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}' "$QDRANT_CONTAINER"
+          docker port "$QDRANT_CONTAINER" 6333/tcp
+          curl -sS -o /dev/null -w 'healthz=%{http_code}\n' --max-time 5 \
+            "http://127.0.0.1:${{ steps.qdrant.outputs.qdrant_port }}/healthz"
+          docker logs --tail 20 "$QDRANT_CONTAINER" 2>&1 || true
+
       # Restore deps + _build/test compiled by `prebuild-mix`. Cache keys
       # are pinned via the prebuild-mix job's outputs, so this restore
       # matches exactly what was just compiled — `mix test` reuses the
@@ -2471,6 +2483,15 @@ jobs:
           # marker skip now saves far more than --stale ever did, because it
           # skips the compile too.
           mix test --warnings-as-errors --slowest 20
+
+      - name: Qdrant state after a test failure
+        if: failure()
+        run: |
+          docker ps -a --filter "name=$QDRANT_CONTAINER" --format '{{.Names}} {{.Status}}'
+          docker inspect --format 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} started={{.State.StartedAt}} finished={{.State.FinishedAt}}' "$QDRANT_CONTAINER" || true
+          curl -sS -o /dev/null -w 'healthz=%{http_code}\n' --max-time 5 \
+            "http://127.0.0.1:${{ steps.qdrant.outputs.qdrant_port }}/healthz" || echo "curl failed too"
+          docker logs --tail 50 "$QDRANT_CONTAINER" 2>&1 || true
 
       - name: OpenAPI spec drift gate
         env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2279,6 +2279,7 @@ jobs:
 
     env:
       PG_CONTAINER: engram-unit-test-${{ github.run_id }}
+      QDRANT_CONTAINER: engram-unit-test-qdrant-${{ github.run_id }}
 
     steps:
       - name: Reset sparse-checkout leaked from cross-repo jobs
@@ -2339,6 +2340,52 @@ jobs:
           echo "pg_port=$PG_PORT" >> "$GITHUB_OUTPUT"
           echo "Postgres on port $PG_PORT (container: $PG_CONTAINER)"
 
+      # Real Qdrant for the `:qdrant_integration` tests. Those tests existed
+      # but NO job ever set QDRANT_INTEGRATION=1, so they had never run in CI
+      # — and the bug class they catch (prod's Qdrant Cloud enforces strict
+      # mode, which 400s a filter on an un-indexed payload field; see #1609)
+      # is invisible to the Bypass suites, which answer 200 to anything.
+      # Ephemeral + random port, same pattern and port-race retry as postgres.
+      - name: Start ephemeral qdrant
+        id: qdrant
+        run: |
+          docker rm -f "$QDRANT_CONTAINER" 2>/dev/null || true
+
+          if [ -n "${LOCAL_REGISTRY:-}" ]; then
+            QDRANT_IMAGE="${LOCAL_REGISTRY}/qdrant/qdrant:v1.17.1"
+            docker pull "$QDRANT_IMAGE" 2>/dev/null || QDRANT_IMAGE="qdrant/qdrant:v1.17.1"
+          else
+            QDRANT_IMAGE="qdrant/qdrant:v1.17.1"
+          fi
+
+          for attempt in 1 2 3 4 5; do
+            if docker run -d --name "$QDRANT_CONTAINER" -p 0:6333 "$QDRANT_IMAGE"; then
+              break
+            fi
+            echo "Attempt $attempt: docker run failed (likely port race) — cleaning up + retrying"
+            docker rm -f "$QDRANT_CONTAINER" 2>/dev/null || true
+            sleep 1
+            if [ "$attempt" = "5" ]; then
+              echo "::error::Qdrant container failed to start after 5 attempts"
+              exit 1
+            fi
+          done
+
+          QDRANT_PORT=$(docker port "$QDRANT_CONTAINER" 6333/tcp | head -1 | cut -d: -f2)
+          echo "qdrant_port=$QDRANT_PORT" >> "$GITHUB_OUTPUT"
+          echo "Qdrant on port $QDRANT_PORT (container: $QDRANT_CONTAINER)"
+
+          for i in $(seq 1 30); do
+            if curl -sf --max-time 2 "http://localhost:${QDRANT_PORT}/healthz" > /dev/null 2>&1; then
+              echo "Qdrant ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Qdrant did not become ready in 30s"
+          docker logs "$QDRANT_CONTAINER" 2>&1 | tail -20
+          exit 1
+
       # Restore deps + _build/test compiled by `prebuild-mix`. Cache keys
       # are pinned via the prebuild-mix job's outputs, so this restore
       # matches exactly what was just compiled — `mix test` reuses the
@@ -2372,6 +2419,10 @@ jobs:
       - name: Run Elixir unit tests
         env:
           DATABASE_URL: postgresql://engram:engram@localhost:${{ steps.pg.outputs.pg_port }}/engram_test
+          # Opts the `:qdrant_integration` tests in (test_helper.exs excludes
+          # them otherwise) and points them at the ephemeral container.
+          QDRANT_INTEGRATION: "1"
+          QDRANT_URL: http://localhost:${{ steps.qdrant.outputs.qdrant_port }}
         run: |
           for i in $(seq 1 30); do
             if docker exec "$PG_CONTAINER" pg_isready -U engram > /dev/null 2>&1; then
@@ -2480,6 +2531,10 @@ jobs:
       - name: Stop ephemeral postgres
         if: always()
         run: docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
+
+      - name: Stop ephemeral qdrant
+        if: always()
+        run: docker rm -fv "$QDRANT_CONTAINER" 2>/dev/null || true
 
       - name: Clean temp files
         if: always()

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2358,8 +2358,12 @@ jobs:
             QDRANT_IMAGE="qdrant/qdrant:v1.17.1"
           fi
 
+          # Bind IPv4 explicitly. With a bare `-p 0:6333` docker publishes on
+          # 0.0.0.0 only, while the BEAM resolves `localhost` to ::1 first and
+          # gets ECONNREFUSED — curl falls back to IPv4 and hides it, so the
+          # readiness probe passed while every test failed to connect.
           for attempt in 1 2 3 4 5; do
-            if docker run -d --name "$QDRANT_CONTAINER" -p 0:6333 "$QDRANT_IMAGE"; then
+            if docker run -d --name "$QDRANT_CONTAINER" -p 127.0.0.1:0:6333 "$QDRANT_IMAGE"; then
               break
             fi
             echo "Attempt $attempt: docker run failed (likely port race) — cleaning up + retrying"
@@ -2371,12 +2375,15 @@ jobs:
             fi
           done
 
-          QDRANT_PORT=$(docker port "$QDRANT_CONTAINER" 6333/tcp | head -1 | cut -d: -f2)
+          # `awk -F: '{print $NF}'`, not `cut -d: -f2`: an IPv6 mapping line
+          # ([::]:32768) has several colons and would yield an empty port.
+          QDRANT_PORT=$(docker port "$QDRANT_CONTAINER" 6333/tcp | head -1 | awk -F: '{print $NF}')
           echo "qdrant_port=$QDRANT_PORT" >> "$GITHUB_OUTPUT"
           echo "Qdrant on port $QDRANT_PORT (container: $QDRANT_CONTAINER)"
 
+          # Probe the SAME address the tests use, or it proves nothing.
           for i in $(seq 1 30); do
-            if curl -sf --max-time 2 "http://localhost:${QDRANT_PORT}/healthz" > /dev/null 2>&1; then
+            if curl -sf --max-time 2 "http://127.0.0.1:${QDRANT_PORT}/healthz" > /dev/null 2>&1; then
               echo "Qdrant ready"
               exit 0
             fi
@@ -2422,7 +2429,9 @@ jobs:
           # Opts the `:qdrant_integration` tests in (test_helper.exs excludes
           # them otherwise) and points them at the ephemeral container.
           QDRANT_INTEGRATION: "1"
-          QDRANT_URL: http://localhost:${{ steps.qdrant.outputs.qdrant_port }}
+          # 127.0.0.1, not localhost: the container publishes on IPv4 and the
+          # BEAM would try ::1 first.
+          QDRANT_URL: http://127.0.0.1:${{ steps.qdrant.outputs.qdrant_port }}
         run: |
           for i in $(seq 1 30); do
             if docker exec "$PG_CONTAINER" pg_isready -U engram > /dev/null 2>&1; then

--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -5,10 +5,10 @@ Config.CSWH: Cross-Site Websocket Hijacking,lib/engram_web/endpoint.ex:45,6EA19F
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/crypto.ex:581,7EA51D6
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/crypto/user_dek_rotation.ex:1440,58BBE92
-Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:4698,441015D
-Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:5073,408825C
+Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:4702,5EEEC10
+Misc.BinToTerm: Unsafe `binary_to_term`,lib/engram/notes.ex:5077,75A4690
 SQL.Query: SQL injection,lib/engram/attachments.ex:1074,41475BB
-SQL.Query: SQL injection,lib/engram/notes.ex:6739,65B48CF
+SQL.Query: SQL injection,lib/engram/notes.ex:6743,110DF81
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/legal/seeder.ex:84,12C6307
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram/release/preflight.ex:114,30D4B80
 Traversal.FileModule: Directory Traversal in `File.read!`,lib/engram_web/controllers/spa_controller.ex:44,6BED2D7

--- a/docs/context/environment-variables.md
+++ b/docs/context/environment-variables.md
@@ -82,7 +82,7 @@ Live. This is regenerated from `config/runtime.exs` (the ~90 vars it reads), wit
 | `EMBED_BACKEND` | `voyage` | `voyage` or `ollama` (:85). |
 | `VOYAGE_API_KEY` | unset | Voyage AI key (used when backend = voyage) (:92). |
 | `EMBED_MODEL` | (compile-time) | Override symmetric embed model (:97). |
-| `EMBED_DIMS` | (compile-time) | Override vector dimensions (:101). |
+| `EMBED_DIMS` | (compile-time) | Override vector dimensions (:101). Sent to Voyage as `output_dimension` ONLY when set, because the older models (`voyage-2`, `voyage-3-lite`, `voyage-law-2`, ...) reject that field and would 400 every embed. Set it only on a model that accepts it: the `voyage-4` family, `voyage-3-large`, `voyage-3.5`, `voyage-code-3`. |
 | `DOC_EMBED_MODEL` | falls back to `EMBED_MODEL` | Asymmetric: doc-indexing model (:107). |
 | `QUERY_EMBED_MODEL` | falls back to `EMBED_MODEL` | Asymmetric: query model (:111). |
 | `EMBED_429_SNOOZE_SECONDS` | `60` | Voyage-429 snooze (worker reschedules without burning an attempt) (:118). |

--- a/docs/context/qdrant-payload-indexes-strict-mode.md
+++ b/docs/context/qdrant-payload-indexes-strict-mode.md
@@ -1,0 +1,44 @@
+# Context Doc: Qdrant payload indexes under strict mode
+
+_Last verified: 2026-09-11_
+
+## Status
+Fixed (#1609). `ensure_collection/2` now reconciles missing payload indexes on every boot.
+
+## Symptom
+- Folder, tag, OKF `type` and date filters return a 400 from Qdrant Cloud.
+- REST `/api/search` surfaces `{"error": "search_failed"}`; MCP `search_notes` says "Search unavailable."
+- Unfiltered search works, so it looks intermittent or filter-specific.
+- Staging (self-hosted Qdrant) does not enforce strict mode, so e2e cannot catch it. Only Qdrant Cloud (prod) does.
+
+## Verified on prod (2026-09-11)
+Qdrant 1.18.2, collection `engram_notes`:
+- `strict_mode_config.enabled=true`, `unindexed_filtering_retrieve=false`: a filter on an un-indexed field is rejected, not slow.
+- `payload_schema` held only `user_id, vault_id, note_id, path_hmac`.
+
+## Root Cause
+Until #1609, payload indexes were created only right after a FRESH collection create (the `{:ok, :created}` branch). Any field added to `@payload_index_fields` later (`type_hmac`, `fm_timestamp`, `fm_created`) never reached an already-existing collection. `folder_hmac` and `tags_hmac` were filtered on but never listed at all.
+
+## Fix (#1609)
+`do_ensure_collection/2` calls `ensure_payload_indexes/2` on both branches. On a 409 (exists), `verify_collection_shape/1` already GETs `collection_info`; it now also returns the `payload_schema` keys, and only the missing fields get a `PUT /collections/<col>/index?wait=true`. A fully indexed collection costs no extra requests. The whole call is memoised per node in `:persistent_term` (#1501), so this runs once per boot.
+
+## Rule going forward
+Any new filter key MUST be added to `@payload_index_fields` (keyword: equality/any-match) or `@integer_payload_index_fields` (range). It then self-heals on the next deploy. A filter key missing from both lists works on staging and 400s on prod.
+
+## Checking prod (read-only)
+1. Capture the key into a shell variable, never echo it: `KEY=$(./bin/sops-get prod qdrant_api_key --show)`. The script lives in the engram-infra repo (`bin/sops-get`), so run it from there.
+2. `GET <QDRANT_URL>/collections/engram_notes` with header `api-key: $KEY`.
+3. Read `.result.payload_schema` (which fields are indexed) and `.result.config.strict_mode_config`.
+
+## Gotchas
+- **Known ceiling (the `ponytail:` comment in `ensure_payload_indexes/2`):** if `collection_info` is unreadable at boot, `verify_collection_shape/1` returns `:unknown`, the index check is skipped, and the memo holds `:ok` until the node restarts. Another node or the next boot reconciles.
+- A collection dropped or recreated out of band needs `forget_collection_memo/0`, or the node keeps skipping `ensure_collection`.
+- Staging green says nothing about filters. Check prod `payload_schema` when a filter-only search fails.
+
+## File Anchors
+- `lib/engram/vector/qdrant.ex`: `@payload_index_fields`, `@integer_payload_index_fields`, `ensure_collection/2`, `ensure_payload_indexes/2`, `verify_collection_shape/1`
+- `test/engram/vector/qdrant_collection_test.exs`
+- `lib/engram_web/controllers/search_controller.ex` (`search_failed`), `lib/engram/mcp/handlers.ex` (`render_search/2`)
+
+## References
+- Issue #1609 (this fix), #626 (original index list), #1501 (per-node memo)

--- a/lib/engram/embedders/voyage.ex
+++ b/lib/engram/embedders/voyage.ex
@@ -109,7 +109,18 @@ defmodule Engram.Embedders.Voyage do
       Req.post(
         "#{url}/v1/embeddings",
         [
-          json: %{input: texts, model: model},
+          json: %{
+            input: texts,
+            model: model,
+            # #1614: Voyage prepends its retrieval prompts only when told which
+            # side an input is on, and its docs say not to omit this for
+            # retrieval. Vectors with and without it are compatible, so the
+            # existing index needs no re-embed.
+            input_type: input_type(purpose),
+            # Without this, a non-default EMBED_DIMS disagrees with the 1024-d
+            # vectors Voyage returns and every upsert 400s.
+            output_dimension: ServiceConfig.get(:embed_dims, 1024)
+          },
           headers: [{"authorization", "Bearer #{api_key}"}]
         ] ++ Keyword.merge(request_defaults(purpose), req_opts)
       )
@@ -127,6 +138,9 @@ defmodule Engram.Embedders.Voyage do
         {:error, reason}
     end
   end
+
+  defp input_type(:query), do: "query"
+  defp input_type(_purpose), do: "document"
 
   # Voyage's `/v1/embeddings` 200 response always carries a `usage` object
   # with `total_tokens`. The field is the only billing-relevant signal — no

--- a/lib/engram/embedders/voyage.ex
+++ b/lib/engram/embedders/voyage.ex
@@ -105,22 +105,23 @@ defmodule Engram.Embedders.Voyage do
     {req_opts, _} = Keyword.split(opts, [:retry, :max_retries, :receive_timeout])
     purpose = Keyword.get(opts, :purpose, :index)
 
+    body =
+      %{
+        input: texts,
+        model: model,
+        # #1614: Voyage prepends its retrieval prompts only when told which
+        # side an input is on, and its docs say not to omit this for
+        # retrieval. Vectors with and without it are compatible, so the
+        # existing index needs no re-embed.
+        input_type: input_type(purpose)
+      }
+      |> maybe_put_output_dimension()
+
     result =
       Req.post(
         "#{url}/v1/embeddings",
         [
-          json: %{
-            input: texts,
-            model: model,
-            # #1614: Voyage prepends its retrieval prompts only when told which
-            # side an input is on, and its docs say not to omit this for
-            # retrieval. Vectors with and without it are compatible, so the
-            # existing index needs no re-embed.
-            input_type: input_type(purpose),
-            # Without this, a non-default EMBED_DIMS disagrees with the 1024-d
-            # vectors Voyage returns and every upsert 400s.
-            output_dimension: ServiceConfig.get(:embed_dims, 1024)
-          },
+          json: body,
           headers: [{"authorization", "Bearer #{api_key}"}]
         ] ++ Keyword.merge(request_defaults(purpose), req_opts)
       )
@@ -141,6 +142,18 @@ defmodule Engram.Embedders.Voyage do
 
   defp input_type(:query), do: "query"
   defp input_type(_purpose), do: "document"
+
+  # Sent ONLY when an operator set EMBED_DIMS. Without it Voyage returns its
+  # default width, which is what an unconfigured deployment already stores, and
+  # the older models (voyage-2, voyage-law-2, ...) reject the field outright —
+  # sending an unasked-for 1024 would 400 every embed for a self-hoster on one.
+  # A deployment that moves off the default sets EMBED_DIMS and gets it.
+  defp maybe_put_output_dimension(body) do
+    case ServiceConfig.get(:embed_dims) do
+      nil -> body
+      dims -> Map.put(body, :output_dimension, dims)
+    end
+  end
 
   # Voyage's `/v1/embeddings` 200 response always carries a `usage` object
   # with `total_tokens`. The field is the only billing-relevant signal — no

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -40,6 +40,16 @@ defmodule Engram.Indexing do
   commit step inside a per-note `Repo.with_tenant/2`.
   """
   def index_note(note, %Engram.Vaults.Vault{} = vault, user \\ nil) do
+    with {:ok, count, _embedded_bytes} <- index_note_with_usage(note, vault, user),
+         do: {:ok, count}
+  end
+
+  @doc """
+  `index_note/3`, plus the bytes this pass actually sent to the embedder
+  (#1618). Chunk reuse makes that a small part of most edits, and a
+  keyword-only pass sends nothing. Returns `{:ok, chunk_count, embedded_bytes}`.
+  """
+  def index_note_with_usage(note, %Engram.Vaults.Vault{} = vault, user \\ nil) do
     # Resolve identity ONCE for the whole call. This function and
     # prepare_index/3 below both need the same `%User{}`, and both used to
     # fetch it independently — on the embed path that made four `get_user!`
@@ -72,7 +82,7 @@ defmodule Engram.Indexing do
             # Returning the error costs one Oban retry.
             with :ok <- purge_stale_index(note) do
               :ok = Engram.Links.replace_links(user, vault, note.id, link_rows)
-              {:ok, 0}
+              {:ok, 0, 0}
             end
 
           {:error, :no_dek} = err ->
@@ -81,7 +91,8 @@ defmodule Engram.Indexing do
         end
 
       {:ok, prepared} ->
-        commit_index(prepared)
+        with {:ok, count} <- commit_index(prepared),
+             do: {:ok, count, prepared.embedded_bytes}
 
       {:error, _} = err ->
         err
@@ -130,9 +141,16 @@ defmodule Engram.Indexing do
              plan = plan_chunks(note, chunks, content_key, semantic?),
              texts = embed_texts(plan),
              {:ok, vectors} <- maybe_embed(semantic?, texts),
-             :ok <- ensure_one_vector_per_text(vectors, texts, note) do
-          avgdl = Engram.KeywordIndex.Stats.avgdl(note.vault_id)
-          build_prepared(note, user, vault, plan, vectors, filter_key, avgdl, link_rows)
+             :ok <- ensure_one_vector_per_text(vectors, texts, note),
+             avgdl = Engram.KeywordIndex.Stats.avgdl(note.vault_id),
+             {:ok, prepared} <-
+               build_prepared(note, user, vault, plan, vectors, filter_key, avgdl, link_rows) do
+          # What the embedder was actually sent (#1618): reused chunks and
+          # keyword-only passes cost nothing, so the meter must not bill them.
+          embedded_bytes =
+            if semantic?, do: texts |> Enum.map(&byte_size/1) |> Enum.sum(), else: 0
+
+          {:ok, Map.put(prepared, :embedded_bytes, embedded_bytes)}
         else
           {:error, :no_dek} = err ->
             emit_no_dek_telemetry(note)

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -127,7 +127,7 @@ defmodule Engram.Indexing do
         with :ok <- Qdrant.ensure_collection(collection(), dims),
              {:ok, filter_key} <- Crypto.dek_filter_key(user),
              {:ok, content_key} <- Crypto.dek_content_hash_key(user),
-             plan = plan_chunks(note, chunks, content_key),
+             plan = plan_chunks(note, chunks, content_key, semantic?),
              texts = embed_texts(plan),
              {:ok, vectors} <- maybe_embed(semantic?, texts),
              :ok <- ensure_one_vector_per_text(vectors, texts, note) do
@@ -572,10 +572,10 @@ defmodule Engram.Indexing do
   # Matched by multiplicity, not by set membership: a note with two identical
   # sections has two rows under one hmac and must consume one point each, or
   # the second chunk silently adopts the first one's point.
-  defp plan_chunks(note, chunks, content_key) do
+  defp plan_chunks(note, chunks, content_key, semantic?) do
     chunks =
       Enum.map(chunks, fn chunk ->
-        Map.put(chunk, :context_hmac, Crypto.hmac_content_hash(content_key, chunk.context_text))
+        Map.put(chunk, :context_hmac, fingerprint(content_key, chunk.context_text, semantic?))
       end)
 
     existing =
@@ -614,6 +614,19 @@ defmodule Engram.Indexing do
       reused_point_ids: reused,
       stale_point_ids: Enum.map(existing, fn {_h, id, _t} -> id end) -- reused
     }
+  end
+
+  # What a point HOLDS is part of the fingerprint, not just its text (#1606).
+  # A keyword-only point has no dense vector: matching it after an upgrade
+  # stamped the note densely indexed with nothing behind the stamp, and a
+  # downgrade kept vectors the tier no longer grants. The model is in it for
+  # the same reason, since another model's vector is not reusable either.
+  defp fingerprint(content_key, context_text, true) do
+    Crypto.hmac_content_hash(content_key, "dense:#{doc_embed_model()}\n" <> context_text)
+  end
+
+  defp fingerprint(content_key, context_text, false) do
+    Crypto.hmac_content_hash(content_key, "sparse\n" <> context_text)
   end
 
   defp embed_texts(plan), do: for({:embed, chunk} <- plan.entries, do: chunk.context_text)

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -467,6 +467,13 @@ defmodule Engram.Indexing do
 
   defp doc_embed_model, do: Application.get_env(:engram, :doc_embed_model)
 
+  # `do_embed_batch/1` passes `:doc_embed_model` only when it is set, and the
+  # embedder falls back to `:embed_model` otherwise. The reuse fingerprint has
+  # to name the model actually used, or changing EMBED_MODEL with
+  # DOC_EMBED_MODEL unset leaves every hmac identical and the collection
+  # silently mixes two models' embedding spaces (#1606).
+  defp effective_embed_model, do: doc_embed_model() || Application.get_env(:engram, :embed_model)
+
   # Voyage caps a request two ways: 1,000 texts AND 120,000 tokens summed over
   # them. Blowing either is a 400 no retry can fix, so the job churns through
   # ReconcileEmbeddings forever.
@@ -640,7 +647,7 @@ defmodule Engram.Indexing do
   # downgrade kept vectors the tier no longer grants. The model is in it for
   # the same reason, since another model's vector is not reusable either.
   defp fingerprint(content_key, context_text, true) do
-    Crypto.hmac_content_hash(content_key, "dense:#{doc_embed_model()}\n" <> context_text)
+    Crypto.hmac_content_hash(content_key, "dense:#{effective_embed_model()}\n" <> context_text)
   end
 
   defp fingerprint(content_key, context_text, false) do

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -143,11 +143,12 @@ defmodule Engram.Notes do
   (Qdrant Cloud is a separate breach surface). The canonical values live
   only in the encrypted `notes` row, so search rehydrates them here keyed by
   the `chunks.qdrant_point_id → note_id` mapping. Tenant-scoped + decrypted
-  as one instrumented batch. Point ids with no live note row are omitted —
-  the caller leaves such candidates' display fields untouched.
+  as one instrumented batch. Point ids with no note row are omitted — the
+  caller leaves such candidates' display fields untouched. A point whose note
+  is soft-deleted maps to `:deleted` so the caller can drop the hit (#1608).
   """
   @spec display_fields_by_qdrant_points(Engram.Accounts.User.t(), [String.t()]) ::
-          %{String.t() => %{source_path: String.t() | nil, tags: [String.t()]}}
+          %{String.t() => %{source_path: String.t() | nil, tags: [String.t()]} | :deleted}
   def display_fields_by_qdrant_points(_user, []), do: %{}
 
   def display_fields_by_qdrant_points(user, qdrant_ids) when is_list(qdrant_ids) do
@@ -172,6 +173,9 @@ defmodule Engram.Notes do
     |> Crypto.decrypt_notes_batch(user)
     |> Enum.zip(qids)
     |> Enum.reduce(%{}, fn
+      {{:ok, %{deleted_at: %DateTime{}}}, qid}, acc ->
+        Map.put(acc, to_string(qid), :deleted)
+
       {{:ok, note}, qid}, acc ->
         Map.put(acc, to_string(qid), %{source_path: note.path, tags: note.tags || []})
 

--- a/lib/engram/parsers/markdown.ex
+++ b/lib/engram/parsers/markdown.ex
@@ -30,6 +30,9 @@ defmodule Engram.Parsers.Markdown do
   def parse("", _path), do: []
 
   def parse(content, path) do
+    # The frontmatter codec and the heading patterns all expect LF, so a CRLF
+    # note lost its frontmatter chunk and had its body cut short (#1605).
+    content = String.replace(content, "\r\n", "\n")
     folder = extract_folder(path)
     title = Helpers.extract_title(content, path)
     body = strip_frontmatter(content)
@@ -187,11 +190,14 @@ defmodule Engram.Parsers.Markdown do
   # Frontmatter
   # ---------------------------------------------------------------------------
 
+  # The same split `frontmatter_chunk/3` uses, so the body and the frontmatter
+  # chunk always agree on where the block ends. The regex this replaced took a
+  # BYTE length and sliced by GRAPHEME, so each multibyte character in the
+  # frontmatter cut one more from the start of the body, and it missed a
+  # closing fence at EOF that the split accepts, indexing that block twice.
   defp strip_frontmatter(content) do
-    case Regex.run(~r/\A---\s*\n.*?\n---\s*\n/s, content, return: :index) do
-      [{0, len}] -> String.slice(content, len, byte_size(content))
-      _ -> content
-    end
+    {_block, body} = Engram.Notes.Frontmatter.split(content)
+    body
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -340,8 +340,11 @@ defmodule Engram.Search do
 
               {:ok, final}
             else
-              diversified = MMR.rerank(ranked, limit, diversity)
-              {:ok, rehydrate_display_fields(diversified, user)}
+              # Rehydrate BEFORE the MMR pass so a soft-deleted hit is dropped
+              # while the pool can still backfill its slot. Dropping after left
+              # a page short of `limit` (#1608).
+              live = rehydrate_display_fields(ranked, user)
+              {:ok, MMR.rerank(live, limit, diversity)}
             end
           end
         end

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -574,7 +574,10 @@ defmodule Engram.Search do
   # #590: Qdrant payloads no longer carry plaintext source_path/tags. Refill
   # them on the final (post-rerank) result set from the encrypted `notes`
   # rows, keyed by qdrant_point_id. Candidates whose note row is missing keep
-  # whatever the payload provided (nil), rather than dropping the hit.
+  # whatever the payload provided (nil), rather than dropping the hit. A hit
+  # whose note is soft-deleted IS dropped: its points outlive the delete until
+  # DeleteNoteIndex succeeds, and they must not answer searches meanwhile
+  # (#1608).
   defp rehydrate_display_fields([], _user), do: []
 
   defp rehydrate_display_fields(results, user) do
@@ -583,13 +586,16 @@ defmodule Engram.Search do
 
     fields_by_qid = Engram.Notes.display_fields_by_qdrant_points(user, qdrant_ids)
 
-    Enum.map(results, fn result ->
+    Enum.flat_map(results, fn result ->
       case Map.get(fields_by_qid, Map.get(result, :qdrant_id)) do
         %{source_path: source_path, tags: tags} ->
-          result |> Map.put(:source_path, source_path) |> Map.put(:tags, tags)
+          [result |> Map.put(:source_path, source_path) |> Map.put(:tags, tags)]
+
+        :deleted ->
+          []
 
         nil ->
-          result
+          [result]
       end
     end)
   end

--- a/lib/engram/search/mmr.ex
+++ b/lib/engram/search/mmr.ex
@@ -8,6 +8,13 @@ defmodule Engram.Search.MMR do
   cosine similarity between dense vectors. `d` (diversity) ∈ [0,1].
 
   `d == 0.0` short-circuits to the relevance order (no vectors required).
+
+  Cost is O(pool × limit) dot products (#1617). Vectors are normalised once so
+  a cosine is a plain dot product, and each candidate carries its running max
+  similarity to the picked set, so a step compares against the newest pick
+  only. The previous version recomputed full cosines against every pick on
+  every step and deep-compared 1024-float maps to drop the pick: 76s of CPU
+  for one limit-50 request over a ~200 pool.
   """
 
   @spec rerank([map()], pos_integer(), float()) :: [map()]
@@ -18,7 +25,7 @@ defmodule Engram.Search.MMR do
 
   def rerank(candidates, limit, diversity)
       when is_list(candidates) and is_number(diversity) do
-    normed = normalize_relevance(candidates)
+    normed = prepare(candidates)
 
     select(normed, [], min(limit, length(normed)), diversity)
     |> Enum.reverse()
@@ -31,48 +38,48 @@ defmodule Engram.Search.MMR do
   defp select([], acc, _n, _d), do: acc
 
   defp select(remaining, acc, n, d) do
-    best =
-      Enum.max_by(remaining, fn item ->
-        mmr_score(item, acc, d)
-      end)
+    # `max_by` keeps the FIRST maximum, so ties still resolve in pool order.
+    {best, best_idx} =
+      remaining
+      |> Enum.with_index()
+      |> Enum.max_by(fn {item, _idx} -> mmr_score(item, acc, d) end)
 
-    select(remaining -- [best], [best | acc], n - 1, d)
+    rest =
+      for {item, idx} <- Enum.with_index(remaining), idx != best_idx do
+        %{item | max_sim: running_max(item.max_sim, dot(item.unit, best.unit))}
+      end
+
+    select(rest, [best | acc], n - 1, d)
   end
 
   defp mmr_score(item, [], _d), do: item.rel
+  defp mmr_score(item, _selected, d), do: (1.0 - d) * item.rel - d * item.max_sim
 
-  defp mmr_score(item, selected, d) do
-    max_sim =
-      selected
-      |> Enum.map(fn s ->
-        cosine(Map.get(item.candidate, :vector), Map.get(s.candidate, :vector))
-      end)
-      |> Enum.max(fn -> 0.0 end)
-
-    (1.0 - d) * item.rel - d * max_sim
-  end
+  defp running_max(nil, sim), do: sim
+  defp running_max(prev, sim), do: max(prev, sim)
 
   # ── helpers ───────────────────────────────────────────────────────
 
-  defp normalize_relevance(candidates) do
+  defp prepare(candidates) do
     scores = Enum.map(candidates, & &1.score)
     {min_s, max_s} = {Enum.min(scores, fn -> 0.0 end), Enum.max(scores, fn -> 0.0 end)}
     range = max_s - min_s
 
     Enum.map(candidates, fn cand ->
       rel = if range == 0.0, do: 1.0, else: (cand.score - min_s) / range
-      %{candidate: cand, rel: rel}
+      %{candidate: cand, rel: rel, unit: unit(Map.get(cand, :vector)), max_sim: nil}
     end)
   end
 
-  # Cosine similarity in [-1,1]; nil vectors → 0.0 (no penalty).
-  defp cosine(nil, _), do: 0.0
-  defp cosine(_, nil), do: 0.0
+  # A nil or zero vector has no direction: similarity 0.0 (no penalty).
+  defp unit(nil), do: nil
 
-  defp cosine(a, b) when is_list(a) and is_list(b) do
-    dot = a |> Enum.zip(b) |> Enum.reduce(0.0, fn {x, y}, acc -> acc + x * y end)
-    mag_a = :math.sqrt(Enum.reduce(a, 0.0, fn x, acc -> acc + x * x end))
-    mag_b = :math.sqrt(Enum.reduce(b, 0.0, fn x, acc -> acc + x * x end))
-    if mag_a == 0.0 or mag_b == 0.0, do: 0.0, else: dot / (mag_a * mag_b)
+  defp unit(v) when is_list(v) do
+    mag = :math.sqrt(Enum.reduce(v, 0.0, fn x, acc -> acc + x * x end))
+    if mag == 0.0, do: nil, else: Enum.map(v, &(&1 / mag))
   end
+
+  defp dot(nil, _), do: 0.0
+  defp dot(_, nil), do: 0.0
+  defp dot(a, b), do: Enum.zip_reduce(a, b, 0.0, fn x, y, acc -> acc + x * y end)
 end

--- a/lib/engram/usage_meters.ex
+++ b/lib/engram/usage_meters.ex
@@ -88,10 +88,9 @@ defmodule Engram.UsageMeters do
   against the user). Real `usage.total_tokens` from the Voyage response is a
   follow-up.
   """
-  @spec estimate_tokens(binary()) :: non_neg_integer()
-  def estimate_tokens(content) when is_binary(content) do
-    div(byte_size(content) + 3, 4)
-  end
+  @spec estimate_tokens(binary() | non_neg_integer()) :: non_neg_integer()
+  def estimate_tokens(content) when is_binary(content), do: estimate_tokens(byte_size(content))
+  def estimate_tokens(bytes) when is_integer(bytes) and bytes >= 0, do: div(bytes + 3, 4)
 
   def estimate_tokens(_), do: 0
 

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -164,8 +164,15 @@ defmodule Engram.Vector.Qdrant do
 
         :__miss__ ->
           case do_ensure_collection(col, dims) do
-            :ok ->
+            {:ok, :verified} ->
               :persistent_term.put({__MODULE__, key}, :ok)
+              :ok
+
+            # Shape and indexes could not be read, so nothing is proven and
+            # nothing is cached: the next caller checks again. Caching it would
+            # strand a node without the payload indexes strict-mode filtering
+            # needs until it restarts, which is the #1609 failure itself.
+            {:ok, :unverified} ->
               :ok
 
             {:error, _} = error ->
@@ -173,7 +180,7 @@ defmodule Engram.Vector.Qdrant do
           end
       end
     else
-      do_ensure_collection(col, dims)
+      with {:ok, _} <- do_ensure_collection(col, dims), do: :ok
     end
   end
 
@@ -197,9 +204,17 @@ defmodule Engram.Vector.Qdrant do
 
   defp do_ensure_collection(col, dims) do
     case create_collection(col, dims) do
-      {:ok, :created} -> ensure_payload_indexes(col, MapSet.new())
-      {:ok, {:exists, indexed}} -> ensure_payload_indexes(col, indexed)
-      {:error, _} = error -> error
+      {:ok, :created} ->
+        with :ok <- ensure_payload_indexes(col, MapSet.new()), do: {:ok, :verified}
+
+      {:ok, {:exists, :unknown}} ->
+        {:ok, :unverified}
+
+      {:ok, {:exists, indexed}} ->
+        with :ok <- ensure_payload_indexes(col, indexed), do: {:ok, :verified}
+
+      {:error, _} = error ->
+        error
     end
   end
 
@@ -248,11 +263,6 @@ defmodule Engram.Vector.Qdrant do
   # collection that already existed: prod indexed only the first four, and
   # strict mode 400'd every folder, tag, type and date filter.
   #
-  # ponytail: `:unknown` (collection_info unreadable) skips the check, and the
-  # memo then holds `:ok` until the node restarts. Another node or the next
-  # boot reconciles; make it retry if a transient read ever strands an index.
-  defp ensure_payload_indexes(_col, :unknown), do: :ok
-
   defp ensure_payload_indexes(col, indexed) do
     keyword = Enum.map(@payload_index_fields, &{&1, "keyword"})
     integer = Enum.map(@integer_payload_index_fields, &{&1, "integer"})
@@ -268,7 +278,12 @@ defmodule Engram.Vector.Qdrant do
   end
 
   defp create_payload_index(col, field, schema) do
-    opts = [json: %{field_name: field, field_schema: schema}] ++ req_opts()
+    # `?wait=true` blocks until the index is built over every existing point,
+    # which on a large collection outlasts the default indexing budget. A
+    # timeout here fails `ensure_collection` (deliberately not memoised), so
+    # every retrying job would re-issue the same build. Give it its own.
+    opts =
+      [json: %{field_name: field, field_schema: schema}, receive_timeout: 120_000] ++ req_opts()
 
     instrument(:create_payload_index, fn ->
       case Req.put("#{base_url()}/collections/#{col}/index?wait=true", opts) do

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -20,8 +20,9 @@ defmodule Engram.Vector.Qdrant do
   # index before any upsert/search/delete. `note_id` is not a live filter key
   # today (deletes resolve via `path_hmac`) but is indexed to match the prod
   # collection + future-proof. See #626. `type_hmac` is the OKF frontmatter
-  # `type` blind index (spec 2026-07-02).
-  @payload_index_fields ~w(user_id vault_id note_id path_hmac type_hmac)
+  # `type` blind index (spec 2026-07-02). `folder_hmac`/`tags_hmac` are the
+  # folder and tag search filters (#1609).
+  @payload_index_fields ~w(user_id vault_id note_id path_hmac type_hmac folder_hmac tags_hmac)
 
   # OKF frontmatter dates are stored plaintext (see build_prepared/6) so
   # Qdrant can range-filter on them; they need an integer payload index
@@ -105,20 +106,15 @@ defmodule Engram.Vector.Qdrant do
   Ensure a collection exists with the given vector dimensions.
   Creates it if missing; no-ops if already present (Qdrant returns 200 either way).
 
-  On a fresh create, also creates the keyword/integer payload indexes every
-  tenant-scoped filter depends on (#626, extended for OKF frontmatter fields).
-  An existing collection already carries them (indexes persist), so the
-  steady-state path skips the work: the only way to lose them is a
-  drop+recreate, which re-enters the create branch.
+  Also creates the keyword/integer payload indexes every tenant-scoped filter
+  depends on (#626, extended for OKF frontmatter fields). On an existing
+  collection it creates only the ones its `payload_schema` lacks (#1609), so
+  a field added to the list later reaches an already-deployed collection on
+  the next boot instead of needing an out-of-band PUT.
 
-  NOTE: `ensure_collection` runs on every note index (see
-  `Indexing.prepare_index/2`), so the `:exists` branch is a hot path. It
-  intentionally does NOT re-run `ensure_payload_indexes/1`, even though that
-  PUT is idempotent, to avoid adding several extra Qdrant round trips to
-  every single note embed. An already-deployed collection that predates a
-  newly-added index field (like this task's `type_hmac`/`fm_timestamp`/
-  `fm_created`) needs that index created once out-of-band, same procedure
-  as #626.
+  Cost: the `payload_schema` comes from the `collection_info` GET the shape
+  check already makes, so a fully indexed collection adds no requests. The
+  whole call is memoised per node (#1501), so this runs once per boot.
   """
   def ensure_collection(col \\ nil, dims) do
     col = col || collection()
@@ -201,8 +197,8 @@ defmodule Engram.Vector.Qdrant do
 
   defp do_ensure_collection(col, dims) do
     case create_collection(col, dims) do
-      {:ok, :created} -> ensure_payload_indexes(col)
-      {:ok, :exists} -> :ok
+      {:ok, :created} -> ensure_payload_indexes(col, MapSet.new())
+      {:ok, {:exists, indexed}} -> ensure_payload_indexes(col, indexed)
       {:error, _} = error -> error
     end
   end
@@ -236,22 +232,34 @@ defmodule Engram.Vector.Qdrant do
   end
 
   # 409 means the collection already exists. Confirm its shape is compatible
-  # and report `:exists` so the caller skips (re-)creating payload indexes,
-  # which an existing collection already carries.
+  # and report which fields it already indexes.
   defp existing_collection(col) do
-    with :ok <- verify_collection_shape(col), do: {:ok, :exists}
+    with {:ok, indexed} <- verify_collection_shape(col), do: {:ok, {:exists, indexed}}
   end
 
-  # Create a payload index per filtered field, right after a fresh
-  # collection create. `?wait=true` blocks until each index is ready so the
-  # first upsert can't race an unbuilt index. Stops at the first failure so a
-  # real error surfaces. Keyword fields are equality/any-match filters;
-  # integer fields (the OKF dates) are range filters.
-  defp ensure_payload_indexes(col) do
+  # Create a payload index for every filtered field the collection lacks.
+  # `?wait=true` blocks until each index is ready so the next upsert or search
+  # can't race an unbuilt one. Stops at the first failure so a real error
+  # surfaces (and is not memoised). Keyword fields are equality/any-match
+  # filters; integer fields (the OKF dates) are range filters.
+  #
+  # Runs on an EXISTING collection too, not just after a fresh create (#1609).
+  # Create-only meant a field added to the list later never reached a
+  # collection that already existed: prod indexed only the first four, and
+  # strict mode 400'd every folder, tag, type and date filter.
+  #
+  # ponytail: `:unknown` (collection_info unreadable) skips the check, and the
+  # memo then holds `:ok` until the node restarts. Another node or the next
+  # boot reconciles; make it retry if a transient read ever strands an index.
+  defp ensure_payload_indexes(_col, :unknown), do: :ok
+
+  defp ensure_payload_indexes(col, indexed) do
     keyword = Enum.map(@payload_index_fields, &{&1, "keyword"})
     integer = Enum.map(@integer_payload_index_fields, &{&1, "integer"})
 
-    Enum.reduce_while(keyword ++ integer, :ok, fn {field, schema}, :ok ->
+    (keyword ++ integer)
+    |> Enum.reject(fn {field, _schema} -> MapSet.member?(indexed, field) end)
+    |> Enum.reduce_while(:ok, fn {field, schema}, :ok ->
       case create_payload_index(col, field, schema) do
         :ok -> {:cont, :ok}
         error -> {:halt, error}
@@ -277,12 +285,12 @@ defmodule Engram.Vector.Qdrant do
   # collection is recreated (wipeable); this guard catches a stale deploy.
   defp verify_collection_shape(col) do
     case collection_info(col) do
-      {:ok, %{"config" => %{"params" => params}}} ->
+      {:ok, %{"config" => %{"params" => params}} = info} ->
         vectors = params["vectors"] || %{}
         sparse = params["sparse_vectors"] || %{}
 
         if is_map(vectors) and Map.has_key?(vectors, "dense") and Map.has_key?(sparse, "keyword") do
-          :ok
+          {:ok, indexed_fields(info)}
         else
           {:error, {:incompatible_collection_schema, col}}
         end
@@ -290,9 +298,11 @@ defmodule Engram.Vector.Qdrant do
       _ ->
         # Couldn't read collection info — don't block indexing on a transient
         # read error; the upsert will surface a real failure if shape is wrong.
-        :ok
+        {:ok, :unknown}
     end
   end
+
+  defp indexed_fields(info), do: MapSet.new(Map.keys(info["payload_schema"] || %{}))
 
   @doc """
   Delete a collection. Idempotent: returns `:ok` for both 200 and 404.

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -461,7 +461,11 @@ defmodule Engram.Vector.Qdrant do
 
     instrument(:delete, fn ->
       case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
-        {:ok, %{status: 200}} -> :ok
+        # 404 is a missing COLLECTION, so there is nothing to delete. Missing
+        # point ids come back 200. Treating it as an error made DeleteNoteIndex
+        # (#1608, which retries now rather than swallowing) burn its attempts
+        # on a stack that has never indexed anything.
+        {:ok, %{status: status}} when status in [200, 404] -> :ok
         {:ok, %{status: status, body: body}} -> {:error, {status, body}}
         {:error, reason} -> {:error, reason}
       end
@@ -490,7 +494,8 @@ defmodule Engram.Vector.Qdrant do
 
     instrument(:delete, fn ->
       case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
-        {:ok, %{status: 200}} -> :ok
+        # Missing collection: nothing to delete. See `delete_points/2`.
+        {:ok, %{status: status}} when status in [200, 404] -> :ok
         {:ok, %{status: status, body: body}} -> {:error, {status, body}}
         {:error, reason} -> {:error, reason}
       end
@@ -537,7 +542,8 @@ defmodule Engram.Vector.Qdrant do
 
     instrument(:delete, fn ->
       case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
-        {:ok, %{status: 200}} -> :ok
+        # Missing collection: nothing to delete. See `delete_points/2`.
+        {:ok, %{status: status}} when status in [200, 404] -> :ok
         {:ok, %{status: status, body: body}} -> {:error, {status, body}}
         {:error, reason} -> {:error, reason}
       end
@@ -561,7 +567,8 @@ defmodule Engram.Vector.Qdrant do
 
     instrument(:delete, fn ->
       case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
-        {:ok, %{status: 200}} -> :ok
+        # Missing collection: nothing to delete. See `delete_points/2`.
+        {:ok, %{status: status}} when status in [200, 404] -> :ok
         {:ok, %{status: status, body: body}} -> {:error, {status, body}}
         {:error, reason} -> {:error, reason}
       end

--- a/lib/engram/workers/delete_note_index.ex
+++ b/lib/engram/workers/delete_note_index.ex
@@ -42,32 +42,7 @@ defmodule Engram.Workers.DeleteNoteIndex do
     case Base.decode64(path_hmac_b64) do
       {:ok, path_hmac} ->
         note = %{id: note_id, user_id: user_id, vault_id: vault_id, path_hmac: path_hmac}
-        _ = Indexing.delete_note_index(note)
-
-        # #591 — the note is gone: drop its outgoing edges and flip any
-        # incoming edges back to dangling.
-        :ok = Links.on_note_soft_deleted(user_id, note_id)
-
-        # Chain a rebind for the deleted note's OWN basename — a same-
-        # basename sibling elsewhere may now win the shortest-path tiebreak
-        # and should inherit the edges this note is vacating. Only possible
-        # when the enqueueing caller had plaintext in scope to compute the
-        # hmac (see `Notes.delete_note_index_job/2`); otherwise skip — the
-        # edge-flip above already ran regardless. `basename_hmac` (base64) —
-        # never plaintext, same T3.2/H3 invariant as `path_hmac` above.
-        _ = maybe_enqueue_rebind(user_id, vault_id, Map.get(args, "basename_hmac"))
-
-        # Deleting a note frees an indexed-note slot. The note that inherits it
-        # already carries a stamped embed_hash from the pass that skipped it, so
-        # nothing would ever re-index it. No-op for uncapped tiers.
-        #
-        # ENQUEUED, not inline. The sweep is whole-vault, and this worker runs
-        # once per DELETED note — a 5,000-note folder delete ran it 5,000 times
-        # over the same rows. The job is unique per (user, kind) over a 2-minute
-        # window, so a delete burst collapses to one sweep after it settles.
-        _ = IndexCapMaintenance.enqueue(user_id, :backfill_slots)
-
-        :ok
+        delete_index_then_unlink(note, args)
 
       :error ->
         {:discard, "invalid path_hmac base64 for note_id=#{note_id}"}
@@ -84,6 +59,38 @@ defmodule Engram.Workers.DeleteNoteIndex do
   # there is no scenario where we want to "process" such a job.
   def perform(%Oban.Job{args: args}) do
     {:discard, "T3.2 legacy or malformed args (keys=#{inspect(Map.keys(args))})"}
+  end
+
+  # A failed Qdrant delete is returned so Oban retries it (#1608). Discarding
+  # it left both the rows and the points, and the deleted note kept answering
+  # searches with nothing left to retry the delete.
+  defp delete_index_then_unlink(%{id: note_id, user_id: user_id, vault_id: vault_id} = note, args) do
+    with :ok <- Indexing.delete_note_index(note) do
+      # #591 — the note is gone: drop its outgoing edges and flip any
+      # incoming edges back to dangling.
+      :ok = Links.on_note_soft_deleted(user_id, note_id)
+
+      # Chain a rebind for the deleted note's OWN basename — a same-
+      # basename sibling elsewhere may now win the shortest-path tiebreak
+      # and should inherit the edges this note is vacating. Only possible
+      # when the enqueueing caller had plaintext in scope to compute the
+      # hmac (see `Notes.delete_note_index_job/2`); otherwise skip — the
+      # edge-flip above already ran regardless. `basename_hmac` (base64) —
+      # never plaintext, same T3.2/H3 invariant as `path_hmac` above.
+      _ = maybe_enqueue_rebind(user_id, vault_id, Map.get(args, "basename_hmac"))
+
+      # Deleting a note frees an indexed-note slot. The note that inherits it
+      # already carries a stamped embed_hash from the pass that skipped it, so
+      # nothing would ever re-index it. No-op for uncapped tiers.
+      #
+      # ENQUEUED, not inline. The sweep is whole-vault, and this worker runs
+      # once per DELETED note — a 5,000-note folder delete ran it 5,000 times
+      # over the same rows. The job is unique per (user, kind) over a 2-minute
+      # window, so a delete burst collapses to one sweep after it settles.
+      _ = IndexCapMaintenance.enqueue(user_id, :backfill_slots)
+
+      :ok
+    end
   end
 
   defp maybe_enqueue_rebind(_user_id, _vault_id, nil), do: :ok

--- a/lib/engram/workers/delete_note_index.ex
+++ b/lib/engram/workers/delete_note_index.ex
@@ -42,7 +42,7 @@ defmodule Engram.Workers.DeleteNoteIndex do
     case Base.decode64(path_hmac_b64) do
       {:ok, path_hmac} ->
         note = %{id: note_id, user_id: user_id, vault_id: vault_id, path_hmac: path_hmac}
-        delete_index_then_unlink(note, args)
+        unlink_then_delete_index(note, args)
 
       :error ->
         {:discard, "invalid path_hmac base64 for note_id=#{note_id}"}
@@ -64,33 +64,36 @@ defmodule Engram.Workers.DeleteNoteIndex do
   # A failed Qdrant delete is returned so Oban retries it (#1608). Discarding
   # it left both the rows and the points, and the deleted note kept answering
   # searches with nothing left to retry the delete.
-  defp delete_index_then_unlink(%{id: note_id, user_id: user_id, vault_id: vault_id} = note, args) do
-    with :ok <- Indexing.delete_note_index(note) do
-      # #591 — the note is gone: drop its outgoing edges and flip any
-      # incoming edges back to dangling.
-      :ok = Links.on_note_soft_deleted(user_id, note_id)
+  #
+  # The local work runs FIRST, and the retryable remote delete last. Behind the
+  # delete, a brief Qdrant 5xx would burn all three attempts and the note would
+  # keep its outgoing edges forever, since nothing re-enqueues this job. Each
+  # step here is idempotent, so a retry repeating them is free.
+  defp unlink_then_delete_index(%{id: note_id, user_id: user_id, vault_id: vault_id} = note, args) do
+    # #591 — the note is gone: drop its outgoing edges and flip any
+    # incoming edges back to dangling.
+    :ok = Links.on_note_soft_deleted(user_id, note_id)
 
-      # Chain a rebind for the deleted note's OWN basename — a same-
-      # basename sibling elsewhere may now win the shortest-path tiebreak
-      # and should inherit the edges this note is vacating. Only possible
-      # when the enqueueing caller had plaintext in scope to compute the
-      # hmac (see `Notes.delete_note_index_job/2`); otherwise skip — the
-      # edge-flip above already ran regardless. `basename_hmac` (base64) —
-      # never plaintext, same T3.2/H3 invariant as `path_hmac` above.
-      _ = maybe_enqueue_rebind(user_id, vault_id, Map.get(args, "basename_hmac"))
+    # Chain a rebind for the deleted note's OWN basename — a same-
+    # basename sibling elsewhere may now win the shortest-path tiebreak
+    # and should inherit the edges this note is vacating. Only possible
+    # when the enqueueing caller had plaintext in scope to compute the
+    # hmac (see `Notes.delete_note_index_job/2`); otherwise skip — the
+    # edge-flip above already ran regardless. `basename_hmac` (base64) —
+    # never plaintext, same T3.2/H3 invariant as `path_hmac` above.
+    _ = maybe_enqueue_rebind(user_id, vault_id, Map.get(args, "basename_hmac"))
 
-      # Deleting a note frees an indexed-note slot. The note that inherits it
-      # already carries a stamped embed_hash from the pass that skipped it, so
-      # nothing would ever re-index it. No-op for uncapped tiers.
-      #
-      # ENQUEUED, not inline. The sweep is whole-vault, and this worker runs
-      # once per DELETED note — a 5,000-note folder delete ran it 5,000 times
-      # over the same rows. The job is unique per (user, kind) over a 2-minute
-      # window, so a delete burst collapses to one sweep after it settles.
-      _ = IndexCapMaintenance.enqueue(user_id, :backfill_slots)
+    # Deleting a note frees an indexed-note slot. The note that inherits it
+    # already carries a stamped embed_hash from the pass that skipped it, so
+    # nothing would ever re-index it. No-op for uncapped tiers.
+    #
+    # ENQUEUED, not inline. The sweep is whole-vault, and this worker runs
+    # once per DELETED note — a 5,000-note folder delete ran it 5,000 times
+    # over the same rows. The job is unique per (user, kind) over a 2-minute
+    # window, so a delete burst collapses to one sweep after it settles.
+    _ = IndexCapMaintenance.enqueue(user_id, :backfill_slots)
 
-      :ok
-    end
+    Indexing.delete_note_index(note)
   end
 
   defp maybe_enqueue_rebind(_user_id, _vault_id, nil), do: :ok

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -136,21 +136,17 @@ defmodule Engram.Workers.EmbedNote do
             case embed_budget_gate(note, user) do
               :ok ->
                 case run_embed(note, user, old_path_hmac_b64) do
-                  {:ok, chunk_count, semantic?} ->
-                    # Charge the embed meter only when Voyage was actually
-                    # called. `chunk_count == 0` is index_note/2's no-chunks
-                    # outcome: the note was empty OR outside the user's
-                    # indexed-note cap, and in neither case did a single token
-                    # get spent. Keyword-only users never call Voyage at all.
+                  {:ok, embedded_bytes} ->
+                    # Charge the embed meter for what Voyage was actually sent
+                    # this pass, not the whole note (#1618). Chunk reuse sends
+                    # only the changed chunks; an empty or over-cap note and a
+                    # keyword-only user send nothing at all.
                     #
-                    # Charging regardless was not merely cosmetic: phantom
-                    # tokens accumulate to the 20M lifetime cap, and
+                    # Charging more was not merely cosmetic: phantom tokens
+                    # accumulate to the 20M lifetime cap, and
                     # embed_budget_gate/2 then cancels indexing entirely — so a
                     # Free user who spent nothing would lose their BM25 index.
-                    _ =
-                      if chunk_count > 0 and semantic? do
-                        record_embed_tokens(note)
-                      end
+                    _ = record_embed_tokens(note.user_id, embedded_bytes)
 
                     :ok
 
@@ -223,17 +219,17 @@ defmodule Engram.Workers.EmbedNote do
     end
   end
 
-  defp record_embed_tokens(%Note{user_id: user_id} = note) do
-    case estimate_note_tokens(note) do
+  defp record_embed_tokens(user_id, embedded_bytes) do
+    case UsageMeters.estimate_tokens(embedded_bytes) do
       0 -> :ok
       tokens -> UsageMeters.add_embed_tokens(user_id, tokens)
     end
   end
 
-  # Token estimate uses the ciphertext byte size. AES-GCM adds a 16-byte
-  # auth tag so we over-count by ~4 tokens per note, which keeps the cap
-  # conservative. Real `usage.total_tokens` from the Voyage response is a
-  # follow-up.
+  # The budget GATE still estimates the whole note: it runs before the pass,
+  # when which chunks will re-embed is not yet known, so it errs towards
+  # blocking. Uses the ciphertext byte size; AES-GCM adds a 16-byte auth tag,
+  # so it over-counts by ~4 tokens per note.
   defp estimate_note_tokens(%Note{content_ciphertext: ct}) when is_binary(ct) do
     UsageMeters.estimate_tokens(ct)
   end
@@ -355,8 +351,8 @@ defmodule Engram.Workers.EmbedNote do
                 Indexing.delete_points_by_path_hmac(decrypted_note, old_path_hmac_b64)
               end
 
-            case Indexing.index_note(decrypted_note, vault, user) do
-              {:ok, count} ->
+            case Indexing.index_note_with_usage(decrypted_note, vault, user) do
+              {:ok, count, embedded_bytes} ->
                 # `user` is the row threaded down from run_and_stamp — the same
                 # one Indexing used to decide whether to call Voyage. Do NOT
                 # re-resolve: a second read lands a DIFFERENT value when a
@@ -365,7 +361,7 @@ defmodule Engram.Workers.EmbedNote do
                 # retries outlives it), and the spend would go unmetered.
                 semantic? = SearchProfile.resolve(user).semantic
                 stamp_embed_hash(note, semantic?, count)
-                {:ok, count, semantic?}
+                {:ok, embedded_bytes}
 
               # Voyage 429 — back off without burning an Oban attempt. Voyage's
               # paid-tier RPM is finite; without this guard five consecutive

--- a/lib/engram/workers/orphan_sweep.ex
+++ b/lib/engram/workers/orphan_sweep.ex
@@ -483,6 +483,15 @@ defmodule Engram.Workers.OrphanSweep do
       |> Enum.uniq()
       |> Enum.chunk_every(@id_query_batch)
       |> Enum.reduce(0, fn batch, acc ->
+        # Chunk reuse (#1595) matches on `context_hmac`, so a surviving hmac
+        # makes the re-index "reuse" the very points Qdrant lost and stamp the
+        # note indexed again (#1607). Cleared before the note hashes: a failure
+        # between the two then costs a full re-embed, never a silent no-op.
+        _ =
+          Chunk
+          |> where([c], c.note_id in ^batch)
+          |> Repo.update_all([set: [context_hmac: nil]], skip_tenant_check: true)
+
         {n, _} =
           Note
           |> where([n], n.id in ^batch)

--- a/test/engram/embedders/voyage_test.exs
+++ b/test/engram/embedders/voyage_test.exs
@@ -121,6 +121,38 @@ defmodule Engram.Embedders.VoyageTest do
 
       Voyage.embed_texts(["hello"])
     end
+
+    # #1614: Voyage prepends its retrieval prompts only when told whether an
+    # input is a query or a document, and without output_dimension a
+    # non-default EMBED_DIMS disagrees with the vectors Voyage returns.
+    test "indexing sends input_type document and the configured output_dimension",
+         %{bypass: bypass} do
+      expect_body(bypass)
+      ServiceConfig.put_override(:embed_dims, 512)
+
+      assert {:ok, _} = Voyage.embed_texts(["hello"])
+      assert_receive {:body, %{"input_type" => "document", "output_dimension" => 512}}
+    end
+
+    test "search sends input_type query", %{bypass: bypass} do
+      expect_body(bypass)
+
+      assert {:ok, _} = Voyage.embed_texts(["hello"], purpose: :query)
+      assert_receive {:body, %{"input_type" => "query", "output_dimension" => 1024}}
+    end
+  end
+
+  defp expect_body(bypass) do
+    test_pid = self()
+
+    Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:body, Jason.decode!(body)})
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, ~s({"data":[{"embedding":[0.1]}]}))
+    end)
   end
 
   describe "client-side rate limit (VOYAGE_RPM)" do

--- a/test/engram/embedders/voyage_test.exs
+++ b/test/engram/embedders/voyage_test.exs
@@ -138,7 +138,19 @@ defmodule Engram.Embedders.VoyageTest do
       expect_body(bypass)
 
       assert {:ok, _} = Voyage.embed_texts(["hello"], purpose: :query)
-      assert_receive {:body, %{"input_type" => "query", "output_dimension" => 1024}}
+      assert_receive {:body, %{"input_type" => "query"}}
+    end
+
+    # Older Voyage models (voyage-2, voyage-law-2, ...) reject output_dimension
+    # outright, and EMBED_DIMS has no default in config, so sending 1024
+    # unasked would 400 every embed for a self-hoster on one of them. Only an
+    # operator who set EMBED_DIMS gets the field.
+    test "omits output_dimension when EMBED_DIMS is not configured", %{bypass: bypass} do
+      expect_body(bypass)
+
+      assert {:ok, _} = Voyage.embed_texts(["hello"])
+      assert_receive {:body, body}
+      refute Map.has_key?(body, "output_dimension")
     end
   end
 

--- a/test/engram/indexing_chunk_reuse_test.exs
+++ b/test/engram/indexing_chunk_reuse_test.exs
@@ -73,6 +73,9 @@ defmodule Engram.IndexingChunkReuseTest do
     end
   end
 
+  defp restore_env(key, nil), do: Application.delete_env(:engram, key)
+  defp restore_env(key, value), do: Application.put_env(:engram, key, value)
+
   defp requests(recorder), do: recorder |> Agent.get(& &1) |> Enum.reverse()
 
   defp reset(recorder), do: Agent.update(recorder, fn _ -> [] end)
@@ -383,6 +386,29 @@ defmodule Engram.IndexingChunkReuseTest do
 
       assert length(embedded_texts()) == count
       assert length(upserts(ctx.recorder)) == count
+    end
+
+    # DOC_EMBED_MODEL is optional: unset, the embedder falls back to
+    # EMBED_MODEL. Fingerprinting only the former meant changing EMBED_MODEL
+    # left every hmac identical, so the collection silently mixed two models'
+    # embedding spaces.
+    test "changing EMBED_MODEL invalidates reuse when DOC_EMBED_MODEL is unset", ctx do
+      prior = Application.get_env(:engram, :embed_model)
+      on_exit(fn -> restore_env(:embed_model, prior) end)
+
+      Application.put_env(:engram, :embed_model, "voyage-4-large")
+      note = put_note(ctx.user, ctx.vault, "Ferritin levels are low.")
+      stub_embedder(self())
+
+      assert {:ok, count} = Indexing.index_note(note, ctx.vault)
+      _ = embedded_texts()
+      reset(ctx.recorder)
+
+      Application.put_env(:engram, :embed_model, "voyage-4-lite")
+      assert {:ok, ^count} = Indexing.index_note(note, ctx.vault)
+
+      assert length(embedded_texts()) == count,
+             "a model change must re-embed every chunk, not reuse the old model's vectors"
     end
 
     test "a downgrade rebuilds every point without a dense vector", ctx do

--- a/test/engram/indexing_chunk_reuse_test.exs
+++ b/test/engram/indexing_chunk_reuse_test.exs
@@ -364,6 +364,49 @@ defmodule Engram.IndexingChunkReuseTest do
     end
   end
 
+  # #1606: reuse matched on the text alone and ignored what the point holds. A
+  # keyword-only point has no dense vector, so reusing it after an upgrade
+  # stamped the note densely indexed with nothing behind the stamp.
+  describe "a tier change" do
+    test "an upgrade embeds every chunk of a keyword-only index", ctx do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      note = put_raw(user, vault, @path, content("Ferritin levels are low.", "[health]"))
+      stub_embedder(self())
+
+      assert {:ok, count} = Indexing.index_note(note, vault)
+      assert embedded_texts() == [], "a keyword-only user must not reach the embedder"
+      reset(ctx.recorder)
+
+      :ok = Engram.Fixtures.grant_semantic!(user)
+      assert {:ok, ^count} = Indexing.index_note(note, vault)
+
+      assert length(embedded_texts()) == count
+      assert length(upserts(ctx.recorder)) == count
+    end
+
+    test "a downgrade rebuilds every point without a dense vector", ctx do
+      note = put_note(ctx.user, ctx.vault, "Ferritin levels are low.")
+      stub_embedder(self())
+
+      assert {:ok, count} = Indexing.index_note(note, ctx.vault)
+      _ = embedded_texts()
+      reset(ctx.recorder)
+
+      Repo.delete_all(
+        from(o in Engram.Billing.UserLimitOverride, where: o.user_id == ^ctx.user.id)
+      )
+
+      Engram.Billing.OverrideCache.evict(ctx.user.id)
+
+      assert {:ok, ^count} = Indexing.index_note(note, ctx.vault)
+
+      points = upserts(ctx.recorder)
+      assert length(points) == count
+      refute Enum.any?(points, &Map.has_key?(&1["vector"], "dense"))
+    end
+  end
+
   describe "a short embedder response" do
     test "fails the attempt and leaves the previous index untouched", ctx do
       note = put_note(ctx.user, ctx.vault, "Ferritin levels are low.")

--- a/test/engram/parsers/markdown_test.exs
+++ b/test/engram/parsers/markdown_test.exs
@@ -186,6 +186,28 @@ defmodule Engram.Parsers.MarkdownTest do
       chunks = Markdown.parse("---\nstatus: done\n---\n", "a/n.md")
       assert [%{heading_path: "frontmatter"}] = chunks
     end
+
+    # #1605: the strip measured the frontmatter in BYTES and sliced the note
+    # in GRAPHEMES, so every multibyte character cut one more from the body.
+    test "multibyte frontmatter keeps the whole body" do
+      content = "---\ntitle: 日本語のノート\n---\nHello world this is the body."
+      [body | _] = Markdown.parse(content, "a/n.md")
+      assert body.text == "Hello world this is the body."
+    end
+
+    test "CRLF frontmatter keeps the whole body and still emits the frontmatter chunk" do
+      content = "---\r\ntitle: T\r\n---\r\nHello world this is the body.\r\n"
+      chunks = Markdown.parse(content, "a/n.md")
+
+      [body | _] = chunks
+      assert body.text == "Hello world this is the body."
+      assert %{text: "title: T\n"} = List.last(chunks)
+    end
+
+    test "a closing fence at EOF is indexed once, as the frontmatter chunk" do
+      chunks = Markdown.parse("---\nstatus: done\n---", "a/n.md")
+      assert [%{heading_path: "frontmatter"}] = chunks
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/search/mmr_test.exs
+++ b/test/engram/search/mmr_test.exs
@@ -46,6 +46,72 @@ defmodule Engram.Search.MMRTest do
     assert MMR.rerank([], 5, 0.0) == []
   end
 
+  # #1617: every greedy step recomputed full cosines (magnitudes included)
+  # against every picked item, and `remaining -- [best]` deep-compared 1024-float
+  # maps. The REST maximum (limit 50) over a ~200 pool measured 76s of CPU.
+  test "a limit-50 rerank over 200 real-width vectors finishes promptly" do
+    :rand.seed(:exsss, {1, 2, 3})
+    cands = for i <- 1..200, do: c(1.0 - i / 1000, random_vec(1024))
+
+    task = Task.async(fn -> MMR.rerank(cands, 50, 0.3) end)
+    result = Task.yield(task, 5_000) || Task.shutdown(task, :brutal_kill)
+
+    assert {:ok, picked} = result, "MMR took longer than 5s for limit=50 over 200 candidates"
+    assert length(picked) == 50
+  end
+
+  # Pins the selection order to the original O(n^3) definition, so the faster
+  # version is a pure optimisation.
+  test "picks the same order as the reference definition" do
+    :rand.seed(:exsss, {4, 5, 6})
+
+    for _ <- 1..25 do
+      cands =
+        for _ <- 1..20 do
+          c(:rand.uniform(), if(:rand.uniform() < 0.1, do: nil, else: random_vec(8)))
+        end
+
+      for d <- [0.05, 0.3, 0.7, 1.0] do
+        assert MMR.rerank(cands, 10, d) == reference(cands, 10, d)
+      end
+    end
+  end
+
+  defp random_vec(dims), do: for(_ <- 1..dims, do: :rand.uniform() - 0.5)
+
+  defp reference(cands, limit, d) do
+    scores = Enum.map(cands, & &1.score)
+    {lo, hi} = Enum.min_max(scores)
+    rel = fn cand -> if hi == lo, do: 1.0, else: (cand.score - lo) / (hi - lo) end
+
+    Enum.reduce(1..min(limit, length(cands)), {cands, []}, fn _, {left, picked} ->
+      best =
+        Enum.max_by(left, fn cand ->
+          case picked do
+            [] ->
+              rel.(cand)
+
+            _ ->
+              max_sim = picked |> Enum.map(&ref_cosine(cand.vector, &1.vector)) |> Enum.max()
+              (1.0 - d) * rel.(cand) - d * max_sim
+          end
+        end)
+
+      {List.delete(left, best), picked ++ [best]}
+    end)
+    |> elem(1)
+  end
+
+  defp ref_cosine(nil, _), do: 0.0
+  defp ref_cosine(_, nil), do: 0.0
+
+  defp ref_cosine(a, b) do
+    dot = a |> Enum.zip(b) |> Enum.reduce(0.0, fn {x, y}, acc -> acc + x * y end)
+    na = :math.sqrt(Enum.reduce(a, 0.0, &(&1 * &1 + &2)))
+    nb = :math.sqrt(Enum.reduce(b, 0.0, &(&1 * &1 + &2)))
+    dot / (na * nb)
+  end
+
   test "absent :vector key (not nil — key missing entirely) degrades safely without raising" do
     # Upstream stripping of nil vectors leaves a map with no :vector key at all.
     # Map.get/2 returns nil, which the cosine(nil, _) clause handles as 0.0

--- a/test/engram/search_integration_test.exs
+++ b/test/engram/search_integration_test.exs
@@ -6,6 +6,11 @@ defmodule Engram.SearchIntegrationTest do
   @moduletag :qdrant_integration
 
   setup do
+    # Per-process override: the Bypass suites delete the global `:qdrant_url`
+    # on exit, so app env alone leaves this pointed at the compiled
+    # localhost:6333 default once any of them has run.
+    Engram.ServiceConfig.put_override(:qdrant_url, qdrant_url())
+
     Engram.Crypto.DekCache.invalidate_all()
     user = insert(:user)
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
@@ -25,6 +30,11 @@ defmodule Engram.SearchIntegrationTest do
     end)
 
     {:ok, user: user, vault: vault, collection: col}
+  end
+
+  defp qdrant_url do
+    System.get_env("QDRANT_URL") ||
+      Application.get_env(:engram, :qdrant_url, "http://localhost:6333")
   end
 
   test "encrypted vault round-trip: upsert → raw payload is ciphertext → search returns plaintext",
@@ -51,10 +61,8 @@ defmodule Engram.SearchIntegrationTest do
 
     # Not a hardcoded port: CI runs Qdrant on an ephemeral one (see
     # test_helper.exs), so read the same URL the client uses.
-    qdrant_url = Application.get_env(:engram, :qdrant_url, "http://localhost:6333")
-
     {:ok, resp} =
-      Req.post("#{qdrant_url}/collections/#{col}/points/scroll",
+      Req.post("#{qdrant_url()}/collections/#{col}/points/scroll",
         json: %{limit: 10, with_payload: true}
       )
 

--- a/test/engram/search_integration_test.exs
+++ b/test/engram/search_integration_test.exs
@@ -36,13 +36,25 @@ defmodule Engram.SearchIntegrationTest do
         "title" => "Journal"
       })
 
-    {:ok, _n} = Engram.Indexing.index_note(note, vault)
+    # `content`/`title` are VIRTUAL fields: the fixture writes ciphertext only,
+    # so the struct it returns carries content: nil. Indexing that parses zero
+    # chunks and returns {:ok, 0} without ever creating the collection, which
+    # surfaced as a confusing 404 two lines down. EmbedNote decrypts first; so
+    # must this.
+    {:ok, decrypted} = Engram.Crypto.maybe_decrypt_note_fields(note, user)
+
+    assert {:ok, chunk_count} = Engram.Indexing.index_note(decrypted, vault)
+    assert chunk_count > 0, "the note must produce chunks, or nothing below is exercised"
 
     {:ok, info} = Engram.Vector.Qdrant.collection_info(col)
     assert info["points_count"] >= 1
 
+    # Not a hardcoded port: CI runs Qdrant on an ephemeral one (see
+    # test_helper.exs), so read the same URL the client uses.
+    qdrant_url = Application.get_env(:engram, :qdrant_url, "http://localhost:6333")
+
     {:ok, resp} =
-      Req.post("http://localhost:6333/collections/#{col}/points/scroll",
+      Req.post("#{qdrant_url}/collections/#{col}/points/scroll",
         json: %{limit: 10, with_payload: true}
       )
 

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -4,6 +4,7 @@ defmodule Engram.SearchTest do
   import Bitwise, only: [bxor: 2]
   import Mox
 
+  alias Engram.Notes.Chunk
   alias Engram.Search
 
   setup :verify_on_exit!
@@ -141,8 +142,8 @@ defmodule Engram.SearchTest do
 
       {:ok, _} =
         Engram.Repo.with_tenant(user.id, fn ->
-          %Engram.Notes.Chunk{}
-          |> Engram.Notes.Chunk.changeset(%{
+          %Chunk{}
+          |> Chunk.changeset(%{
             note_id: note.id,
             user_id: user.id,
             vault_id: vault.id,
@@ -213,8 +214,8 @@ defmodule Engram.SearchTest do
 
       {:ok, _} =
         Engram.Repo.with_tenant(user.id, fn ->
-          %Engram.Notes.Chunk{}
-          |> Engram.Notes.Chunk.changeset(%{
+          %Chunk{}
+          |> Chunk.changeset(%{
             note_id: note.id,
             user_id: user.id,
             vault_id: vault.id,
@@ -267,6 +268,89 @@ defmodule Engram.SearchTest do
       end)
 
       assert {:ok, []} = Search.search(user, vault, "ferritin")
+    end
+
+    # Dropping deleted hits AFTER the MMR pass shrinks the page: the deleted
+    # one occupied a slot in the top-K and nothing backfilled it from the pool.
+    test "#1608: a deleted hit does not shrink the page below the limit",
+         %{bypass: bypass, user: user, vault: vault} do
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts, _opts -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      [live_a, deleted, live_c] =
+        for name <- ~w(alpha beta gamma) do
+          {:ok, note} =
+            Engram.Notes.upsert_note(user, vault, %{
+              "path" => "Health/#{name}.md",
+              "content" => "# #{name}\n\nFerritin levels.",
+              "mtime" => 1_000.0
+            })
+
+          point_id = Ecto.UUID.generate()
+
+          {:ok, _} =
+            Engram.Repo.with_tenant(user.id, fn ->
+              %Chunk{}
+              |> Chunk.changeset(%{
+                note_id: note.id,
+                user_id: user.id,
+                vault_id: vault.id,
+                position: 0,
+                char_start: 0,
+                char_end: 10,
+                qdrant_point_id: point_id
+              })
+              |> Engram.Repo.insert!()
+            end)
+
+          %{note: note, point_id: point_id}
+        end
+
+      Engram.Repo.update_all(
+        from(n in Engram.Notes.Note, where: n.id == ^deleted.note.id),
+        [set: [deleted_at: DateTime.utc_now()]],
+        skip_tenant_check: true
+      )
+
+      results =
+        [live_a, deleted, live_c]
+        |> Enum.zip([0.95, 0.9, 0.85])
+        |> Enum.map(fn {%{point_id: point_id}, score} ->
+          {:ok, enc} =
+            Engram.Crypto.encrypt_qdrant_payload(
+              %{text: "Ferritin levels.", title: "t", heading_path: "t"},
+              user,
+              "engram_notes",
+              point_id
+            )
+
+          %{
+            "id" => point_id,
+            "score" => score,
+            "payload" => %{
+              "text" => enc.text,
+              "title" => enc.title,
+              "heading_path" => enc.heading_path,
+              "text_nonce" => enc.text_nonce,
+              "title_nonce" => enc.title_nonce,
+              "heading_path_nonce" => enc.heading_path_nonce,
+              "aad_version" => enc.aad_version,
+              "user_id" => to_string(user.id),
+              "vault_id" => to_string(vault.id)
+            }
+          }
+        end)
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"result" => results}))
+      end)
+
+      assert {:ok, hits} = Search.search(user, vault, "ferritin", limit: 2)
+
+      assert length(hits) == 2, "the live third candidate must backfill the deleted one's slot"
+      refute Enum.any?(hits, &(&1.source_path == "Health/beta.md"))
     end
 
     test "includes vault_id filter in Qdrant request", %{bypass: bypass, user: user, vault: vault} do

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -194,6 +194,81 @@ defmodule Engram.SearchTest do
       assert result.tags == ["labs"]
     end
 
+    # #1608: rehydration joined notes with no deleted_at filter, and a hit it
+    # could not fill in was kept anyway, so a deleted note's surviving points
+    # kept answering searches.
+    test "#1608: drops a hit whose note is soft-deleted",
+         %{bypass: bypass, user: user, vault: vault} do
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts, _opts -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      {:ok, note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "Health/gone.md",
+          "content" => "# Gone\n\nFerritin levels.",
+          "mtime" => 1_000.0
+        })
+
+      point_id = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          %Engram.Notes.Chunk{}
+          |> Engram.Notes.Chunk.changeset(%{
+            note_id: note.id,
+            user_id: user.id,
+            vault_id: vault.id,
+            position: 0,
+            char_start: 0,
+            char_end: 10,
+            qdrant_point_id: point_id
+          })
+          |> Engram.Repo.insert!()
+        end)
+
+      Engram.Repo.update_all(
+        from(n in Engram.Notes.Note, where: n.id == ^note.id),
+        [set: [deleted_at: DateTime.utc_now()]],
+        skip_tenant_check: true
+      )
+
+      {:ok, enc} =
+        Engram.Crypto.encrypt_qdrant_payload(
+          %{text: "Ferritin levels.", title: "Gone", heading_path: "Gone"},
+          user,
+          "engram_notes",
+          point_id
+        )
+
+      qdrant_result = %{
+        "result" => [
+          %{
+            "id" => point_id,
+            "score" => 0.9,
+            "payload" => %{
+              "text" => enc.text,
+              "title" => enc.title,
+              "heading_path" => enc.heading_path,
+              "text_nonce" => enc.text_nonce,
+              "title_nonce" => enc.title_nonce,
+              "heading_path_nonce" => enc.heading_path_nonce,
+              "aad_version" => enc.aad_version,
+              "user_id" => to_string(user.id),
+              "vault_id" => to_string(vault.id)
+            }
+          }
+        ]
+      }
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(qdrant_result))
+      end)
+
+      assert {:ok, []} = Search.search(user, vault, "ferritin")
+    end
+
     test "includes vault_id filter in Qdrant request", %{bypass: bypass, user: user, vault: vault} do
       Engram.MockEmbedder
       |> expect(:embed_texts, fn _, _ -> {:ok, [List.duplicate(0.1, 3)]} end)

--- a/test/engram/vector/qdrant_collection_test.exs
+++ b/test/engram/vector/qdrant_collection_test.exs
@@ -14,9 +14,41 @@ defmodule Engram.Vector.QdrantCollectionTest do
   # strict-mode requires an index for. ensure_collection must create them
   # (idempotently) or every filtered op 400s on Cloud. See #626. `type_hmac`
   # is the OKF frontmatter blind index (keyword); `fm_timestamp`/`fm_created`
-  # are the OKF frontmatter dates (integer, range-filterable).
-  @indexed_fields ~w(user_id vault_id note_id path_hmac type_hmac)
+  # are the OKF frontmatter dates (integer, range-filterable). `folder_hmac`
+  # and `tags_hmac` are the folder/tag search filters (#1609).
+  @indexed_fields ~w(user_id vault_id note_id path_hmac type_hmac folder_hmac tags_hmac)
   @integer_indexed_fields ~w(fm_timestamp fm_created)
+
+  # A named-shape collection_info body carrying the given payload_schema.
+  defp existing_body(payload_schema) do
+    Jason.encode!(%{
+      result: %{
+        config: %{
+          params: %{
+            vectors: %{"dense" => %{size: 1024, distance: "Cosine"}},
+            sparse_vectors: %{"keyword" => %{modifier: "idf"}}
+          }
+        },
+        payload_schema: payload_schema
+      }
+    })
+  end
+
+  defp expect_existing(bypass, col, payload_schema) do
+    Bypass.expect_once(bypass, "PUT", "/collections/#{col}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(409, ~s({"status":{"error":"already exists"}}))
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/collections/#{col}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, existing_body(payload_schema))
+    end)
+  end
+
+  defp schema_for(fields, type), do: Map.new(fields, &{&1, %{data_type: type}})
 
   # Stub the payload-index endpoint so tests asserting other behaviour don't
   # fail on the index PUTs ensure_collection now fires.
@@ -67,33 +99,18 @@ defmodule Engram.Vector.QdrantCollectionTest do
     end
   end
 
-  test "does NOT re-create payload indexes on a pre-existing collection (409)",
+  test "does NOT re-create payload indexes an existing collection already has",
        %{bypass: bypass} do
     test_pid = self()
 
-    Bypass.expect_once(bypass, "PUT", "/collections/c1", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.send_resp(409, ~s({"status":{"error":"already exists"}}))
-    end)
-
-    named_shape_body =
-      Jason.encode!(%{
-        result: %{
-          config: %{
-            params: %{
-              vectors: %{"dense" => %{size: 1024, distance: "Cosine"}},
-              sparse_vectors: %{"keyword" => %{modifier: "idf"}}
-            }
-          }
-        }
-      })
-
-    Bypass.expect_once(bypass, "GET", "/collections/c1", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.send_resp(200, named_shape_body)
-    end)
+    expect_existing(
+      bypass,
+      "c1",
+      Map.merge(
+        schema_for(@indexed_fields, "keyword"),
+        schema_for(@integer_indexed_fields, "integer")
+      )
+    )
 
     # If the steady-state path wrongly (re-)created indexes, this fires.
     Bypass.stub(bypass, "PUT", "/collections/c1/index", fn conn ->
@@ -103,6 +120,68 @@ defmodule Engram.Vector.QdrantCollectionTest do
 
     assert :ok = Qdrant.ensure_collection("c1", 1024)
     refute_receive :index_called
+  end
+
+  # #1609: indexes were only created on a fresh collection, so any field added
+  # to the list later never reached a collection that already existed. Prod
+  # carried only these four, and strict mode 400s a filter on the rest.
+  test "creates the payload indexes an existing collection is missing", %{bypass: bypass} do
+    test_pid = self()
+    present = ~w(user_id vault_id note_id path_hmac)
+
+    expect_existing(bypass, "c1", schema_for(present, "keyword"))
+
+    Bypass.expect(bypass, "PUT", "/collections/c1/index", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      json = Jason.decode!(body)
+      send(test_pid, {:index, json["field_name"], json["field_schema"]})
+      Plug.Conn.send_resp(conn, 200, ~s({"status":"ok"}))
+    end)
+
+    assert :ok = Qdrant.ensure_collection("c1", 1024)
+
+    for field <- @indexed_fields -- present do
+      assert_receive {:index, ^field, "keyword"}
+    end
+
+    for field <- @integer_indexed_fields do
+      assert_receive {:index, ^field, "integer"}
+    end
+
+    for field <- present do
+      refute_received {:index, ^field, _}
+    end
+  end
+
+  test "an existing collection with no payload_schema gets every index", %{bypass: bypass} do
+    test_pid = self()
+
+    expect_existing(bypass, "c1", nil)
+
+    Bypass.expect(bypass, "PUT", "/collections/c1/index", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:index, Jason.decode!(body)["field_name"]})
+      Plug.Conn.send_resp(conn, 200, ~s({"status":"ok"}))
+    end)
+
+    assert :ok = Qdrant.ensure_collection("c1", 1024)
+
+    for field <- @indexed_fields ++ @integer_indexed_fields do
+      assert_receive {:index, ^field}
+    end
+  end
+
+  test "a failed index create on an existing collection is returned, not swallowed",
+       %{bypass: bypass} do
+    expect_existing(bypass, "c1", schema_for(~w(user_id vault_id note_id path_hmac), "keyword"))
+
+    Bypass.expect_once(bypass, "PUT", "/collections/c1/index", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(500, ~s({"status":{"error":"boom"}}))
+    end)
+
+    assert {:error, {500, _}} = Qdrant.ensure_collection("c1", 1024)
   end
 
   # H2 — 409 "already exists" must verify the collection shape, not blindly

--- a/test/engram/vector/qdrant_ensure_collection_memo_test.exs
+++ b/test/engram/vector/qdrant_ensure_collection_memo_test.exs
@@ -89,6 +89,32 @@ defmodule Engram.Vector.QdrantEnsureCollectionMemoTest do
            "expected exactly 2 round trips — one failing, one retry that succeeds."
   end
 
+  # #1609: an unreadable collection_info means the payload indexes could not be
+  # checked. Caching :ok for that would leave a node running without the
+  # indexes strict-mode filtering needs until it restarts, which is the exact
+  # failure #1609 exists to fix.
+  test "an unverified collection is NOT memoised", %{bypass: bypass} do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    Bypass.stub(bypass, "PUT", "/collections/unverified_col", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(409, ~s({"status":{"error":"already exists"}}))
+    end)
+
+    Bypass.stub(bypass, "GET", "/collections/unverified_col", fn conn ->
+      Agent.update(counter, &(&1 + 1))
+      Plug.Conn.send_resp(conn, 500, ~s({"status":"error"}))
+    end)
+
+    assert :ok = Qdrant.ensure_collection("unverified_col", 1024)
+    assert :ok = Qdrant.ensure_collection("unverified_col", 1024)
+
+    assert Agent.get(counter, & &1) == 2,
+           "the unverified result was memoised: this node would never create the\n" <>
+             "missing payload indexes, and strict-mode filters would keep 400ing."
+  end
+
   test "a different collection or dims is a separate memo entry", %{bypass: bypass} do
     {:ok, counter} = Agent.start_link(fn -> 0 end)
 

--- a/test/engram/vector/qdrant_strict_mode_test.exs
+++ b/test/engram/vector/qdrant_strict_mode_test.exs
@@ -13,6 +13,7 @@ defmodule Engram.Vector.QdrantStrictModeTest do
   """
   use ExUnit.Case, async: false
 
+  alias Engram.ServiceConfig
   alias Engram.Vector.Qdrant
 
   @moduletag :qdrant_integration
@@ -24,6 +25,13 @@ defmodule Engram.Vector.QdrantStrictModeTest do
   @tag_hmac "dGFnLWhtYWM="
 
   setup do
+    # Per-process override, NOT the global app env. 22 Bypass suites set
+    # `:qdrant_url` globally and `Application.delete_env` it on exit, which
+    # wipes the CI-provided URL for everything that runs after them: the client
+    # then falls back to its compiled localhost:6333 default and every request
+    # here dies with econnrefused against a perfectly healthy container.
+    ServiceConfig.put_override(:qdrant_url, qdrant_url())
+
     col = "engram_strict_#{System.unique_integer([:positive])}"
 
     :ok = Qdrant.ensure_collection(col, @dims)
@@ -108,5 +116,8 @@ defmodule Engram.Vector.QdrantStrictModeTest do
     :ok
   end
 
-  defp qdrant_url, do: Application.get_env(:engram, :qdrant_url, "http://localhost:6333")
+  defp qdrant_url do
+    System.get_env("QDRANT_URL") ||
+      Application.get_env(:engram, :qdrant_url, "http://localhost:6333")
+  end
 end

--- a/test/engram/vector/qdrant_strict_mode_test.exs
+++ b/test/engram/vector/qdrant_strict_mode_test.exs
@@ -1,0 +1,112 @@
+defmodule Engram.Vector.QdrantStrictModeTest do
+  @moduledoc """
+  Prod runs Qdrant Cloud with strict mode ON (`unindexed_filtering_retrieve:
+  false`), which rejects a filter on any payload field that has no index. The
+  CI stack and staging run self-hosted Qdrant with strict mode OFF, and the
+  Bypass suites answer 200 to anything, so #1609 (prod indexed four of the
+  filter keys and 400'd folder, tag, type and date filters) could not fail a
+  single test we had.
+
+  This turns strict mode ON for one throwaway collection and filters on every
+  key `Qdrant.search/3` can send. A key missing from `@payload_index_fields`
+  fails here the way prod fails, not silently.
+  """
+  use ExUnit.Case, async: false
+
+  alias Engram.Vector.Qdrant
+
+  @moduletag :qdrant_integration
+
+  @dims 8
+  @vector List.duplicate(0.1, @dims)
+  @user_id "11111111-1111-1111-1111-111111111111"
+  @vault_id "22222222-2222-2222-2222-222222222222"
+  @tag_hmac "dGFnLWhtYWM="
+
+  setup do
+    col = "engram_strict_#{System.unique_integer([:positive])}"
+
+    :ok = Qdrant.ensure_collection(col, @dims)
+    :ok = enable_strict_mode(col)
+    :ok = upsert_point(col)
+
+    on_exit(fn -> Qdrant.delete_collection(col) end)
+
+    %{col: col}
+  end
+
+  # Guards the guard: if strict mode were not actually enforced, every
+  # assertion below would pass against an unindexed collection and this suite
+  # would be decoration. An unindexed key must be rejected.
+  test "strict mode is enforced: filtering an unindexed key is rejected", %{col: col} do
+    body = %{
+      query: @vector,
+      using: "dense",
+      filter: %{must: [%{key: "definitely_not_indexed", match: %{value: "x"}}]},
+      limit: 1
+    }
+
+    {:ok, resp} = Req.post("#{qdrant_url()}/collections/#{col}/points/query", json: body)
+
+    assert resp.status in 400..499,
+           "strict mode is not enforcing: an unindexed filter returned #{resp.status}, " <>
+             "so every other assertion in this file would pass vacuously"
+  end
+
+  test "every filter key Qdrant.search/3 sends has a payload index", %{col: col} do
+    base = [user_id: @user_id, vault_id: @vault_id, limit: 1]
+
+    cases = [
+      {"user_id + vault_id", []},
+      {"folder_hmac", [folder_hmac: "Zm9sZGVyLWhtYWM="]},
+      {"tags_hmac", [tags_hmac: [@tag_hmac]]},
+      {"type_hmac", [type_hmac: "dHlwZS1obWFj"]},
+      {"fm_timestamp range", [fm_timestamp_gte: 0, fm_timestamp_lte: 2_000_000_000]},
+      {"fm_created range", [fm_created_gte: 0, fm_created_lte: 2_000_000_000]}
+    ]
+
+    for {label, opts} <- cases do
+      assert {:ok, _results} = Qdrant.search(col, @vector, base ++ opts),
+             "#{label}: strict mode rejected this filter, so its payload index is missing. " <>
+               "Add the key to @payload_index_fields (keyword) or " <>
+               "@integer_payload_index_fields (integer) in lib/engram/vector/qdrant.ex."
+    end
+  end
+
+  test "path_hmac, the delete filter key, is indexed too", %{col: col} do
+    # `delete_by_note/4` filters on path_hmac. Under strict mode an unindexed
+    # key fails the DELETE, which would strand a deleted note's points.
+    assert :ok = Qdrant.delete_by_note(col, @user_id, @vault_id, "cGF0aC1obWFj")
+  end
+
+  defp upsert_point(col) do
+    Qdrant.upsert_points(col, [
+      %{
+        id: Ecto.UUID.generate(),
+        vector: %{"dense" => @vector},
+        payload: %{
+          user_id: @user_id,
+          vault_id: @vault_id,
+          note_id: Ecto.UUID.generate(),
+          path_hmac: "cGF0aC1obWFj",
+          folder_hmac: "Zm9sZGVyLWhtYWM=",
+          tags_hmac: [@tag_hmac],
+          type_hmac: "dHlwZS1obWFj",
+          fm_timestamp: 1_700_000_000,
+          fm_created: 1_600_000_000
+        }
+      }
+    ])
+  end
+
+  defp enable_strict_mode(col) do
+    {:ok, %{status: 200}} =
+      Req.patch("#{qdrant_url()}/collections/#{col}",
+        json: %{strict_mode_config: %{enabled: true, unindexed_filtering_retrieve: false}}
+      )
+
+    :ok
+  end
+
+  defp qdrant_url, do: Application.get_env(:engram, :qdrant_url, "http://localhost:6333")
+end

--- a/test/engram/vector/qdrant_test.exs
+++ b/test/engram/vector/qdrant_test.exs
@@ -283,6 +283,43 @@ defmodule Engram.Vector.QdrantTest do
     end
   end
 
+  # Qdrant answers 404 when the COLLECTION is absent, which means there is
+  # nothing to delete. Returning an error there makes DeleteNoteIndex (#1608,
+  # which now retries instead of swallowing) burn its attempts and discard on
+  # a fresh self-host or dev stack that has never indexed anything. Missing
+  # point ids are not this case: those come back 200.
+  describe "deletes against a missing collection" do
+    test "delete_points/2 treats 404 as nothing to delete", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/test_col/points/delete", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, ~s({"status":{"error":"Collection not found"}}))
+      end)
+
+      assert :ok = Qdrant.delete_points("test_col", [Ecto.UUID.generate()])
+    end
+
+    test "delete_by_note/4 treats 404 as nothing to delete", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/test_col/points/delete", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, ~s({"status":{"error":"Collection not found"}}))
+      end)
+
+      assert :ok = Qdrant.delete_by_note("test_col", "user-1", "vault-1", "stub-hmac-base64")
+    end
+
+    test "a 500 is still an error", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/test_col/points/delete", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(500, ~s({"status":{"error":"boom"}}))
+      end)
+
+      assert {:error, {500, _}} = Qdrant.delete_points("test_col", [Ecto.UUID.generate()])
+    end
+  end
+
   describe "count_by_note/4" do
     test "returns the exact point count for the filter", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->

--- a/test/engram/workers/delete_note_index_test.exs
+++ b/test/engram/workers/delete_note_index_test.exs
@@ -1,0 +1,80 @@
+defmodule Engram.Workers.DeleteNoteIndexTest do
+  @moduledoc """
+  #1608: a failed Qdrant delete used to be discarded and the job returned
+  `:ok`, so the rows and points both survived and the deleted note stayed
+  searchable with nothing left to retry it.
+  """
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Ecto.Query
+
+  alias Engram.Notes.Chunk
+  alias Engram.Repo
+  alias Engram.Workers.DeleteNoteIndex
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
+
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+    note = insert(:note, user: user, vault: vault)
+
+    Repo.insert!(
+      %Chunk{
+        note_id: note.id,
+        user_id: user.id,
+        vault_id: vault.id,
+        position: 0,
+        char_start: 0,
+        char_end: 1,
+        qdrant_point_id: Ecto.UUID.generate()
+      },
+      skip_tenant_check: true
+    )
+
+    %{bypass: bypass, note: note}
+  end
+
+  defp args(note) do
+    %{
+      "note_id" => note.id,
+      "user_id" => note.user_id,
+      "vault_id" => note.vault_id,
+      "path_hmac" => Base.encode64(note.path_hmac)
+    }
+  end
+
+  defp chunk_count(note) do
+    Repo.aggregate(from(c in Chunk, where: c.note_id == ^note.id), :count,
+      skip_tenant_check: true
+    )
+  end
+
+  test "returns the Qdrant error so Oban retries, keeping the rows", %{
+    bypass: bypass,
+    note: note
+  } do
+    Bypass.expect(bypass, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(500, ~s({"status":{"error":"boom"}}))
+    end)
+
+    assert {:error, _} = perform_job(DeleteNoteIndex, args(note))
+    assert chunk_count(note) == 1
+  end
+
+  test "deletes the rows once Qdrant accepts the delete", %{bypass: bypass, note: note} do
+    Bypass.expect(bypass, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, ~s({"result":{"status":"completed"}}))
+    end)
+
+    assert :ok = perform_job(DeleteNoteIndex, args(note))
+    assert chunk_count(note) == 0
+  end
+end

--- a/test/engram/workers/delete_note_index_test.exs
+++ b/test/engram/workers/delete_note_index_test.exs
@@ -19,6 +19,7 @@ defmodule Engram.Workers.DeleteNoteIndexTest do
     on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
 
     user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     vault = insert(:vault, user: user)
     note = insert(:note, user: user, vault: vault)
 
@@ -35,7 +36,7 @@ defmodule Engram.Workers.DeleteNoteIndexTest do
       skip_tenant_check: true
     )
 
-    %{bypass: bypass, note: note}
+    %{bypass: bypass, user: user, vault: vault, note: note}
   end
 
   defp args(note) do
@@ -65,6 +66,39 @@ defmodule Engram.Workers.DeleteNoteIndexTest do
 
     assert {:error, _} = perform_job(DeleteNoteIndex, args(note))
     assert chunk_count(note) == 1
+  end
+
+  # The edge flip used to run unconditionally. Putting it behind the retryable
+  # Qdrant delete means a brief 5xx burns all three attempts and the deleted
+  # note keeps its outgoing edges forever, since nothing re-enqueues this job.
+  test "drops the note's link edges even when the Qdrant delete fails", %{
+    bypass: bypass,
+    user: user,
+    vault: vault,
+    note: note
+  } do
+    :ok =
+      Engram.Links.replace_links(user, vault, note.id, Engram.Links.Parser.extract("[[Other]]"))
+
+    assert Repo.aggregate(
+             from(l in Engram.Links.NoteLink, where: l.source_note_id == ^note.id),
+             :count,
+             skip_tenant_check: true
+           ) == 1
+
+    Bypass.expect(bypass, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(500, ~s({"status":{"error":"boom"}}))
+    end)
+
+    assert {:error, _} = perform_job(DeleteNoteIndex, args(note))
+
+    assert Repo.aggregate(
+             from(l in Engram.Links.NoteLink, where: l.source_note_id == ^note.id),
+             :count,
+             skip_tenant_check: true
+           ) == 0
   end
 
   test "deletes the rows once Qdrant accepts the delete", %{bypass: bypass, note: note} do

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -66,6 +66,14 @@ defmodule Engram.Workers.EmbedNoteTest do
     Bypass.pass(bypass)
   end
 
+  defp drain_embedded do
+    receive do
+      {:embedded, texts} -> texts ++ drain_embedded()
+    after
+      0 -> []
+    end
+  end
+
   describe "perform/1" do
     test "indexes note and returns :ok", %{bypass: bypass, note: note} do
       Engram.MockEmbedder
@@ -784,6 +792,69 @@ defmodule Engram.Workers.EmbedNoteTest do
       assert :ok = perform_job(EmbedNote, %{note_id: note.id})
 
       assert Engram.UsageMeters.lifetime_embed_tokens(user.id) > 0
+    end
+
+    # #1618: since chunk reuse (#1595) a pass embeds only the changed chunks,
+    # but the meter kept billing the whole note on every edit.
+    test "charges only the chunks a pass actually embeds",
+         %{bypass: bypass, user: user, vault: vault} do
+      stub_qdrant(bypass)
+      test_pid = self()
+
+      stub(Engram.MockEmbedder, :embed_texts, fn texts ->
+        send(test_pid, {:embedded, texts})
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      body =
+        Enum.map_join(1..6, "\n\n", &"## Section #{&1}\n\n#{String.duplicate("word#{&1} ", 200)}")
+
+      note =
+        Engram.Fixtures.insert_note!(user, vault, %{
+          path: "Test/Long.md",
+          content: "# Long\n\n" <> body
+        })
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+      first = Engram.UsageMeters.lifetime_embed_tokens(user.id)
+      _ = drain_embedded()
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Test/Long.md",
+          "content" => "# Long\n\n" <> String.replace(body, "word3 ", "edited3 ", global: false),
+          "mtime" => 2_000.0
+        })
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      sent = drain_embedded()
+      assert sent != [], "the edited section must be re-embedded"
+      delta = Engram.UsageMeters.lifetime_embed_tokens(user.id) - first
+      assert delta == Engram.UsageMeters.estimate_tokens(Enum.join(sent))
+      assert delta < div(first, 2)
+    end
+
+    test "a pass that reuses every chunk charges nothing",
+         %{bypass: bypass, user: user, note: note} do
+      stub_qdrant(bypass)
+
+      # Exactly one embed call: the second pass must reach Voyage with nothing.
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+      first = Engram.UsageMeters.lifetime_embed_tokens(user.id)
+
+      Repo.update_all(from(n in Note, where: n.id == ^note.id), [set: [embed_hash: nil]],
+        skip_tenant_check: true
+      )
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      assert Engram.UsageMeters.lifetime_embed_tokens(user.id) == first
     end
 
     test "user override raises the cap above the default",

--- a/test/engram/workers/orphan_sweep_missing_points_test.exs
+++ b/test/engram/workers/orphan_sweep_missing_points_test.exs
@@ -108,6 +108,37 @@ defmodule Engram.Workers.OrphanSweepMissingPointsTest do
     assert is_nil(reloaded.dense_indexed_hash)
   end
 
+  # #1607: chunk reuse (#1595) matches on `context_hmac`. Leaving it set made
+  # the re-index "reuse" the very point ids Qdrant had lost, so nothing was
+  # upserted and the note was stamped indexed again, still unsearchable.
+  test "nulls the flagged note's chunk hmacs so the re-index cannot reuse lost points", %{
+    bypass: bypass
+  } do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+    note = insert(:note, user: user, vault: vault, embed_hash: "cafe", content_hash: "cafe")
+    chunk = insert_chunk!(note, Ecto.UUID.generate())
+
+    Repo.update_all(where(Chunk, id: ^chunk.id), [set: [context_hmac: "h"]],
+      skip_tenant_check: true
+    )
+
+    kept_note = insert(:note, user: user, vault: vault, embed_hash: "beef", content_hash: "beef")
+    kept_point = Ecto.UUID.generate()
+    kept = insert_chunk!(kept_note, kept_point)
+
+    Repo.update_all(where(Chunk, id: ^kept.id), [set: [context_hmac: "k"]],
+      skip_tenant_check: true
+    )
+
+    stub_qdrant(bypass, [kept_point])
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert is_nil(Repo.get!(Chunk, chunk.id, skip_tenant_check: true).context_hmac)
+    assert Repo.get!(Chunk, kept.id, skip_tenant_check: true).context_hmac == "k"
+  end
+
   test "leaves a note alone when Qdrant has every point its chunks name", %{bypass: bypass} do
     user = insert(:user)
     vault = insert(:vault, user: user)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -33,6 +33,22 @@ if System.get_env("QDRANT_INTEGRATION") == "1" do
   if url = System.get_env("QDRANT_URL") do
     Application.put_env(:engram, :qdrant_url, url)
   end
+
+  # Preflight, so an unreachable Qdrant says WHICH url it tried instead of
+  # surfacing as a bare econnrefused inside every test's setup block.
+  resolved = Application.get_env(:engram, :qdrant_url, "http://localhost:6333")
+
+  case Req.get(resolved <> "/healthz", retry: false, receive_timeout: 5_000) do
+    {:ok, %{status: 200}} ->
+      IO.puts("qdrant_integration: #{resolved} reachable")
+
+    other ->
+      IO.warn("""
+      QDRANT_INTEGRATION=1 but #{resolved} is not answering /healthz: #{inspect(other)}
+      Every :qdrant_integration test will fail in setup. Check QDRANT_URL and that
+      the container is still running.
+      """)
+  end
 end
 
 cluster_excluded = if System.get_env("CLUSTER_TESTS") == "1", do: [], else: [:cluster]

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -25,6 +25,16 @@ ExUnit.configure(capture_log: true)
 qdrant_excluded =
   if System.get_env("QDRANT_INTEGRATION") == "1", do: [], else: [:qdrant_integration]
 
+# `config/runtime.exs` reads QDRANT_URL only outside :test, so the integration
+# tests would otherwise be stuck on the client's compiled-in default port. CI
+# runs its Qdrant on an ephemeral port (same pattern as the postgres container),
+# so honour the env var here when those tests are actually enabled.
+if System.get_env("QDRANT_INTEGRATION") == "1" do
+  if url = System.get_env("QDRANT_URL") do
+    Application.put_env(:engram, :qdrant_url, url)
+  end
+end
+
 cluster_excluded = if System.get_env("CLUSTER_TESTS") == "1", do: [], else: [:cluster]
 
 integration_excluded =


### PR DESCRIPTION
## Summary

Fixes from the 2026-09-11 audit of chunking, embedding and search (tracking #1625). One commit per issue, so review commit by commit.

- **Prod filters (#1609):** prod Qdrant indexed only `user_id`, `vault_id`, `note_id`, `path_hmac` under strict mode, so folder, tag, type and date filters 400. `ensure_collection` now creates any index the collection lacks, once per boot. Context doc added.
- **Index correctness:**
  - #1605: frontmatter stripping cut the start of the body on multibyte or CRLF frontmatter.
  - #1606: chunk reuse ignored tier and model, so Free to Pro upgrades never got dense vectors.
  - #1607: the OrphanSweep repair from #1576 was a no-op since chunk reuse.
  - #1608: deleted notes could stay in search results.
- **Search CPU (#1617):** MMR re-ranking is now O(pool x limit). Same inputs: limit 20 over a 200 pool went from 9.9s to 0.44s. It was 76s at limit 50.
- **Voyage:**
  - #1614: requests now send `input_type` and `output_dimension`.
  - #1618: the Free-tier meter charges only the bytes actually embedded, not the whole note.

An adversarial review of the branch found seven more problems, all fixed here with their own regression tests:

- `delete_note_index` ran the link unlink behind the retryable Qdrant delete, so a brief 5xx burned all three attempts and left the deleted note's edges forever. Local work runs first now.
- `ensure_collection` memoised an unverified collection, so one transient `collection_info` failure meant a node never created the missing indexes: the #1609 failure itself.
- Payload-index creation gets its own 120s budget, since `wait=true` builds over every existing point.
- The reuse fingerprint named `DOC_EMBED_MODEL`, which is optional. With it unset, changing `EMBED_MODEL` left every hash identical and the collection would mix two models' embedding spaces.
- Search dropped deleted hits after the MMR pass, leaving the page short of the requested limit. It now drops them before, so the pool backfills.

Two more from my own pass:

- `output_dimension` is sent only when an operator set `EMBED_DIMS`. It has no default in config, and older Voyage models reject the field, so sending the 1024 fallback would have 400'd every embed for a self-hoster on one. Prod sets `EMBED_DIMS=1024` and is unchanged.
- A Qdrant 404 on a delete means the collection does not exist, so there is nothing to delete. That was harmless while #1608 swallowed delete failures; now that the job retries, a stack that never indexed anything would burn every attempt and discard on each note delete.

One-time cost: #1606 changes the reuse fingerprint, so each note fully re-indexes on its next embed. That is free for keyword-only notes and one Voyage pass for the rest.

## New: the #1609 regression fence

`:qdrant_integration` tests existed but **no CI job ever set `QDRANT_INTEGRATION=1`**, so they had never run anywhere. That is precisely why #1609 could not fail a test: prod's Qdrant Cloud enforces strict mode (a filter on an un-indexed payload field 400s), while the CI stack runs with it off and the Bypass suites answer 200 to anything.

- `unit-tests` now starts an ephemeral Qdrant (same pattern and port-race retry as its postgres) and enables the tag.
- `test/engram/vector/qdrant_strict_mode_test.exs` turns strict mode ON for a throwaway collection and filters on every key `Qdrant.search/3` sends, plus the delete filter key. Verified both ways: green as committed, and the filter-key test fails when `@payload_index_fields` is reverted to its pre-#1609 list.
- One test asserts an unindexed key is *rejected*, so the suite cannot pass vacuously if strict mode stops being enforced.
- Turning the tag on surfaced three broken things: `QDRANT_URL` was ignored in test env (pinning tests to the client's default port); `search_integration_test` indexed a note whose plaintext `content` was nil, so it parsed zero chunks and failed on a misattributed 404; and **22 Bypass suites `Application.delete_env(:engram, :qdrant_url)` on exit**, wiping the CI-provided URL so the client fell back to `localhost:6333` and every integration test hit `econnrefused` against a healthy container. Both suites now pin the URL with a per-process `ServiceConfig` override, proven with a contaminator in the same run.

## Test plan

- [x] New failing tests first for every fix, then green
- [x] `mix test`: full suite green locally (OTP 27)
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer` clean
- [x] Randomized reference test pins MMR selection order to the original definition
- [ ] After deploy: `GET /collections/engram_notes` on prod shows `folder_hmac`, `tags_hmac`, `type_hmac`, `fm_timestamp`, `fm_created` in `payload_schema`
- [ ] After deploy: a folder-filtered search in the web app returns results

Closes #1605
Closes #1606
Closes #1607
Closes #1608
Closes #1609
Closes #1614
Closes #1617
Closes #1618

BEGIN_COMMIT_OVERRIDE
fix(search): create missing Qdrant payload indexes so folder, tag, type and date filters work (#1609)

fix(search): keep the whole note body when frontmatter has multibyte characters or CRLF (#1605)

fix(search): make chunk reuse tier- and model-aware so upgraded users get semantic search (#1606)

fix(search): clear chunk hmacs when OrphanSweep flags a note for re-index (#1607)

fix(search): stop deleted notes answering searches (#1608)

perf(search): make MMR re-ranking linear in the result limit (#1617)

fix(search): send input_type and output_dimension to Voyage (#1614)

fix(billing): meter only the bytes a pass actually embeds (#1618)
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGn1VTY4YQjg3xS5Xy98LS
