### PR TITLE
fix(search): rebuild notes whose chunks came from an older chunker (#1620)

### DIFF
--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -39,6 +39,11 @@ defmodule Engram.Notes.Note do
     field :content_hash, :string
     field :embed_hash, :string
     field :dense_indexed_hash, :string
+    # #1620 — which chunker built the current index rows. NULL means "a chunker
+    # older than the stamp", which is what makes an already-indexed note
+    # eligible for a rebuild. Unrelated to `:version` above, which is the
+    # sync/conflict counter.
+    field :chunker_version, :integer
     # Poison-loop guard: when a note exhausts its EmbedNote attempts, the worker
     # stamps a cooldown timestamp here. ReconcileEmbeddings skips notes whose
     # cooldown hasn't elapsed, so a permanently-failing note re-bills Voyage at

--- a/lib/engram/parsers/markdown.ex
+++ b/lib/engram/parsers/markdown.ex
@@ -12,6 +12,25 @@ defmodule Engram.Parsers.Markdown do
   @max_chunk_chars 2048
   @max_prefix_bytes 512
 
+  # #1620 — bump when a change alters the chunks `parse/2` emits for input it
+  # already handled: a different split point, different chunk text, different
+  # ordering. Do NOT bump for a change that cannot move a boundary (a typespec,
+  # a comment, a refactor with identical output). Every bump costs one re-embed
+  # pass over the corpus.
+  @chunker_version 1
+
+  @doc """
+  Version of the chunking algorithm in this build (#1620).
+
+  Stamped onto `notes.chunker_version` by `EmbedNote` after a successful index
+  and compared there on the next pass: a note carrying anything else — including
+  NULL, meaning it was indexed before this stamp existed — is rebuilt rather
+  than skipped, which is how a chunker fix reaches notes nobody edits.
+  """
+  # No @spec: the body is a literal, so dialyzer narrows the success typing to
+  # that exact integer and rejects any wider contract as a supertype.
+  def chunker_version, do: @chunker_version
+
   @doc """
   Parse markdown content into indexable chunks.
 

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -12,6 +12,21 @@ defmodule Engram.Workers.EmbedNote do
   (content hasn't changed since last successful embed). On success, sets
   embed_hash = content_hash using an optimistic lock — if content changed
   mid-embed, the update is a no-op and the next job picks up the new version.
+
+  That skip is also gated on `chunker_version` (#1620): content being unchanged
+  is not enough if the chunks were built by an older chunker, so a note stamped
+  with anything other than the current `Markdown.chunker_version/0` is rebuilt
+  rather than skipped. Nothing selects on that column automatically — an
+  operator drives the backfill per vault via `ReindexKeyword`, which does real
+  work on the first run after a version bump and is a no-op on every run after
+  that. Deliberate: it keeps a corpus-wide re-embed an explicit action rather
+  than something a deploy can start.
+
+  This does NOT revive `ReindexKeyword` for its original #605 purpose
+  (re-normalizing BM25 against a drifted `avgdl`, which involves no chunker
+  change and so never makes a note look stale). #1477 stays open for that, and
+  the stale BM25 weights already baked into existing points are NOT repaired
+  here — only the chunk boundaries are.
   """
 
   use Oban.Worker,
@@ -33,6 +48,7 @@ defmodule Engram.Workers.EmbedNote do
   alias Engram.Logger.DecryptFailure
   alias Engram.Logger.Metadata
   alias Engram.Notes.Note
+  alias Engram.Parsers.Markdown
   alias Engram.Repo
   alias Engram.Search.SearchProfile
   alias Engram.UsageMeters
@@ -40,6 +56,13 @@ defmodule Engram.Workers.EmbedNote do
   alias Engram.Workers.BackgroundPriority
 
   require Logger
+
+  # Read at COMPILE time so it can appear in a clause head below — a guard
+  # cannot call `Markdown.chunker_version/0`. The tradeoff is a compile-time
+  # dependency on the parser: bumping the version recompiles this worker, which
+  # is what we want, since a stale copy here would skip the notes the bump
+  # exists to rebuild.
+  @chunker_version Markdown.chunker_version()
 
   @impl Oban.Worker
   def timeout(_job), do: :timer.minutes(10)
@@ -55,11 +78,29 @@ defmodule Engram.Workers.EmbedNote do
       {:discard, _reason} = discard ->
         discard
 
-      {:ok, %Note{content_hash: hash, embed_hash: hash, dense_indexed_hash: hash}}
+      {:ok,
+       %Note{
+         content_hash: hash,
+         embed_hash: hash,
+         dense_indexed_hash: hash,
+         chunker_version: @chunker_version
+       }}
       when hash != nil and is_nil(old_path_hmac_b64) ->
-        # Already indexed this exact content WITH dense vectors, no rename
-        # pending — skip.
+        # Already indexed this exact content WITH dense vectors, by the CURRENT
+        # chunker, no rename pending — skip.
         :ok
+
+      # #1620 — content is indexed, but by an older chunker (NULL means older
+      # than the stamp itself). Rebuild regardless of tier: re-chunking a
+      # keyword-only note never reaches the embedder, so it costs no EMBEDDING
+      # spend — it does still cost a decrypt, a re-parse, a Qdrant upsert and a
+      # rewrite of the note's `chunks` rows — and leaving Free users on a
+      # splitter we know emits 2.5MB chunks is the bug.
+      # `run_and_stamp` re-stamps the version, so a given note matches this at
+      # most once per bump — it cannot become a re-embed loop.
+      {:ok, %Note{content_hash: hash, embed_hash: hash, chunker_version: cv} = note}
+      when hash != nil and is_nil(old_path_hmac_b64) and cv != @chunker_version ->
+        run_and_stamp(note, old_path_hmac_b64, job)
 
       {:ok, %Note{content_hash: hash, embed_hash: hash} = note}
       when hash != nil and is_nil(old_path_hmac_b64) ->
@@ -438,15 +479,25 @@ defmodule Engram.Workers.EmbedNote do
     # entitled user: a per-user `indexed_notes_cap` override (a promo grant, a
     # throttled abuser) puts a semantic user over the cap, and nothing but a
     # content edit would ever re-open the note.
+    # `chunker_version` is stamped on BOTH paths, including the keyword-only /
+    # no-chunks one. It records which chunker last ran, not whether vectors were
+    # written, and leaving it NULL after a successful pass would re-select the
+    # note on every future sweep.
     set =
       if semantic? and chunk_count > 0 do
         [
           embed_hash: note.content_hash,
           dense_indexed_hash: note.content_hash,
+          chunker_version: @chunker_version,
           embed_retry_after: nil
         ]
       else
-        [embed_hash: note.content_hash, dense_indexed_hash: nil, embed_retry_after: nil]
+        [
+          embed_hash: note.content_hash,
+          dense_indexed_hash: nil,
+          chunker_version: @chunker_version,
+          embed_retry_after: nil
+        ]
       end
 
     {count, _} =

--- a/priv/repo/migrations/20260913020000_add_chunker_version_to_notes_expand.exs
+++ b/priv/repo/migrations/20260913020000_add_chunker_version_to_notes_expand.exs
@@ -1,0 +1,39 @@
+defmodule Engram.Repo.Migrations.AddChunkerVersionToNotesExpand do
+  use Ecto.Migration
+
+  @moduledoc """
+  #1620 — records which chunker built a note's index rows.
+
+  `EmbedNote` skips a note when `embed_hash == content_hash`, and nothing
+  recorded which chunker produced the chunks. So every chunker fix (#1591,
+  #1600, #1605) reached only notes that someone happened to edit afterwards.
+  Prod evidence: sections spanning 2.5MB in three chunk rows, left by the
+  pre-#1591 splitter, whose dense vector covers only Voyage's truncated prefix
+  and whose token_count inflates the vault's BM25 `avgdl` for every OTHER
+  chunk in that vault.
+
+  Deliberately NOT backfilled. NULL is the signal — "indexed by a chunker that
+  predates this stamp" — and that is exactly the set that needs rebuilding.
+  Writing a value here would erase the only evidence of which rows are stale.
+  That also keeps this migration free of tenant-table DML, so it needs none of
+  the `NO FORCE ROW LEVEL SECURITY` dance (see
+  `docs/context/migrations-force-rls-data-dml.md`).
+
+  Re-indexing is NOT automatic: `ReconcileEmbeddings` does not select on this
+  column, so shipping the migration cannot trigger a corpus-wide re-embed.
+  An operator drives the backfill per vault via `ReindexKeyword`, which does
+  real work on the first run after a version bump and is a no-op afterwards.
+  """
+
+  def up do
+    alter table(:notes) do
+      add :chunker_version, :integer
+    end
+  end
+
+  def down do
+    alter table(:notes) do
+      remove :chunker_version
+    end
+  end
+end

--- a/priv/repo/migrations/20260913020000_add_chunker_version_to_notes_expand.exs
+++ b/priv/repo/migrations/20260913020000_add_chunker_version_to_notes_expand.exs
@@ -27,7 +27,11 @@ defmodule Engram.Repo.Migrations.AddChunkerVersionToNotesExpand do
 
   def up do
     alter table(:notes) do
-      add :chunker_version, :integer
+      # `:bigint`, not `:integer` — squawk's prefer-bigint-over-int gate fails
+      # the build on a 32-bit int column. A chunker version will never approach
+      # 2^31, but 4 extra bytes on a nullable column is cheaper than an
+      # exception, and the Ecto field stays `:integer` (it reads int8 fine).
+      add :chunker_version, :bigint
     end
   end
 

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -11,6 +11,7 @@ defmodule Engram.Workers.EmbedNoteTest do
   alias Engram.Crypto.DekCache
   alias Engram.Notes
   alias Engram.Notes.Note
+  alias Engram.Parsers.Markdown
   alias Engram.Repo
   alias Engram.Workers.EmbedNote
 
@@ -103,14 +104,67 @@ defmodule Engram.Workers.EmbedNoteTest do
     test "skips embedding when both hashes match content_hash", %{note: note} do
       import Ecto.Query
 
+      # `chunker_version` is part of the skip condition since #1620 — a note at
+      # an older version is rebuilt, so this test has to pin the current one to
+      # still be testing the hash-match skip.
       from(n in Note, where: n.id == ^note.id)
       |> Repo.update_all(
-        [set: [embed_hash: note.content_hash, dense_indexed_hash: note.content_hash]],
+        [
+          set: [
+            embed_hash: note.content_hash,
+            dense_indexed_hash: note.content_hash,
+            chunker_version: Markdown.chunker_version()
+          ]
+        ],
         skip_tenant_check: true
       )
 
       # No mock expectations — if it tried to embed, Mox would fail
       assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+    end
+
+    # #1620 — chunker fixes never reached an already-indexed note. Both hashes
+    # match, so the skip clause returned :ok and the note kept chunks built by
+    # an older splitter forever. A NULL chunker_version is exactly that note:
+    # indexed by a chunker that predates the stamp.
+    test "re-indexes a note whose chunker_version is stale", %{bypass: bypass, note: note} do
+      import Ecto.Query
+
+      from(n in Note, where: n.id == ^note.id)
+      |> Repo.update_all(
+        [
+          set: [
+            embed_hash: note.content_hash,
+            dense_indexed_hash: note.content_hash,
+            chunker_version: nil
+          ]
+        ],
+        skip_tenant_check: true
+      )
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts -> {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)} end)
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      assert Repo.get!(Note, note.id, skip_tenant_check: true).chunker_version ==
+               Markdown.chunker_version()
+    end
+
+    test "stamps the current chunker version on success", %{bypass: bypass, note: note} do
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      assert Repo.get!(Note, note.id, skip_tenant_check: true).chunker_version ==
+               Markdown.chunker_version()
     end
 
     test "re-embeds an entitled user's note that has no dense vectors (upgrade backfill)", %{
@@ -154,14 +208,57 @@ defmodule Engram.Workers.EmbedNoteTest do
 
       OverrideCache.evict(note.user_id)
 
+      # Pinned to the current chunker version on purpose: this test is about
+      # TIER gating, not #1620. Left NULL it would match the stale-chunker
+      # clause and rebuild, which would prove nothing about entitlement.
       from(n in Note, where: n.id == ^note.id)
       |> Repo.update_all(
-        [set: [embed_hash: note.content_hash, dense_indexed_hash: nil]],
+        [
+          set: [
+            embed_hash: note.content_hash,
+            dense_indexed_hash: nil,
+            chunker_version: Markdown.chunker_version()
+          ]
+        ],
         skip_tenant_check: true
       )
 
       # No mock expectations — any embed call fails the test.
       assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+    end
+
+    test "rebuilds a keyword-only user's note when the chunker version is stale", %{
+      bypass: bypass,
+      note: note
+    } do
+      import Ecto.Query
+
+      # A Free user's notes carry the same bad chunks as everyone else's, and
+      # re-chunking them calls no embedder, so #1620 rebuilds them too. The
+      # absence of a Mox expectation is the assertion that Voyage is NOT hit:
+      # the tier gate still holds, only the skip does not.
+      Engram.Repo.delete_all(
+        from(o in Engram.Billing.UserLimitOverride,
+          where: o.user_id == ^note.user_id and o.key == "search_semantic_enabled"
+        )
+      )
+
+      OverrideCache.evict(note.user_id)
+
+      from(n in Note, where: n.id == ^note.id)
+      |> Repo.update_all(
+        [set: [embed_hash: note.content_hash, dense_indexed_hash: nil, chunker_version: nil]],
+        skip_tenant_check: true
+      )
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      updated = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert updated.chunker_version == Markdown.chunker_version()
+      # Still keyword-only: the rebuild must not invent dense vectors.
+      assert is_nil(updated.dense_indexed_hash)
     end
 
     test "optimistic lock: does not stamp embed_hash if content changed mid-embed", %{

--- a/test/engram/workers/reconcile_embeddings_test.exs
+++ b/test/engram/workers/reconcile_embeddings_test.exs
@@ -28,6 +28,33 @@ defmodule Engram.Workers.ReconcileEmbeddingsTest do
       assert_enqueued(worker: EmbedNote, args: %{"note_id" => note.id})
     end
 
+    test "ignores a stale chunker_version — the cron must never start a mass re-embed" do
+      # #1620 added `notes.chunker_version` and taught EmbedNote to rebuild a
+      # note whose stamp is out of date. This cron was deliberately NOT taught
+      # the same thing: every already-indexed note in prod carries NULL, so
+      # selecting on it here would re-embed the entire corpus of every paying
+      # user on the next 15-minute tick, unprompted, the moment the migration
+      # lands. The backfill is operator-driven per vault instead.
+      #
+      # This is the assertion that protects that property — without it, adding
+      # one `or` to the eligibility query is a silent five-figure Voyage bill.
+      user = insert(:user)
+      insert(:subscription, user: user, tier: "pro", status: "active")
+
+      note =
+        insert(:note,
+          user: user,
+          content_hash: "abc123",
+          embed_hash: "abc123",
+          dense_indexed_hash: "abc123",
+          chunker_version: nil
+        )
+
+      assert :ok = perform_job(ReconcileEmbeddings, %{})
+
+      refute_enqueued(worker: EmbedNote, args: %{"note_id" => note.id})
+    end
+
     test "backfills dense vectors for every entitled status, past_due included" do
       # The subscription join is a SQL proxy for the real 4-layer entitlement
       # resolver. A hand-rolled subset that dropped `past_due` stranded the


### PR DESCRIPTION
## Problem

`EmbedNote` skips a note when `embed_hash == content_hash`, and nothing recorded **which chunker** built its chunk rows. So every chunker fix (#1591, #1600, #1605) reached only the notes someone happened to edit afterwards.

Prod evidence from the 2026-09-11 audit: sections spanning 2.5MB held in three chunk rows, left by the pre-#1591 splitter. The oversized chunk's dense vector covers only Voyage's truncated prefix, and its `token_count` inflates that vault's BM25 `avgdl` for every other chunk in the vault.

## Fix

- New nullable `notes.chunker_version` (migration, **no backfill** — NULL *is* the signal "older than this stamp", and writing a value would erase the only evidence of which rows are stale).
- `Engram.Parsers.Markdown.chunker_version/0` returns the current version, read into `EmbedNote` at compile time so it can appear in a clause head.
- `EmbedNote` stamps it on success and folds it into the skip clauses: unchanged content is no longer sufficient to skip if the chunks are stale.

Bump `@chunker_version` whenever a change moves a chunk boundary. Each bump costs one re-index pass.

## Two deliberate choices

**A stale note rebuilds regardless of tier.** Re-chunking a keyword-only note never reaches the embedder (verified through `maybe_embed/2`), so it costs no embedding spend, and leaving Free users on a splitter we know emits 2.5MB chunks is the bug. It does still cost a decrypt, a re-parse, a Qdrant upsert and a `chunks` row rewrite.

**`ReconcileEmbeddings` is untouched, so merging this cannot start a corpus-wide re-embed.** Every already-indexed note in prod carries NULL; had the 15-minute cron selected on this column, the migration landing would re-embed every paying user's corpus unprompted. The backfill is operator-driven per vault via `ReindexKeyword` instead. `reconcile_embeddings_test.exs` now pins this with a `refute_enqueued` — without it, adding one `or` to that eligibility query is a silent five-figure Voyage bill.

## Scope — what this does NOT fix

The BM25 `avgdl` damage is **not** repaired. `indexing.ex:145` bakes the BM25 weight into the stored sparse vector at index time, and `avgdl` is not part of the reuse fingerprint, so an unchanged chunk keeps its stale weight. Rebuilding the oversized note lowers the vault's `avgdl` but every other chunk keeps a weight computed against the old inflated value.

Relatedly, `ReindexKeyword` does real work on the first run after a version bump and is a no-op afterwards. That is correct for this issue but does **not** revive it for its original #605 purpose (re-normalizing against a drifted `avgdl`, which involves no chunker change). **#1477 stays open**, and its own proposed fix — clearing `embed_hash` in the statement that selects the notes — is still the right one and would also close the `avgdl` gap above.

Also not included: any operator tooling to *find* stale notes. Today that is `count(*) FILTER (WHERE chunker_version IS DISTINCT FROM 1)` by hand.

## Tests

Written failing first, then green.

- stale version rebuilds (reverting the production change leaves the `embed_texts` expectation unmet)
- the current version still skips
- the version is stamped on success
- a **keyword-only** user's stale note rebuilds without reaching Voyage and without setting `dense_indexed_hash`
- `ReconcileEmbeddings` ignores the column entirely

`mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` and `mix dialyzer` all clean. Full suite was 5231 tests / 0 failures; the touched files are 57 / 0 after the review fixes.

## Review

An adversarial pass confirmed no new re-enqueue loop, no clause shadowing, no tier leak, and that the migration needs no `NO FORCE ROW LEVEL SECURITY` handling (it contains zero DML). Findings applied: removed a dead `:chunker_version` changeset cast (unreachable today, but a permanent hole aimed at the one column whose job is to be untrustworthy-if-forged), deleted a vacuous test that duplicated its sibling, corrected a comment that claimed the rebuild "costs nothing", and scoped the `ReindexKeyword` claims above.

One finding was rejected: the clause-2 `is_nil(old_path_hmac_b64)` guard was called load-bearing and untested, but the catch-all at `embed_note.ex:115` makes the identical `run_and_stamp(note, old_path_hmac_b64, job)` call, so dropping it changes no behavior and renames cannot silently stop purging old-path points.

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGn1VTY4YQjg3xS5Xy98LS
